### PR TITLE
[#41] Bug : 회원가입 API Refresh token

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
@@ -1,16 +1,18 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.RefreshToken;
+import umc.GrowIT.Server.domain.User;
 
 import java.time.LocalDateTime;
 
 public class TokenConverter {
 
-    public static RefreshToken toRefreshToken(String refreshToken, LocalDateTime expiryDate) {
+    public static RefreshToken toRefreshToken(String refreshToken, LocalDateTime expiryDate, User user) {
 
         return RefreshToken.builder()
                 .refreshToken(refreshToken)
                 .expiryDate(expiryDate)
+                .user(user)
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
+++ b/src/main/java/umc/GrowIT/Server/domain/RefreshToken.java
@@ -23,4 +23,7 @@ public class RefreshToken extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime expiryDate;
+
+    @OneToOne(mappedBy = "refreshToken")
+    private User user;
 }

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -55,6 +55,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Diary> diaries;
 
+    @Setter
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "refresh_token_id", nullable = true)
     private RefreshToken refreshToken;

--- a/src/main/java/umc/GrowIT/Server/service/refreshToken/RefreshTokenCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshToken/RefreshTokenCommandService.java
@@ -1,8 +1,9 @@
 package umc.GrowIT.Server.service.refreshToken;
 
+import umc.GrowIT.Server.domain.RefreshToken;
+import umc.GrowIT.Server.domain.User;
+
 public interface RefreshTokenCommandService {
-
-    void createRefreshToken(String refreshToken);
-
+    RefreshToken createRefreshToken(String refreshToken, User user);
 
 }

--- a/src/main/java/umc/GrowIT/Server/service/refreshToken/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshToken/RefreshTokenCommandServiceImpl.java
@@ -1,11 +1,13 @@
-package umc.GrowIT.Server.service.refreshToken;
+package umc.GrowIT.Server.service.refreshTokenService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.converter.TokenConverter;
 import umc.GrowIT.Server.domain.RefreshToken;
+import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.jwt.JwtTokenProvider;
 import umc.GrowIT.Server.repository.RefreshTokenRepository;
+import umc.GrowIT.Server.service.refreshToken.RefreshTokenCommandService;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -19,13 +21,13 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public void createRefreshToken(String refreshToken) {
+    public RefreshToken createRefreshToken(String refreshToken, User user) {
         Date expiryDate = jwtTokenProvider.parseClaims(refreshToken).getExpiration();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(expiryDate.toInstant(), ZoneId.systemDefault());
 
-        RefreshToken refreshTokenEntity = TokenConverter.toRefreshToken(refreshToken, localDateTime);
+        RefreshToken refreshTokenEntity = TokenConverter.toRefreshToken(refreshToken, localDateTime, user);
 
-        refreshTokenRepository.save(refreshTokenEntity);
+        return refreshTokenRepository.save(refreshTokenEntity);
     }
 
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
@@ -15,6 +15,7 @@ import umc.GrowIT.Server.apiPayload.exception.TermHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.TermConverter;
 import umc.GrowIT.Server.converter.UserConverter;
+import umc.GrowIT.Server.domain.RefreshToken;
 import umc.GrowIT.Server.domain.Term;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserTerm;
@@ -86,10 +87,12 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .collect(Collectors.toList());
 
         newUser.setUserTerms(userTerms);
-        userRepository.save(newUser);
 
         UserResponseDTO.TokenDTO tokenDTO = jwtTokenProvider.generateToken(getAuthentication(newUser)); //JWT 토큰 생성 메소드 호출
-        refreshTokenCommandService.createRefreshToken(tokenDTO.getRefreshToken()); //RefreshToken DB 저장
+        RefreshToken refreshToken = refreshTokenCommandService.createRefreshToken(tokenDTO.getRefreshToken(), newUser); //RefreshToken DB 저장
+
+        newUser.setRefreshToken(refreshToken);
+        userRepository.save(newUser);
 
         return tokenDTO;
     }


### PR DESCRIPTION
## 📝 작업 내용
- user, refresh token 이 현재 1:1 관계, user가 연관관계 주인으로 설정한 상황입니다.
- 회원가입 API 에서 회원 email, name, password, userTerms 데이터 넣고 요청했을 때
user 테이블에 refresh token id 값(외래키)이 들어가지 않는 것을 확인 후 수정했습니다.


## 🔍 테스트 방법
1. 스웨거에서 회원가입 요청
<img width="1149" alt="스크린샷 2025-01-16 오후 1 13 24" src="https://github.com/user-attachments/assets/fa2ddd26-4be1-42b0-8c3e-1dafee972586" />

2. DB에 refresh token id (외래키) 들어가는지 확인
<img width="1204" alt="스크린샷 2025-01-16 오후 1 15 24" src="https://github.com/user-attachments/assets/558b6d94-8c4a-4f0a-861d-19078a5b4e8d" />
