### PR TITLE
[#7] Feat: 아이템/Gro관련 Entity 및 API Swagger관련기능 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,10 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 //	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -39,6 +38,11 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,16 +28,19 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    // 아이템 관련 에러
+    ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM4001", "아이템을 찾을 수 없습니다."),
+    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM4002", "보유하지 않은 아이템입니다."),
+    ITEM_ALREADY_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM4003", "동일 카테고리의 다른 아이템이 이미 착용중입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/GrowIT/Server/domain/Gro.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Gro.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Gro extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    @ColumnDefault("1")
+    private Integer level;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Item.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Item.java
@@ -1,0 +1,32 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Item extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ItemCategory category;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String imageUrl;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
+++ b/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 512)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Term.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Term.java
@@ -1,0 +1,36 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.TermType;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TermType type;
+
+    @OneToMany(mappedBy = "term", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerm;
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -1,0 +1,51 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.UserStatus;
+import umc.GrowIT.Server.domain.enums.Provider;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false, length = 30)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer currentCredit;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer totalCredit;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerm;
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/UserItem.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserItem.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Enumerated(EnumType.STRING)
+    private ItemStatus status;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
@@ -1,0 +1,31 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean agreed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
+++ b/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/ItemCategory.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/ItemCategory.java
@@ -1,0 +1,8 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum ItemCategory {
+    BACKGROUND,      // 배경
+    OBJECT,         // 캐릭터 옆에 놓일 오브제
+    PLANT,     // 화분 스킨
+    HEAD_ACCESSORY  // 캐릭터 머리 장식
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/ItemStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/ItemStatus.java
@@ -1,0 +1,6 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum ItemStatus {
+    EQUIPPED,    // 착용
+    UNEQUIPPED  // 미착용
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum Provider {
+    KAKAO, APPLE
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum TermType {
+    MANDATORY, OPTIONAL
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum UserStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.web.dto.GroDTO.GroRequestDTO;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 
+@SecurityRequirement(name = "JWT TOKEN")
 @Tag(name = "Gro", description = "Gro 관련 API")
 @RestController
 @RequiredArgsConstructor
@@ -39,8 +41,6 @@ public class GroController {
 
 
     public ApiResponse<GroResponseDTO> createGro(
-            @Parameter(description = "Bearer {kakao_access_token}")
-            @RequestHeader("Authorization") String authorization,
             @Valid @RequestBody GroRequestDTO request
     ) {
         // Service를 통해 엔티티 생성

--- a/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
@@ -1,0 +1,50 @@
+package umc.GrowIT.Server.web.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.GroDTO.GroRequestDTO;
+import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
+
+@Tag(name = "Gro", description = "Gro 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/characters")
+public class GroController {
+
+
+    @PostMapping("")
+    @Operation(summary = "그로 캐릭터 생성", description = "사용자의 그로 캐릭터를 생성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH001",
+                    description = "acess 토큰 만료",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+
+
+    public ApiResponse<GroResponseDTO> createGro(
+            @Parameter(description = "Bearer {kakao_access_token}")
+            @RequestHeader("Authorization") String authorization,
+            @Valid @RequestBody GroRequestDTO request
+    ) {
+        // Service를 통해 엔티티 생성
+        //Gro gro = groService.createGro(request);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -1,0 +1,38 @@
+package umc.GrowIT.Server.web.controller;
+
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+
+
+@Tag(name="Item", description = "아이템 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/items")
+public class ItemController {
+
+    @GetMapping("")
+    public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(
+            @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
+                    schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
+                    example = "BACKGROUND")
+            @RequestParam ItemCategory category)
+    {
+        return ApiResponse.onSuccess(null);
+    }
+
+
+
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -1,18 +1,20 @@
 package umc.GrowIT.Server.web.controller;
 
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipRequestDTO;
+import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipResponseDTO;
 
 
 @Tag(name="Item", description = "아이템 관련 API")
@@ -33,6 +35,23 @@ public class ItemController {
 
 
 
+    @PatchMapping("/{itemId}")
+    @Operation(
+            summary = "아이템 착용 상태 변경",
+            description = "사용자가 보유한 아이템의 착용 상태를 변경합니다."
+    )
+    public ApiResponse<ItemEquipResponseDTO> updateItemStatus(
 
-
+            @Parameter(description = "아이템 ID", example = "1")
+            @PathVariable(name = "itemId") Long itemId,
+            @Valid @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "아이템 착용 상태 정보",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = ItemEquipRequestDTO.class)
+                    )
+            ) ItemEquipRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -23,6 +23,10 @@ import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipResponseDTO;
 @RequestMapping("/items")
 public class ItemController {
 
+    @Operation(
+            summary = "카테고리별 아이템 조회",
+            description = "상점이나 보유아이템 조회에서 카테고리를 선택했을 때 실행."
+    )
     @GetMapping("")
     public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(
             @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 
 @Tag(name = "User", description = "User 관련 API")
@@ -23,9 +25,6 @@ public class UserController {
     @Operation(summary = "보유중인 아이템 조회", description = "사용자가 보유한 아이템들을 조회합니다.")
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(
 
-//            @Schema(description = "아이템 카테고리 (카테고리 명으로 전달)",
-//                    allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"},
-//                    example = "BACKGROUND")
             @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
                     schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
                     example = "BACKGROUND")
@@ -34,4 +33,23 @@ public class UserController {
         return ApiResponse.onSuccess(null);
     }
 
+
+
+    @GetMapping("/credits")
+    @Operation(summary = "보유중인 크레딧 조회", description = "사용자가 현재 보유한 크레딧 조회")
+    public ApiResponse<CreditResponseDTO.CreditDTO> getUserCredit(
+
+    )
+    {
+        return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping("/credits/total")
+    @Operation(summary = "누적 크레딧 조회", description = "사용자의 누적 크레딧을 조회합니다.")
+    public ApiResponse<CreditResponseDTO.CreditDTO> getUserTotalCredit(
+
+    )
+    {
+        return ApiResponse.onSuccess(null);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -2,18 +2,19 @@ package umc.GrowIT.Server.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentRequestDTO;
+import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentResponseDTO;
 
 @Tag(name = "User", description = "User 관련 API")
 @RestController
@@ -51,5 +52,22 @@ public class UserController {
     )
     {
         return ApiResponse.onSuccess(null);
+    }
+
+    @PostMapping("/credits/payment")
+    @Operation(
+            summary = "크레딧 구매",
+            description = "결제를 통해 크레딧을 구매합니다."
+    )
+    public ApiResponse<PaymentResponseDTO> purchaseCredits(
+            @Valid @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "결제 정보",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PaymentRequestDTO.class)
+                    )
+            ) PaymentRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(null);  // 실제 구현은 service에서 처리
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -1,0 +1,37 @@
+package umc.GrowIT.Server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+
+@Tag(name = "User", description = "User 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    @GetMapping("/items")
+    @Operation(summary = "보유중인 아이템 조회", description = "사용자가 보유한 아이템들을 조회합니다.")
+    public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(
+
+//            @Schema(description = "아이템 카테고리 (카테고리 명으로 전달)",
+//                    allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"},
+//                    example = "BACKGROUND")
+            @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
+                    schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
+                    example = "BACKGROUND")
+            @RequestParam ItemCategory category)
+    {
+        return ApiResponse.onSuccess(null);
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/CreditDTO/CreditResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/CreditDTO/CreditResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.web.dto.CreditDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CreditResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreditDTO {
+        @Schema(description = "현재 보유한 크레딧", example = "1200")
+        private Integer credit;
+    }
+
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
@@ -1,0 +1,15 @@
+package umc.GrowIT.Server.web.dto.GroDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class GroRequestDTO {
+
+    @Schema(description = "성장할 그로의 이름(최대 50자)", example = "그로이름")
+    @NotBlank(message = "name은 필수 입력 항목입니다.")
+    @Size(max = 50, message = "name은 최대 50자까지 입력 가능합니다.")
+    private String name;
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
@@ -1,0 +1,28 @@
+package umc.GrowIT.Server.web.dto.GroDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroResponseDTO {
+
+    @Schema(description = "그로 id")
+    private Long id;
+
+    @Schema(description = "사용자 id")
+    private Long user_id;
+
+    @Schema(description = "사용자가 입력한 그로의 이름")
+    private String name;
+
+    @Schema(description = "초기 레벨")
+    private Integer level;
+
+    @Schema(description = "생성 시간")
+    private String created_at;
+
+    @Schema(description = "수정 시간")
+    private String updated_at;
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemRequestDTO.java
@@ -1,0 +1,4 @@
+package umc.GrowIT.Server.web.dto.ItemDTO;
+
+public class ItemRequestDTO {
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
@@ -1,0 +1,49 @@
+package umc.GrowIT.Server.web.dto.ItemDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
+
+import java.util.List;
+
+public class ItemResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemListDTO {
+        @Schema(description = "아이템 목록")
+        private List<ItemDTO> itemList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemDTO {
+        @Schema(description = "아이템 ID")
+        Long id;
+
+        @Schema(description = "아이템명")
+        String name;
+
+        @Schema(description = "아이템 가격 (크레딧)", example = "120")
+        Integer price;
+
+        @Schema(description = "이미지 URL")
+        String imageUrl;
+
+        @Schema(description = "아이템 카테고리", allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"})
+        String category;
+
+        @Schema(description = "착용 상태", example = "EQUIPPED", allowableValues = {"EQUIPPED","UNEQUIPPED"})
+        String status;
+
+        @Schema(description = "구매 여부", example = "false")
+        boolean purchased;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemEquipDTO/ItemEquipRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemEquipDTO/ItemEquipRequestDTO.java
@@ -1,0 +1,23 @@
+package umc.GrowIT.Server.web.dto.ItemEquipDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ItemEquipRequestDTO {
+    @Schema(
+            description = "아이템 착용 상태",
+            example = "EQUIPPED",
+            allowableValues = {"EQUIPPED", "UNEQUIPPED"},
+            required = true
+    )
+    @NotNull(message = "착용 상태는 필수입니다.")
+    private String status;
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemEquipDTO/ItemEquipResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemEquipDTO/ItemEquipResponseDTO.java
@@ -1,0 +1,45 @@
+package umc.GrowIT.Server.web.dto.ItemEquipDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemEquipResponseDTO {
+    @Schema(
+            description = "아이템 ID",
+            example = "1"
+    )
+    private Long itemId;
+
+    @Schema(
+            description = "아이템명",
+            example = "블루 배경화면"
+    )
+    private String name;
+
+    @Schema(
+            description = "아이템 카테고리",
+            example = "BACKGROUND",
+            allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}
+    )
+    private String category;
+
+    @Schema(
+            description = "착용 상태",
+            example = "EQUIPPED",
+            allowableValues = {"EQUIPPED", "UNEQUIPPED"}
+    )
+    private String status;
+
+    @Schema(
+            description = "상태 변경 시간",
+            example = "2024-01-11T15:30:00"
+    )
+    private String updatedAt;
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/PaymentDTO/PaymentRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/PaymentDTO/PaymentRequestDTO.java
@@ -1,0 +1,38 @@
+package umc.GrowIT.Server.web.dto.PaymentDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentRequestDTO {
+    @NotNull
+    @Schema(
+            description = "결제 고유 ID",
+            example = "imp_123456789"
+    )
+    private String paymentId;
+
+    @NotNull
+    @Schema(
+            description = "결제 금액",
+            example = "10000"
+    )
+    private Integer amount;
+
+    @NotNull
+    @Schema(
+            description = "구매한 크레딧 양",
+            example = "100"
+    )
+    private Integer creditAmount;
+
+
+    private String paymentMethod;
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/PaymentDTO/PaymentResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/PaymentDTO/PaymentResponseDTO.java
@@ -1,0 +1,38 @@
+package umc.GrowIT.Server.web.dto.PaymentDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentResponseDTO {
+    @Schema(
+            description = "결제 후 현재 크레딧",
+            example = "150"  // 기존 50 크레딧에 100 크레딧 추가된 경우
+    )
+    private Integer currentCredit;
+
+    @Schema(
+            description = "결제 후 누적 크레딧",
+            example = "300"  // 기존 200 크레딧에 100 크레딧 추가된 경우
+    )
+    private Integer totalCredit;
+
+    @Schema(
+            description = "결제 상태",
+            example = "SUCCESS",
+            allowableValues = {"SUCCESS", "FAILED", "PENDING"}
+    )
+    private String status;
+
+    @Schema(
+            description = "결제 시간",
+            example = "2024-01-11T15:30:00"
+    )
+    private String paidAt;
+}


### PR DESCRIPTION
## 📝 작업 내용
### 아이템/Gro관련 Entity 및 API Swagger관련기능 생성
--------
#### 작업한파일
- domain
   - Gro
   - Item
   - RefreshToken
   - UserItem
- web
   - controller
       -  GroController
       - ItemController
       - UserController
   - dto
       - CreditDTO
       - GroDTO
       - ItemDTO
       - ItemEquipDTO
       - PaymentDTO


## 🔍 테스트 방법
![image](https://github.com/user-attachments/assets/95130077-181f-4813-b519-ccc809c7c00f)


