### PR TITLE
[#33] Feat: 챌린지 현황 조회(완료/미완료) API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -1,7 +1,7 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Challenge;
-import umc.GrowIT.Server.repository.ChallengeRepository;
+import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.util.List;
@@ -27,8 +27,8 @@ public class ChallengeConverter {
     }
 
     // 챌린지 리포트를 ChallengeHome.ChallengeReport로 변환
-    public static ChallengeResponseDTO.ChallengeReport toChallengeReportDTO(int totalCredits, int totalDiaries, String userDate) {
-        return ChallengeResponseDTO.ChallengeReport.builder()
+    public static ChallengeResponseDTO.ChallengeReportDTO toChallengeReportDTO(int totalCredits, int totalDiaries, String userDate) {
+        return ChallengeResponseDTO.ChallengeReportDTO.builder()
                 .totalCredits(totalCredits)
                 .totalDiaries(totalDiaries)
                 .userDate(userDate)
@@ -45,5 +45,18 @@ public class ChallengeConverter {
                 .recommendedChallenges(toRecommendedChallengeListDTO(recommendedChallenges, completedChallengeIds))
                 .challengeReport(toChallengeReportDTO(totalCredits, totalDiaries, diaryGoal))
                 .build();
+    }
+
+    // 챌린지 현황
+    public static List<ChallengeResponseDTO.ChallengeStatusDTO> toChallengeStatusListDTO(List<Challenge> challenges) {
+        return challenges.stream()
+                .map(challenge -> ChallengeResponseDTO.ChallengeStatusDTO.builder()
+                        .id(challenge.getId())
+                        .title(challenge.getTitle())
+                        .time(challenge.getTime())
+                        //.status(challenge.getStatus()) // 상태
+                        .completed(challenge.isCompleted()) // 완료 여부
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/Challenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Challenge.java
@@ -35,7 +35,6 @@ public class Challenge extends BaseEntity {
     private ChallengeType dtype;
 
     @Column(nullable = false)
-    @ColumnDefault("false")
     private boolean completed;
 
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -62,5 +61,9 @@ public class Challenge extends BaseEntity {
             throw new IllegalStateException("이미 완료된 챌린지입니다.");
         }
         this.completed = true;
+    }
+
+    public String getStatus() {
+        return "";
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/enums/ChallengeType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/ChallengeType.java
@@ -1,5 +1,5 @@
 package umc.GrowIT.Server.domain.enums;
 
 public enum ChallengeType {
-    TOTAL, COMPLETE, RANDOM, DAILY
+    RANDOM, DAILY
 }

--- a/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.Challenge;
 
 import java.time.LocalDate;
@@ -34,5 +35,16 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     // 사용자 가입날짜 조회
     @Query("SELECT u.createdAt FROM User u WHERE u.id = :userId")
     Optional<LocalDate> findJoinDateByUserId(Long userId);
+
+
+    // 챌린지 상태 및 완료 여부에 따라 챌린지 목록 조회
+    @Query("SELECT uc.challenge FROM UserChallenge uc WHERE uc.user.id = :userId " +
+            "AND (:completed IS NULL OR uc.completed = :completed)")
+    List<Challenge> findChallengesByStatusAndCompletion(@Param("userId") Long userId, @Param("completed") Boolean completed);
+
+
+
+
+
 
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.service.ChallengeService;
 
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.util.List;
@@ -10,4 +11,5 @@ public interface ChallengeQueryService {
     int getTotalDiaries(Long userId);
     String getUserDate(Long userId);
     ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId);
+    ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, Boolean completed);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.converter.ChallengeConverter;
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 import umc.GrowIT.Server.repository.ChallengeRepository;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
@@ -53,4 +54,16 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
                 getUserDate(userId)
         );
     }
+
+    @Override
+    public ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, Boolean completed) {
+        // 유저 ID와 완료 여부를 기반으로 챌린지를 조회
+        List<Challenge> challenges = challengeRepository.findChallengesByStatusAndCompletion(userId, completed);
+
+        // 조회된 챌린지 리스트를 DTO로 변환하여 반환
+        return ChallengeResponseDTO.ChallengeStatusListDTO.builder()
+                .challenges(ChallengeConverter.toChallengeStatusListDTO(challenges))
+                .build();
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeRestController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeRestController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.converter.ChallengeConverter;
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeCommandService;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
@@ -45,10 +46,17 @@ public class ChallengeRestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 현황 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
     })
-    public ApiResponse<ChallengeResponseDTO.ChallengeStatusList> getChallengeStatus(@RequestParam(required = false) String status,
-                                                                                    @RequestParam(required = false) Boolean completed) {
-        return null;
+    public ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
+            @RequestParam Long userId,
+            @RequestParam(required = false) Boolean completed) {
+        // 서비스 호출
+        ChallengeResponseDTO.ChallengeStatusListDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, completed);
+
+        // 성공 응답 반환
+        return ApiResponse.onSuccess(challengeStatusList);
     }
