### PR TITLE
[#10] Docs: 계정/인증 관련 API 명세서 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
+++ b/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
@@ -2,8 +2,10 @@ package umc.GrowIT.Server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class GrowItServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
@@ -27,6 +27,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
+    public static <T> ApiResponse<T> onSuccess(){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), null);
+    }
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
             return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    //멤버 관련 에러
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호 확인이 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4002", "이메일 또는 패스워드가 일치하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다."),
+
+    //토큰 관련 에러
+    INVALID_TOKEN(HttpStatus.NOT_FOUND, "AUTH4001", "토큰이 유효하지 않습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package umc.GrowIT.Server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/", "/login/email", "/login/kakao","/users/password/find", "/users", "/terms").permitAll()
+                                .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/controller/KakaoController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/KakaoController.java
@@ -1,0 +1,23 @@
+package umc.GrowIT.Server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.controller.specification.KakaoSpecification;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+import umc.GrowIT.Server.service.KakaoService;
+
+@RestController
+@RequiredArgsConstructor
+public class KakaoController implements KakaoSpecification {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping("/login/kakao")
+    public ApiResponse<KakaoResponseDTO.KakaoTokenDTO> kakaoLogin(@RequestParam(value = "code", required = false) String code) {
+        KakaoResponseDTO.KakaoTokenDTO token = kakaoService.getToken(code);
+        return ApiResponse.onSuccess(token);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/controller/TermController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/TermController.java
@@ -1,0 +1,24 @@
+package umc.GrowIT.Server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.controller.specification.TermSpecification;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+import umc.GrowIT.Server.service.TermQueryService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TermController implements TermSpecification {
+
+    private final TermQueryService termQueryService;
+
+    @GetMapping("/terms")
+    public ApiResponse<List<TermResponseDTO.TermDTO>> getTerms() {
+        return ApiResponse.onSuccess(termQueryService.getTerms());
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/UserController.java
@@ -1,0 +1,39 @@
+package umc.GrowIT.Server.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.controller.specification.UserSpecification;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+import umc.GrowIT.Server.service.UserCommandService;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController implements UserSpecification {
+
+    private final UserCommandService userCommandService;
+
+    @PostMapping("/login/email")
+    public ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO) {
+        UserResponseDTO.TokenDTO tokenDTO = userCommandService.emailLogin(emailLoginDTO);
+        return ApiResponse.onSuccess(tokenDTO);
+    }
+
+    @PostMapping("/users")
+    public ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO) {
+        UserResponseDTO.TokenDTO tokenDTO = userCommandService.createUser(userInfoDTO);
+        if (tokenDTO == null) {
+            return ApiResponse.onFailure(ErrorStatus.EMAIL_ALREADY_EXISTS.getCode(), ErrorStatus.EMAIL_ALREADY_EXISTS.getMessage(), null);
+        }
+        return ApiResponse.onSuccess(tokenDTO);
+    }
+
+    @PatchMapping("/users/password/find")
+    public ApiResponse<Void> findPassword(@RequestHeader(name = "tempToken") String tempToken, @RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO) {
+        userCommandService.updatePassword(passwordDTO);
+        return ApiResponse.onSuccess();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/KakaoSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/KakaoSpecification.java
@@ -1,0 +1,16 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+public interface KakaoSpecification {
+
+    @GetMapping("/login/kakao")
+    @Operation(summary = "카카오 소셜 로그인", description = "", security = @SecurityRequirement(name = ""))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+    ApiResponse<KakaoResponseDTO.KakaoTokenDTO> kakaoLogin(@RequestParam(value = "code", required = false) String code);
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/TermSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/TermSpecification.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.GetMapping;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+import java.util.List;
+
+public interface TermSpecification {
+
+    @GetMapping("/terms")
+    @Operation(summary = "약관 목록 조회", description = "", security = @SecurityRequirement(name = ""))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+    ApiResponse<List<TermResponseDTO.TermDTO>> getTerms();
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/UserSpecification.java
@@ -1,0 +1,48 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+
+public interface UserSpecification {
+
+    @PostMapping("/users")
+    @SecurityRequirement(name = "")
+    @Operation(summary = "이메일 회원가입", description = "", security = @SecurityRequirement(name = ""))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 회원가입 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO);
+
+
+    @PostMapping("/login/email")
+    @Operation(summary = "이메일 로그인", description = "", security = @SecurityRequirement(name = ""))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 로그인 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO);
+
+
+    @PatchMapping("/users/password/find")
+    @Operation(summary = "비밀번호 변경", description = "", security = @SecurityRequirement(name = "tempToken"))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "❌ 토큰이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<Void> findPassword(@RequestHeader(name = "tempToken") String tempToken, @RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/converter/TermConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/TermConverter.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserTerm;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+public class TermConverter {
+
+    public static TermResponseDTO.TermDTO toTermDTO(Term term){
+        return TermResponseDTO.TermDTO.builder()
+                .title(term.getTitle())
+                .content(term.getContent())
+                .type(term.getType().name())
+                .build();
+    }
+
+    public static UserTerm toUserTerm(Boolean agreed, Term term, User user){
+        return UserTerm.builder()
+                .user(user)
+                .term(term)
+                .agreed(agreed)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -1,0 +1,21 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.enums.Role;
+import umc.GrowIT.Server.domain.enums.UserStatus;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+
+public class UserConverter {
+
+    public static User toUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
+        return User.builder()
+                .name(userInfoDTO.getName())
+                .email(userInfoDTO.getEmail())
+                .password(userInfoDTO.getPassword())
+                .status(UserStatus.ACTIVE)
+                .role(Role.USER)
+                .currentCredit(0)
+                .totalCredit(0)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -1,0 +1,31 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Diary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50)
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
+    private List<DiaryKeyword> diaryKeywords;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
+++ b/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
@@ -1,0 +1,28 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DiaryKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    /* 임시 주석
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id")
+    private Keyword keyword;
+
+     */
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Term.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Term.java
@@ -1,0 +1,35 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.TermType;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TermType type;
+
+    @OneToMany(mappedBy = "term", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerm;
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -1,0 +1,63 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.Provider;
+import umc.GrowIT.Server.domain.enums.Role;
+import umc.GrowIT.Server.domain.enums.UserStatus;
+
+import java.util.List;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer currentCredit;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer totalCredit;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Setter
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerms;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Diary> diaries;
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
@@ -1,0 +1,29 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean agreed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
+++ b/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum Provider {
+    KAKAO, APPLE
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/Role.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
@@ -1,0 +1,6 @@
+package umc.GrowIT.Server.domain.enums;
+
+
+public enum TermType {
+    MANDATORY, OPTIONAL
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum UserStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/umc/GrowIT/Server/dto/KakaoResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/KakaoResponseDTO.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class KakaoResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoTokenDTO {
+        String accessToken;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/TermRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/TermRequestDTO.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class TermRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserTermDTO {
+
+        @NotEmpty
+        private Long termId;
+
+        @NotNull
+        private Boolean agreed;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/TermResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/TermResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TermResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermDTO {
+
+        private String title;
+
+        private String content;
+
+        private String type; //필수, 선택 여부
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/UserRequestDTO.java
@@ -1,0 +1,63 @@
+package umc.GrowIT.Server.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoDTO {
+
+        @NotBlank(message = "필수 입력 항목입니다.")
+        @Email(message = "이메일 형식에 맞춰주세요.")
+        private String email;
+
+        @Size(min = 1, max = 20, message = "크기는 1에서 20 사이입니다.")
+        private String name;
+
+        @Size(min = 8, max = 30, message =  "크기는 8에서 30 사이입니다.")
+        private String password;
+
+        @NotEmpty(message = "필수 입력 항목입니다.")
+        private List<TermRequestDTO.UserTermDTO> userTerm;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailLoginDTO {
+
+        @NotBlank(message = "필수 입력 항목입니다.")
+        @Email(message = "이메일 형식에 맞춰주세요.")
+        private String email;
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String password;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PasswordDTO {
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String password;
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String passwordCheck;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/dto/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/UserResponseDTO.java
@@ -1,0 +1,18 @@
+package umc.GrowIT.Server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenDTO {
+        String token;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.Term;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long>  {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/umc/GrowIT/Server/service/KakaoService.java
+++ b/src/main/java/umc/GrowIT/Server/service/KakaoService.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+
+public interface KakaoService {
+
+    KakaoResponseDTO.KakaoTokenDTO getToken(String code);
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/KakaoServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/KakaoServiceImpl.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.service;
+
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+@Service
+public class KakaoServiceImpl implements KakaoService {
+
+    @Override
+    public KakaoResponseDTO.KakaoTokenDTO getToken(String code){
+        return null;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermCommandService.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.TermRequestDTO;
+
+import java.util.List;
+
+
+public interface TermCommandService {
+
+    void createUserTerms(List<TermRequestDTO.UserTermDTO> userTermDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermCommandServiceImpl.java
@@ -1,0 +1,18 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.dto.TermRequestDTO;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class TermCommandServiceImpl implements TermCommandService {
+
+    @Override
+    public void createUserTerms(List<TermRequestDTO.UserTermDTO> userTermDTO) {
+
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermQueryService.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+import java.util.List;
+
+public interface TermQueryService {
+
+    List<TermResponseDTO.TermDTO> getTerms();
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.converter.TermConverter;
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+import umc.GrowIT.Server.repository.TermRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermQueryServiceImpl implements TermQueryService{
+
+    private final TermRepository termRepository;
+
+    public List<TermResponseDTO.TermDTO> getTerms(){
+        List<Term> terms = termRepository.findAll();
+
+        return terms.stream()
+                .map(TermConverter::toTermDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/UserCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/UserCommandService.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+
+
+public interface UserCommandService {
+
+    UserResponseDTO.TokenDTO createUser(UserRequestDTO.UserInfoDTO userInfoDTO);
+
+    UserResponseDTO.TokenDTO emailLogin(UserRequestDTO.EmailLoginDTO emailLoginDTO);
+
+    void updatePassword(UserRequestDTO.PasswordDTO passwordDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/service/UserCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/UserCommandServiceImpl.java
@@ -1,0 +1,67 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.converter.TermConverter;
+import umc.GrowIT.Server.converter.UserConverter;
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserTerm;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+import umc.GrowIT.Server.repository.TermRepository;
+import umc.GrowIT.Server.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final TermRepository termRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public UserResponseDTO.TokenDTO createUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
+        String email = userInfoDTO.getEmail();
+        Optional<User> user = userRepository.findByEmail(email);
+        if (user.isPresent()) {
+            return null;
+        } else {
+            //TODO: 비밀번호 인코딩, 토큰 생성
+            User newUser = UserConverter.toUser(userInfoDTO);
+
+            newUser.encodePassword(passwordEncoder.encode(newUser.getPassword()));
+
+            //UserInfoDTO의 UserTermDTO(term_id, agreed) -> UserTerm
+            List<UserTerm> userTerms = userInfoDTO.getUserTerm().stream()
+                    .map(tempUserTerm -> {
+                        Term term = termRepository.findById(tempUserTerm.getTermId()).orElseThrow();
+                        return TermConverter.toUserTerm(tempUserTerm.getAgreed(), term, newUser);
+                    })
+                    .collect(Collectors.toList());
+
+            newUser.setUserTerms(userTerms);
+
+            userRepository.save(newUser);
+
+            UserResponseDTO.TokenDTO tokenDTO = new UserResponseDTO.TokenDTO("token");
+            return tokenDTO;
+        }
+    }
+
+    @Override
+    public UserResponseDTO.TokenDTO emailLogin(UserRequestDTO.EmailLoginDTO emailLoginDTO){
+        return null;
+    }
+
+    @Override
+    public void updatePassword(UserRequestDTO.PasswordDTO passwordDTO) {
+
+    }
+}

--- a/src/test/java/umc/GrowIT/Server/repository/TermRepositoryTest.java
+++ b/src/test/java/umc/GrowIT/Server/repository/TermRepositoryTest.java
@@ -1,0 +1,79 @@
+package umc.GrowIT.Server.repository;
+
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.repository.TermRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static umc.GrowIT.Server.domain.enums.TermType.MANDATORY;
+import static umc.GrowIT.Server.domain.enums.TermType.OPTIONAL;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class TermRepositoryTest {
+    @Autowired
+    private TermRepository termRepository;
+
+    @Test
+    public void createTermTest(){
+        Term term1 = Term.builder()
+                .title("이용약관 (1)")
+                .content("이용약관 (1) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term1);
+
+        Term term2 = Term.builder()
+                .title("이용약관 (2)")
+                .content("이용약관 (2) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term2);
+
+        Term term3 = Term.builder()
+                .title("이용약관 (3)")
+                .content("이용약관 (3) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term3);
+
+        Term term4 = Term.builder()
+                .title("이용약관 (4)")
+                .content("이용약관 (4) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term4);
+
+        Term term5 = Term.builder()
+                .title("개인정보 수집 이용 동의")
+                .content("개인정보 수집 이용 동의 내용")
+                .type(OPTIONAL)
+                .build();
+        termRepository.save(term5);
+
+        Term term6 = Term.builder()
+                .title("개인정보 제3자 제공 동의")
+                .content("개인정보 제3자 제공 동의 내용")
+                .type(OPTIONAL)
+                .build();
+        termRepository.save(term6);
+
+        assertThat(termRepository.findAll().size()).isEqualTo(6);
+    }
+
+    @Test
+    public void selectTermTest(){
+
+        assertThat(termRepository.findById(5L).get().getTitle()).isEqualTo("개인정보 수집 이용 동의");
+
+    }
+
+    @Test
+    public void deleteTermTest(){
+        for (int i=7; i<=12; i++)
+            termRepository.deleteById((long)i);
+
+        assertThat(termRepository.findAll().size()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

### 1. 계정/인증 관련 API 명세서 작성
- **Controller**
  - Kakao, Term, User 관련 API 작성
- **DTO**
  - KakaoResponse, TermRequest/TermResponse, UserRequest/UserResponse 작성
- **Specification 디렉토리**
  - Swagger 명세용 어노테이션을 별도 인터페이스로 분리하여 관리

### 2. 약관 동의 API 및 회원가입 API 구현
- **새로운 레포지토리로 일부 CRUD 작업 내용 이동**
  - **Domain** : Diary, DiaryKeyword, Term, User, UserTerm
  - **Service** : Kakao, Term, User
  - **Converter** : Term, User
  - **Repository** : Term, User

- **약관 동의 API**
  - 약관 목록을 조회하는 API 구현

- **회원 가입 API**
  - 이메일이 존재하는 회원이면 예외를 던지고, 존재하지 않는 경우 회원 생성.
  - 비밀번호는 인코딩하여 저장.
  - 추가 예정: 회원가입 완료 시 토큰 생성 로직 및 기타 추가 구현 예정.

### 3. Spring Security 설정 일부 포함
  - **SpringConfig**


## 🔍 테스트 방법
### 1. 계정/인증 관련 API 명세서 작성
<details>
  <summary>Swagger 계정 관련 API 명세서</summary>

  ![Swagger 계정 관련 API 명세서](https://github.com/user-attachments/assets/8c2186ee-3900-411f-8973-c6c8617fda90)

</details>

### 2-1. 약관 목록 조회 API 구현

<details>
  <summary>약관 목록 조회 API</summary>

  - `src/test/java/umc/GrowIT/Server/repository/TermRepositoryTest.java`에서 `createTermTest()` 실행시키면 DB에 약관이 저장됩니다.
  - Swagger에서 `GET /terms` 요청

  ![약관 목록 조회 API](https://github.com/user-attachments/assets/803526a0-db34-47fe-a8b7-c91e8e5391d8)

</details>

### 2-2. 회원 가입 API 구현

<details>
  <summary>회원 가입 API</summary>

  - Swagger에서 `POST /users` 요청
  - 사진과 같이 바디 부분에 약관 목록 (1~6)을 넣고 요청 해주세요.
  ![이메일이 존재하는 회원](https://github.com/user-attachments/assets/3f3bb1ef-190a-436d-b16e-af88fe8500ce)
  ![회원 가입 성공](https://github.com/user-attachments/assets/489942cd-c2be-4733-9125-97658f029553)

</details>