### PR TITLE
[#12] Feat: 계정/인증 관련 API 명세서 및 회원 가입 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -38,6 +38,11 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
+++ b/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
@@ -2,8 +2,10 @@ package umc.GrowIT.Server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class GrowItServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
@@ -27,6 +27,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
+    public static <T> ApiResponse<T> onSuccess(){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), null);
+    }
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
             return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,21 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    //멤버 관련 에러
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호 확인이 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4002", "이메일 또는 패스워드가 일치하지 않습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다."),
+
+    //약관 관련 에러
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),
+    MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 약관에 반드시 동의해야 합니다."),
+    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4003", "전체 약관 정보를 주세요."),
+
+    //토큰 관련 에러
+    INVALID_TOKEN(HttpStatus.NOT_FOUND, "AUTH4001", "토큰이 유효하지 않습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/TermHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/TermHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class TermHandler extends GeneralException {
+
+    public TermHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/UserHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/UserHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class UserHandler extends GeneralException {
+
+    public UserHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package umc.GrowIT.Server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                            .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() //인증 없이 접근 가능
+                            .requestMatchers("/", "/login/email", "/login/kakao","/users/password/find", "/users", "/terms").permitAll() //인증 없이 접근 가능
+                            .anyRequest().permitAll()
+                            //.anyRequest().authenticated() //나머지 요청은 인증 필요
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/controller/KakaoController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/KakaoController.java
@@ -1,0 +1,23 @@
+package umc.GrowIT.Server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.controller.specification.KakaoSpecification;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+import umc.GrowIT.Server.service.KakaoService;
+
+@RestController
+@RequiredArgsConstructor
+public class KakaoController implements KakaoSpecification {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping("/login/kakao")
+    public ApiResponse<KakaoResponseDTO.KakaoTokenDTO> kakaoLogin(@RequestParam(value = "code", required = false) String code) {
+        KakaoResponseDTO.KakaoTokenDTO token = kakaoService.getToken(code);
+        return ApiResponse.onSuccess(token);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/controller/TermController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/TermController.java
@@ -1,0 +1,24 @@
+package umc.GrowIT.Server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.controller.specification.TermSpecification;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+import umc.GrowIT.Server.service.TermQueryService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TermController implements TermSpecification {
+
+    private final TermQueryService termQueryService;
+
+    @GetMapping("/terms")
+    public ApiResponse<List<TermResponseDTO.TermDTO>> getTerms() {
+        return ApiResponse.onSuccess(termQueryService.getTerms());
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/controller/UserController.java
@@ -1,0 +1,39 @@
+package umc.GrowIT.Server.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.controller.specification.UserSpecification;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+import umc.GrowIT.Server.service.UserCommandService;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController implements UserSpecification {
+
+    private final UserCommandService userCommandService;
+
+    @PostMapping("/login/email")
+    public ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO) {
+        UserResponseDTO.TokenDTO tokenDTO = userCommandService.emailLogin(emailLoginDTO);
+        return ApiResponse.onSuccess(tokenDTO);
+    }
+
+    @PostMapping("/users")
+    public ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO) {
+        UserResponseDTO.TokenDTO tokenDTO = userCommandService.createUser(userInfoDTO);
+        if (tokenDTO == null) {
+            return ApiResponse.onFailure(ErrorStatus.EMAIL_ALREADY_EXISTS.getCode(), ErrorStatus.EMAIL_ALREADY_EXISTS.getMessage(), null);
+        }
+        return ApiResponse.onSuccess(tokenDTO);
+    }
+
+    @PatchMapping("/users/password/find")
+    public ApiResponse<Void> findPassword(@RequestHeader(name = "tempToken") String tempToken, @RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO) {
+        userCommandService.updatePassword(passwordDTO);
+        return ApiResponse.onSuccess();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/KakaoSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/KakaoSpecification.java
@@ -1,0 +1,16 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+public interface KakaoSpecification {
+
+    @GetMapping("/login/kakao")
+    @Operation(summary = "카카오 소셜 로그인", description = "", security = @SecurityRequirement(name = ""))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+    ApiResponse<KakaoResponseDTO.KakaoTokenDTO> kakaoLogin(@RequestParam(value = "code", required = false) String code);
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/TermSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/TermSpecification.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.web.bind.annotation.GetMapping;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+import java.util.List;
+
+public interface TermSpecification {
+
+    @GetMapping("/terms")
+    @Operation(summary = "약관 목록 조회", description = "", security = @SecurityRequirement(name = ""))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+    ApiResponse<List<TermResponseDTO.TermDTO>> getTerms();
+}

--- a/src/main/java/umc/GrowIT/Server/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/controller/specification/UserSpecification.java
@@ -1,0 +1,51 @@
+package umc.GrowIT.Server.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+
+public interface UserSpecification {
+
+    @PostMapping("/users")
+    @SecurityRequirement(name = "")
+    @Operation(summary = "이메일 회원가입", description = "", security = @SecurityRequirement(name = ""))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TEMP4001", description = "❌ 존재하지 않는 약관을 요청했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TEMP4002", description = "❌ 필수 약관에 반드시 동의해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TEMP4003", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 회원가입 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO);
+
+
+    @PostMapping("/login/email")
+    @Operation(summary = "이메일 로그인", description = "", security = @SecurityRequirement(name = ""))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 로그인 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO);
+
+
+    @PatchMapping("/users/password/find")
+    @Operation(summary = "비밀번호 변경", description = "", security = @SecurityRequirement(name = "tempToken"))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "❌ 토큰이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<Void> findPassword(@RequestHeader(name = "tempToken") String tempToken, @RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/converter/TermConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/TermConverter.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserTerm;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+public class TermConverter {
+
+    public static TermResponseDTO.TermDTO toTermDTO(Term term){
+        return TermResponseDTO.TermDTO.builder()
+                .title(term.getTitle())
+                .content(term.getContent())
+                .type(term.getType().name())
+                .build();
+    }
+
+    public static UserTerm toUserTerm(Boolean agreed, Term term, User user){
+        return UserTerm.builder()
+                .user(user)
+                .term(term)
+                .agreed(agreed)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
@@ -1,0 +1,19 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.RefreshToken;
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class TokenConverter {
+
+    public static RefreshToken toRefreshToken(String refreshToken, LocalDateTime expiryDate) {
+
+        return RefreshToken.builder()
+                .refreshToken(refreshToken)
+                .expiryDate(expiryDate)
+                .build();
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -1,0 +1,21 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.enums.Role;
+import umc.GrowIT.Server.domain.enums.UserStatus;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+
+public class UserConverter {
+
+    public static User toUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
+        return User.builder()
+                .name(userInfoDTO.getName())
+                .email(userInfoDTO.getEmail())
+                .password(userInfoDTO.getPassword())
+                .status(UserStatus.ACTIVE)
+                .role(Role.USER)
+                .currentCredit(0)
+                .totalCredit(0)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -1,0 +1,31 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Diary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50)
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL)
+    private List<DiaryKeyword> diaryKeywords;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
+++ b/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
@@ -1,0 +1,28 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DiaryKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    /* 임시 주석
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id")
+    private Keyword keyword;
+
+     */
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
+++ b/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
@@ -1,0 +1,26 @@
+package umc.GrowIT.Server.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 512)
+    private String refreshToken;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/Term.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Term.java
@@ -1,0 +1,35 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.TermType;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TermType type;
+
+    @OneToMany(mappedBy = "term", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerm;
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -1,0 +1,67 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.Provider;
+import umc.GrowIT.Server.domain.enums.Role;
+import umc.GrowIT.Server.domain.enums.UserStatus;
+
+import java.util.List;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer currentCredit;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer totalCredit;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Setter
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserTerm> userTerms;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Diary> diaries;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "refresh_token_id", nullable = true)
+    private RefreshToken refreshToken;
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserTerm.java
@@ -1,0 +1,29 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Boolean agreed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
+}

--- a/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
+++ b/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.domain.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/Provider.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum Provider {
+    KAKAO, APPLE
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/Role.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/TermType.java
@@ -1,0 +1,6 @@
+package umc.GrowIT.Server.domain.enums;
+
+
+public enum TermType {
+    MANDATORY, OPTIONAL
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum UserStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/umc/GrowIT/Server/dto/KakaoResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/KakaoResponseDTO.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class KakaoResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoTokenDTO {
+        String accessToken;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/TermRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/TermRequestDTO.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class TermRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserTermDTO {
+
+        @NotEmpty
+        private Long termId;
+
+        @NotNull
+        private Boolean agreed;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/TermResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/TermResponseDTO.java
@@ -1,0 +1,22 @@
+package umc.GrowIT.Server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TermResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermDTO {
+
+        private String title;
+
+        private String content;
+
+        private String type; //필수, 선택 여부
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/dto/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/UserRequestDTO.java
@@ -1,0 +1,63 @@
+package umc.GrowIT.Server.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserRequestDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserInfoDTO {
+
+        @NotBlank(message = "필수 입력 항목입니다.")
+        @Email(message = "이메일 형식에 맞춰주세요.")
+        private String email;
+
+        @Size(min = 1, max = 20, message = "크기는 1에서 20 사이입니다.")
+        private String name;
+
+        @Size(min = 8, max = 30, message =  "크기는 8에서 30 사이입니다.")
+        private String password;
+
+        @NotEmpty(message = "필수 입력 항목입니다.")
+        private List<TermRequestDTO.UserTermDTO> userTerms;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailLoginDTO {
+
+        @NotBlank(message = "필수 입력 항목입니다.")
+        @Email(message = "이메일 형식에 맞춰주세요.")
+        private String email;
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String password;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PasswordDTO {
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String password;
+
+        @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
+        private String passwordCheck;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/dto/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/dto/UserResponseDTO.java
@@ -1,0 +1,20 @@
+package umc.GrowIT.Server.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenDTO {
+        private String accessToken;
+        private String refreshToken;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/jwt/JwtTokenProvider.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/JwtTokenProvider.java
@@ -1,0 +1,70 @@
+package umc.GrowIT.Server.jwt;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+
+@Component
+public class JwtTokenProvider {
+
+    public static final long ACCESS_TOKEN_EXPIRATION_MS = 12L * 60 * 60 * 1000; //Access token 만료 시간 12시간
+    public static final long REFRESH_TOKEN_EXPIRATION_MS = 30L * 24 * 60 * 60 * 1000; //Refresh token 만료 시간 30일
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${spring.jwt.secretKey}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // User 정보를 가지고 AccessToken, RefreshToken 생성
+    public UserResponseDTO.TokenDTO generateToken(Authentication authentication) {
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRATION_MS);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName()) //principal 값 (이메일) 저장
+                .claim("roles", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRATION_MS))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return UserResponseDTO.TokenDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+    public Date getExpirationDate(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claims.getExpiration();
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/repository/RefreshTokenRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.Term;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long>  {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/umc/GrowIT/Server/service/KakaoService.java
+++ b/src/main/java/umc/GrowIT/Server/service/KakaoService.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+
+public interface KakaoService {
+
+    KakaoResponseDTO.KakaoTokenDTO getToken(String code);
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/KakaoServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/KakaoServiceImpl.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.service;
+
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.dto.KakaoResponseDTO;
+
+@Service
+public class KakaoServiceImpl implements KakaoService {
+
+    @Override
+    public KakaoResponseDTO.KakaoTokenDTO getToken(String code){
+        return null;
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/RefreshTokenCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/RefreshTokenCommandService.java
@@ -1,0 +1,8 @@
+package umc.GrowIT.Server.service;
+
+public interface RefreshTokenCommandService {
+
+    void createRefreshToken(String refreshToken);
+
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/RefreshTokenCommandServiceImpl.java
@@ -1,0 +1,31 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.converter.TokenConverter;
+import umc.GrowIT.Server.domain.RefreshToken;
+import umc.GrowIT.Server.jwt.JwtTokenProvider;
+import umc.GrowIT.Server.repository.RefreshTokenRepository;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void createRefreshToken(String refreshToken) {
+        Date expiryDate = jwtTokenProvider.getExpirationDate(refreshToken);
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault());
+
+        RefreshToken refreshTokenEntity = TokenConverter.toRefreshToken(refreshToken, localDateTime);
+
+        refreshTokenRepository.save(refreshTokenEntity);
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermCommandService.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.TermRequestDTO;
+
+import java.util.List;
+
+
+public interface TermCommandService {
+
+    void createUserTerms(List<TermRequestDTO.UserTermDTO> userTermDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermCommandServiceImpl.java
@@ -1,0 +1,18 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.dto.TermRequestDTO;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class TermCommandServiceImpl implements TermCommandService {
+
+    @Override
+    public void createUserTerms(List<TermRequestDTO.UserTermDTO> userTermDTO) {
+
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermQueryService.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.TermResponseDTO;
+
+import java.util.List;
+
+public interface TermQueryService {
+
+    List<TermResponseDTO.TermDTO> getTerms();
+}

--- a/src/main/java/umc/GrowIT/Server/service/TermQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/TermQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.converter.TermConverter;
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.dto.TermResponseDTO;
+import umc.GrowIT.Server.repository.TermRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermQueryServiceImpl implements TermQueryService{
+
+    private final TermRepository termRepository;
+
+    public List<TermResponseDTO.TermDTO> getTerms(){
+        List<Term> terms = termRepository.findAll();
+
+        return terms.stream()
+                .map(TermConverter::toTermDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/UserCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/UserCommandService.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.service;
+
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+
+
+public interface UserCommandService {
+
+    UserResponseDTO.TokenDTO createUser(UserRequestDTO.UserInfoDTO userInfoDTO);
+
+    UserResponseDTO.TokenDTO emailLogin(UserRequestDTO.EmailLoginDTO emailLoginDTO);
+
+    void updatePassword(UserRequestDTO.PasswordDTO passwordDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/service/UserCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/UserCommandServiceImpl.java
@@ -1,0 +1,108 @@
+package umc.GrowIT.Server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.TermHandler;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.converter.TermConverter;
+import umc.GrowIT.Server.converter.UserConverter;
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserTerm;
+import umc.GrowIT.Server.domain.enums.TermType;
+import umc.GrowIT.Server.dto.UserRequestDTO;
+import umc.GrowIT.Server.dto.UserResponseDTO;
+import umc.GrowIT.Server.repository.TermRepository;
+import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.jwt.JwtTokenProvider;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    public static final int TERM_COUNT = 6;
+    private final UserRepository userRepository;
+    private final TermRepository termRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenCommandService refreshTokenCommandService;
+
+    @Override
+    @Transactional
+    public UserResponseDTO.TokenDTO createUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
+        String email = userInfoDTO.getEmail();
+        Optional<User> user = userRepository.findByEmail(email);
+
+        //이미 가입한 회원일 때(이메일 존재) 예외 처리
+        if (user.isPresent()) {
+            throw new UserHandler(ErrorStatus.EMAIL_ALREADY_EXISTS);
+        }
+
+        //전체 약관 정보가 주어지지 않았을 때 예외 처리
+        if (userInfoDTO.getUserTerms().size() < TERM_COUNT) {
+            throw new TermHandler(ErrorStatus.ALL_TERMS_REQUIRED);
+        }
+
+        //User 엔티티로 변환
+        User newUser = UserConverter.toUser(userInfoDTO);
+        newUser.encodePassword(passwordEncoder.encode(newUser.getPassword()));
+
+        /*
+          사용자 약관 처리 과정
+          1. UserInfoDTO 내부 userTerms(term_id, agreed) Stream 형태로 처리
+          2. 약관 존재 여부 및 동의 상태 검증
+          3. UserTerm 엔티티로 변환
+        */
+        List<UserTerm> userTerms = userInfoDTO.getUserTerms().stream()
+                .map(tempUserTerm -> {
+                    Term term = termRepository.findById(tempUserTerm.getTermId())
+                            .orElse(null);
+                    //존재하지 않는 약관을 요청하면 예외 처리
+                    if (term == null) {
+                        throw new TermHandler(ErrorStatus.TERM_NOT_FOUND);
+                    //필수 약관에 동의하지 않으면 예외 처리
+                    } else if (term.getType() == TermType.MANDATORY && !tempUserTerm.getAgreed()) {
+                        throw new TermHandler(ErrorStatus.MANDATORY_TERMS_REQUIRED);
+                    }
+                    return TermConverter.toUserTerm(tempUserTerm.getAgreed(), term, newUser);
+                })
+                .collect(Collectors.toList());
+
+        newUser.setUserTerms(userTerms);
+        userRepository.save(newUser);
+
+        //User 정보를 담은 Authentication 객체 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                newUser.getEmail(), //principal
+                null, //credentials
+                List.of(new SimpleGrantedAuthority(newUser.getRole().name())) //authorities
+        );
+
+        UserResponseDTO.TokenDTO tokenDTO = jwtTokenProvider.generateToken(authentication); //JWT 토큰 생성 메소드 호출
+        refreshTokenCommandService.createRefreshToken(tokenDTO.getRefreshToken()); //RefreshToken DB 저장
+
+        return tokenDTO;
+    }
+
+
+    @Override
+    public UserResponseDTO.TokenDTO emailLogin(UserRequestDTO.EmailLoginDTO emailLoginDTO){
+        return null;
+    }
+
+    @Override
+    public void updatePassword(UserRequestDTO.PasswordDTO passwordDTO) {
+
+    }
+}

--- a/src/test/java/umc/GrowIT/Server/repository/TermRepositoryTest.java
+++ b/src/test/java/umc/GrowIT/Server/repository/TermRepositoryTest.java
@@ -1,0 +1,79 @@
+package umc.GrowIT.Server.repository;
+
+import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.repository.TermRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static umc.GrowIT.Server.domain.enums.TermType.MANDATORY;
+import static umc.GrowIT.Server.domain.enums.TermType.OPTIONAL;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class TermRepositoryTest {
+    @Autowired
+    private TermRepository termRepository;
+
+    @Test
+    public void createTermTest(){
+        Term term1 = Term.builder()
+                .title("이용약관 (1)")
+                .content("이용약관 (1) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term1);
+
+        Term term2 = Term.builder()
+                .title("이용약관 (2)")
+                .content("이용약관 (2) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term2);
+
+        Term term3 = Term.builder()
+                .title("이용약관 (3)")
+                .content("이용약관 (3) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term3);
+
+        Term term4 = Term.builder()
+                .title("이용약관 (4)")
+                .content("이용약관 (4) 내용")
+                .type(MANDATORY)
+                .build();
+        termRepository.save(term4);
+
+        Term term5 = Term.builder()
+                .title("개인정보 수집 이용 동의")
+                .content("개인정보 수집 이용 동의 내용")
+                .type(OPTIONAL)
+                .build();
+        termRepository.save(term5);
+
+        Term term6 = Term.builder()
+                .title("개인정보 제3자 제공 동의")
+                .content("개인정보 제3자 제공 동의 내용")
+                .type(OPTIONAL)
+                .build();
+        termRepository.save(term6);
+
+        assertThat(termRepository.findAll().size()).isEqualTo(6);
+    }
+
+    @Test
+    public void selectTermTest(){
+
+        assertThat(termRepository.findById(5L).get().getTitle()).isEqualTo("개인정보 수집 이용 동의");
+
+    }
+
+    @Test
+    public void deleteTermTest(){
+        for (int i=7; i<=12; i++)
+            termRepository.deleteById((long)i);
+
+        assertThat(termRepository.findAll().size()).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

1. 계정/인증 관련 API 명세서
- 카카오 로그인
- 이메일 로그인
- 회원 가입
- 약관 조회
- 비밀번호 찾기(변경)

2. 회원 가입 API 개발
- 약관 동의
- 회원 가입


## 🔍 테스트 방법
<details>
  <summary>Swagger API 명세서 확인</summary>

![계정/인증 관련 API 명세서](https://github.com/user-attachments/assets/051f005a-cb3e-47d2-85f1-eb6ebc215b25)

</details>