### PR TITLE
[#38] Feat: 챌린지 현황(랜덤, 데일리) 조회 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -54,7 +54,7 @@ public class ChallengeConverter {
                         .id(challenge.getId())
                         .title(challenge.getTitle())
                         .time(challenge.getTime())
-                        //.status(challenge.getStatus()) // 상태
+                        .status(challenge.getStatus()) // 상태
                         .completed(challenge.isCompleted()) // 완료 여부
                         .build())
                 .collect(Collectors.toList());

--- a/src/main/java/umc/GrowIT/Server/domain/Challenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Challenge.java
@@ -31,7 +31,6 @@ public class Challenge extends BaseEntity {
     private Integer time;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private ChallengeType dtype;
 
     @Column(nullable = false)
@@ -64,6 +63,12 @@ public class Challenge extends BaseEntity {
     }
 
     public String getStatus() {
-        return "";
+        if (this.dtype != null) {
+            return this.dtype.name(); // dtype 값 반환 (RANDOM, DAILY)
+        }
+        if (this.completed) {
+            return "COMPLETED"; // completed가 true인 경우
+        }
+        return "TOTAL"; // completed가 false인 경우
     }
 }

--- a/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.enums.ChallengeType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -39,8 +40,9 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     // 챌린지 상태 및 완료 여부에 따라 챌린지 목록 조회
     @Query("SELECT uc.challenge FROM UserChallenge uc WHERE uc.user.id = :userId " +
-            "AND (:completed IS NULL OR uc.completed = :completed)")
-    List<Challenge> findChallengesByStatusAndCompletion(@Param("userId") Long userId, @Param("completed") Boolean completed);
+            "AND (:completed IS NULL OR uc.completed = :completed)" +
+            "AND (:status IS NULL OR uc.challenge.dtype = :status)")
+    List<Challenge> findChallengesByStatusAndCompletion(@Param("userId") Long userId, @Param("status") ChallengeType challengeType, @Param("completed") Boolean completed);
 
 
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.service.ChallengeService;
 
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.enums.ChallengeStatus;
+import umc.GrowIT.Server.domain.enums.ChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.util.List;
@@ -11,5 +12,5 @@ public interface ChallengeQueryService {
     int getTotalDiaries(Long userId);
     String getUserDate(Long userId);
     ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId);
-    ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, Boolean completed);
+    ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, ChallengeType status, Boolean completed);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.converter.ChallengeConverter;
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.enums.ChallengeStatus;
+import umc.GrowIT.Server.domain.enums.ChallengeType;
 import umc.GrowIT.Server.repository.ChallengeRepository;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
@@ -56,9 +57,9 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     }
 
     @Override
-    public ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, Boolean completed) {
+    public ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, ChallengeType status, Boolean completed) {
         // 유저 ID와 완료 여부를 기반으로 챌린지를 조회
-        List<Challenge> challenges = challengeRepository.findChallengesByStatusAndCompletion(userId, completed);
+        List<Challenge> challenges = challengeRepository.findChallengesByStatusAndCompletion(userId, status, completed);
 
         // 조회된 챌린지 리스트를 DTO로 변환하여 반환
         return ChallengeResponseDTO.ChallengeStatusListDTO.builder()

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.domain.enums.ChallengeType;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,9 +42,10 @@ public class ChallengeController {
     })
     public ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
             @RequestParam Long userId,
+            @RequestParam(required = false) ChallengeType status,
             @RequestParam(required = false) Boolean completed) {
         // 서비스 호출
-        ChallengeResponseDTO.ChallengeStatusListDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, completed);
+        ChallengeResponseDTO.ChallengeStatusListDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, status, completed);
 
         // 성공 응답 반환
         return ApiResponse.onSuccess(challengeStatusList);

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -52,7 +52,7 @@ public class ChallengeResponseDTO {
     public static class ChallengeSummaryDTO {
         private Long id;
         private String title;
-        //private String status;
+        private String status;
         private boolean completed;
     }
 
@@ -72,7 +72,7 @@ public class ChallengeResponseDTO {
     public static class ChallengeStatusDTO {
         private Long id;
         private String title;
-        //private String status;
+        private String status;
         private Integer time;
         private boolean completed;
     }


### PR DESCRIPTION
## 📝 작업 내용
> 챌린지 현황 중 랜덤챌린지와 데일리챌린지를 조회하는 API입니다.
챌린지를 조회하면 status값이 출력되는데, 화면설계서를 보면 "전체" 카테고리가 미완료 챌린지를 의미하기 때문에 미완료 챌린지를 조회하면 status="TOTAL"이라고 뜨고 완료 챌린지를 조회하면 status="COMPLETED"이라고 뜹니다.
- 미완료 챌린지 중 랜덤챌린지와 데일리챌린지는 status 값이 각각 RANDOM, DAILY로 출력됩니다.
- DB에 챌린지 값이 있어야 스웨거에서 테스트 가능(미완료, 완료, 랜덤, 데일리 모두 추가해야 테스트하기 굿굿)
- 저는 로컬호스트에서 테스트했지만 **RDS에서 테스트하려면 현재 Challenge 테이블에 dtype 값이 잘못 들어가있어서
   yml파일에서 테이블 생성하고 DB에 값 insert하고 테스트 해야할겁니다!**
- (예시) Challenge 테이블
![image](https://github.com/user-attachments/assets/abfc8d2a-19a6-4ed4-a026-0303e65aed19)
- (예시) UserChallenge 테이블
![image](https://github.com/user-attachments/assets/c79781a2-a8bb-429c-a5ba-7c181750a4cd)

## 🚨 테이블 수정 사항
ChallengeType 값을 RANDOM, DAILY로 수정하였으며 Challenge 엔티티의
@Enumerated(EnumType.STRING)
    private ChallengeType dtype;
코드에서@Column(nullable = false)
코드를 삭제하였습니다.    -> (결과) Challenge 테이블 dtype가 not null에서 null로 변경됨.
(dtype 값이 2가지이며, 카테고리는 총 4개이기 때문에 dtype 값을 줄 필요 없이 completed에 0 또는 1을 주면 미완료챌린지와 완료챌린지를 구분할 수 있게 구현함.)
텍스트로 설명하려니까 어렵네요 ㅜ 궁금하신 점 커멘트 남겨주세요~!


## 🔍 테스트 방법
(* 4번, 5번은 테스트할 때 completed 값을 true로 주게되면 code200은 뜨지만 정상적으로 조회되지 않습니다! completed 값을 주지 않거나 false로 줘야 정상적으로 조회됩니다 참고해주세요~)
> 1. 전체 챌린지 조회
![image](https://github.com/user-attachments/assets/5a3751af-e126-43f5-b488-6278778fcec0)
    2. 완료한 챌린지 조회
![image](https://github.com/user-attachments/assets/2fc53a39-d055-4ba4-a932-d05ee98a0acd)
    3. 미완료한 챌린지 조회
![image](https://github.com/user-attachments/assets/1b12c4e8-b2c4-43b7-9614-15bc71fec0e3)
    4. 랜덤챌린지 조회
![image](https://github.com/user-attachments/assets/623019b3-bbbb-4324-b810-c646247469a6)
    5. 데일리챌린지 조회
![image](https://github.com/user-attachments/assets/feb39a15-cf49-46c6-bacb-025aae5232e8)
