### PR TITLE
[#51] Feat: 회원가입 API 이메일 인증 확인

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
@@ -48,6 +48,10 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     @Transactional
     public UserResponseDTO.TokenDTO createUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
+        //인증 받지 않았을 때 예외 처리
+        if (userInfoDTO.getIsVerified() == null || !userInfoDTO.getIsVerified())
+            throw new UserHandler(ErrorStatus.EMAIL_NOT_VERIFIED);
+
         String email = userInfoDTO.getEmail();
         Optional<User> user = userRepository.findByEmail(email);
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
@@ -20,6 +20,7 @@ public class UserRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UserInfoDTO {
+        private Boolean isVerified;
 
         @NotBlank(message = "필수 입력 항목입니다.")
         @Email(message = "이메일 형식에 맞춰주세요.")


### PR DESCRIPTION
## 📝 작업 내용
이메일 회원가입 할 때 이메일 인증을 먼저 했는지 확인하는 코드 추가했습니다.
- 프론트에서 요청을 보낼 때 이메일 인증 여부를 보내게 됩니다.
- 회원가입 API 호출 시 이메일 인증 여부에 따라 인증 확인이 됐을 때 회원 정보를 등록하게 됩니다. 이메일 인증 확인이 되지 않았을 때 예외처리를 했습니다.


## 🔍 테스트 방법
1. 회원가입 시 isVerified 에 false 값을 주면
<img width="1161" alt="스크린샷 2025-01-18 오전 1 45 03" src="https://github.com/user-attachments/assets/02e91f51-3f58-45f9-98fd-66189ca5b5b7" />
2. 회원 등록에 실패합니다.
<img width="1158" alt="스크린샷 2025-01-18 오전 1 45 10" src="https://github.com/user-attachments/assets/abff032c-4d24-4f69-9da7-1a92a503b4b2" />

