### PR TITLE
[#8] Fix: Swagger 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 📝 작업 내용
> springdoc-openapi 버전 2.7.0으로 변경


## 🔍 테스트 방법
> 1. http://localhost:8080/swagger-ui/index.html 접속
> ![image](https://github.com/user-attachments/assets/b51f7d32-32d9-4269-853d-bb4c77ee0876)