+
+
 
     @PostMapping("/{challengeId}/select")
     @Operation(summary = "선택된 챌린지 저장 API", description = "사용자가 선택한 챌린지를 저장합니다.")
@@ -77,7 +85,7 @@ public class ChallengeRestController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 인증 내용 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
     })
-    public ApiResponse<ChallengeResponseDTO.ProofDetails> getChallengeProofDetails(@PathVariable Long challengeId) {
+    public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long challengeId) {
         return null;
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.GrowIT.Server.domain.ChallengeKeyword;
+import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,7 +18,7 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class ChallengeHomeDTO {
         private List<RecommendedChallengeDTO> recommendedChallenges; // 오늘의 챌린지 추천
-        private ChallengeReport challengeReport; // 챌린지 리포트
+        private ChallengeReportDTO challengeReport; // 챌린지 리포트
     }
 
     // 챌린지 추천
@@ -37,7 +38,7 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChallengeReport {
+    public static class ChallengeReportDTO {
         private int totalCredits;
         private int totalDiaries;
         private String userDate;
@@ -48,10 +49,10 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChallengeSummary {
+    public static class ChallengeSummaryDTO {
         private Long id;
         private String title;
-        private String status;
+        //private String status;
         private boolean completed;
     }
 
@@ -60,18 +61,19 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChallengeStatusList {
-        private List<ChallengeStatus> challenges;
+    public static class ChallengeStatusListDTO {
+        private List<ChallengeResponseDTO.ChallengeStatusDTO> challenges;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChallengeStatus {
+    public static class ChallengeStatusDTO {
         private Long id;
         private String title;
-        private String status;
+        //private String status;
+        private Integer time;
         private boolean completed;
     }
 
@@ -80,7 +82,7 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ProofDetails {
+    public static class ProofDetailsDTO {
         private Long challengeId;
         private String certificationImage;
         private String thoughts;


### PR DESCRIPTION
## 📝 작업 내용
>
- [x] 챌린지 현황 조회(완료/미완료)
(랜덤 챌린지, 데일리 챌린지 조회 API 곧 개발하겠습니다!)


## 👩‍🏫 설명
> 챌린지 현황을 조회하는 API입니다. 먼저 스웨거에서 회원가입 후 Authorize에서 토큰 적용하셔야 합니다. 챌린지 테이블에 테스트 값들 넣어놨습니다. (챌린지 추천 기능은 API 또는 DB에 저장하는 식으로 구현할 예정)
completed에 true 값을 주면 완료한 챌린지가 조회되어야 하고, false 값을 주면 미완료한 챌린지가 조회되어야 정상입니다. 궁금하신 점 있으시면 커멘트 남겨주세요!!

completed가 테이블에서 bit형으로 선언되어있는데 completed가 0이면 false(미완료), completed가 1이면 true(완료)입니다. DB에 insert하실 때 참고해주세요!
(boolean형이 아닌 enum 등을 사용하여 수정해볼 예정 -> 아이디어 있으시면 답변 부탁드립니더..)



## 🔍 테스트 방법
> 1. userId를 입력하고 completed에 아무런 값을 주지 않으면 전체 챌린지 조회
![image](https://github.com/user-attachments/assets/d0607427-f183-4b51-b37f-bda2afefab3c)
    2. userId를 입력하고 completed에 true 값을 주면 완료한 챌린지 조회
![image](https://github.com/user-attachments/assets/abbf5593-08f7-460f-80a8-e576a65fdfc0)
    3. userId를 입력하고 completed에 false 값을 주면 미완료한 챌린지 조회
![image](https://github.com/user-attachments/assets/ca40ae76-67be-4516-b208-10476f586974)
