### PR TITLE
[#14] Feat: 아이템 구매/설정 관련 API

### DIFF
--- a/src/main/java/umc/GrowIT/Server/controller/User2Controller.java
+++ b/src/main/java/umc/GrowIT/Server/controller/User2Controller.java
@@ -12,7 +12,7 @@ import umc.GrowIT.Server.service.UserCommandService;
 
 @RestController
 @RequiredArgsConstructor
-public class UserController implements UserSpecification {
+public class User2Controller implements UserSpecification {
 
     private final UserCommandService userCommandService;
 

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -1,24 +1,14 @@
 package umc.GrowIT.Server.domain;
 
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/develop
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import umc.GrowIT.Server.domain.common.BaseEntity;
-<<<<<<< HEAD
 import umc.GrowIT.Server.domain.enums.Provider;
 import umc.GrowIT.Server.domain.enums.Role;
 import umc.GrowIT.Server.domain.enums.UserStatus;
 
-=======
-import umc.GrowIT.Server.domain.enums.UserStatus;
-import umc.GrowIT.Server.domain.enums.Provider;
->>>>>>> origin/develop
 import java.util.List;
-
 
 @Entity
 @Getter

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeRestController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeRestController.java
@@ -1,0 +1,33 @@
+package umc.GrowIT.Server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+
+@Tag(name = "Challenge", description = "Challenge 관련 API")
+@RestController
+@RequestMapping("/challenges")
+public class ChallengeRestController {
+
+    @DeleteMapping("{challengeId}")
+    @Operation(
+            summary = "챌린지 삭제 API",
+            description = "특정 챌린지를 삭제하는 API입니다. 챌린지 ID를 path variable로 전달받아 해당 챌린지를 삭제합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameter(name = "challengeId", description = "삭제할 챌린지의 ID", required = true)
+    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long challengeId) {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/HomeRestController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/HomeRestController.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.HomeDTO.HomeResponseDTO;
+
+@Tag(name = "Home", description = "Home 관련 API")
+@RestController
+@RequestMapping("/home")
+public class HomeRestController {
+
+    @GetMapping()
+    @Operation(
+            summary = "홈 화면 조회 API",
+            description = "홈 화면을 조회하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<HomeResponseDTO.GetHomeResponseDTO> getHome() {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemRestController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemRestController.java
@@ -1,0 +1,33 @@
+package umc.GrowIT.Server.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+
+@Tag(name = "Item", description = "Item 관련 API")
+@RestController
+@RequestMapping("/items")
+public class ItemRestController {
+
+    @PostMapping("/{itemId}/order")
+    @Operation(
+            summary = "아이템 주문 API",
+            description = "특정 아이템을 주문하는 API입니다. 아이템 ID를 path variable로 전달받아 해당 아이템을 주문합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameter(name = "itemId", description = "주문할 아이템의 ID", required = true)
+    public ApiResponse<ItemResponseDTO.OrderItemResponseDTO> orderItem(@PathVariable("itemId") Long itemId) {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.Getter;
@@ -24,8 +25,10 @@ public class UserController {
 
     @GetMapping("/items")
     @Operation(summary = "보유중인 아이템 조회", description = "사용자가 보유한 아이템들을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(
-
             @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
                     schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
                     example = "BACKGROUND")

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserRestController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserRestController.java
@@ -1,0 +1,68 @@
+package umc.GrowIT.Server.web.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+@Tag(name = "User", description = "User 관련 API")
+@RestController
+@RequestMapping("/users")
+public class UserRestController {
+
+    // 사용자 계정 관련
+    @PostMapping("/password")
+    @Operation(
+            summary = "비밀번호 재설정 API",
+            description = "사용자가 비밀번호를 재설정하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<UserRequestDTO.ResetPasswordRequestDTO> resetPassword(@RequestBody UserRequestDTO.ResetPasswordRequestDTO request) {
+        return ApiResponse.onSuccess(null);
+    }
+
+    @PatchMapping("")
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = "사용자가 자신의 계정을 삭제하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser(@RequestBody UserRequestDTO.DeleteUserRequestDTO request) {
+        return ApiResponse.onSuccess(null);
+    }
+
+    // 사용자 인증 관련
+    @PostMapping("/email")
+    @Operation(
+            summary = "인증 메일 전송 API",
+            description = "사용자에게 인증 메일을 전송하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<UserResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(@RequestBody UserRequestDTO.SendAuthEmailRequestDTO request) {
+        return ApiResponse.onSuccess(null);
+    }
+
+    @PostMapping("/verification")
+    @Operation(
+            summary = "인증 번호 확인 API",
+            description = "사용자가 입력한 인증 번호를 확인하는 API입니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<UserResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(@RequestBody UserRequestDTO.VerifyAuthCodeRequestDTO request) {
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -1,0 +1,19 @@
+package umc.GrowIT.Server.web.dto.ChallengeDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChallengeResponseDTO {
+
+    // 챌린지 삭제 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteChallengeResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 챌린지 삭제가 완료되었습니다
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/HomeDTO/HomeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/HomeDTO/HomeResponseDTO.java
@@ -1,0 +1,23 @@
+package umc.GrowIT.Server.web.dto.HomeDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class HomeResponseDTO {
+
+    // 홈 화면 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetHomeResponseDTO {
+        private Integer credit; // 보유 크레딧
+        private Long itemId;    // 착용 중인 아이템 ID
+
+        // TODO 이미지 처리 방식 확정되면 이후 수정 필요
+        private String itemImage; // 착용 중인 아이템 이미지
+        private String groImage; // 그로 이미지
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
@@ -46,4 +46,14 @@ public class ItemResponseDTO {
         @Schema(description = "구매 여부", example = "false")
         boolean purchased;
     }
+
+    // 아이템 주문 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OrderItemResponseDTO {
+        private Long itemId;    // 구매한 아이템 ID
+        private String itemName; // 구매한 아이템 이름
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
@@ -1,0 +1,46 @@
+package umc.GrowIT.Server.web.dto.UserDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserRequestDTO {
+
+    // 이메일 인증 전송 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SendAuthEmailRequestDTO {
+        private String email; // 인증번호 받을 이메일
+    }
+
+    // 인증 코드 확인 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VerifyAuthCodeRequestDTO {
+        private String authCode; // 인증 번호
+    }
+
+    // 비밀번호 재설정 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResetPasswordRequestDTO {
+        private String newPassword; // 새로운 비밀번호
+        private String confirmPassword; // 비밀번호 확인
+    }
+
+    // 회원 탈퇴 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteUserRequestDTO {
+        private String reason; // 탈퇴 사유
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -1,0 +1,70 @@
+package umc.GrowIT.Server.web.dto.UserDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserResponseDTO {
+
+    // 이메일 인증 전송 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SendAuthEmailResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 인증 이메일이 발송되었습니다
+    }
+
+    // 인증 코드 확인 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VerifyAuthCodeResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 인증이 완료되었습니다, 인증번호가 올바르지 않습니다
+    }
+
+    // 비밀번호 재설정 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ResetPasswordResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 비밀번호 변경이 완료되었습니다
+    }
+
+    // 회원 탈퇴 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteUserResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 회원 탈퇴가 완료되었습니다
+    }
+
+    // 보유 중인 아이템 조회 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetOwnedItemsResponseDTO {
+        private List<ItemDTO> items;  // 아이템 목록
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ItemDTO {
+            private Long itemId;    // 아이템 ID
+            private String itemName; // 아이템 이름
+            private String itemStatus; // 아이템 상태 (착용 여부)
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 아이템 구매/설정 API
> - 보유 중인 아이템 조회
> - 인증 메일 전송
> - 인증 번호 확인
> - 비밀번호 재설정
> - 회원 탈퇴
> - 아이템 구매
> - 홈 화면
> - 챌린지 삭제


## 🔍 테스트 방법
> 1. 다른 이슈에서의 작업으로 인해 application.yml 업데이트 필요
> 2. http://localhost:8080/swagger-ui/index.html 접속
> <img width="1001" alt="image" src="https://github.com/user-attachments/assets/156810c1-b4a2-4a29-ae05-8225f5aa2b52" />