### PR TITLE
[#56] Feat: 일기 작성 날짜 조회 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -1,0 +1,27 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DiaryConverter {
+    public static DiaryResponseDTO.DiaryDateDTO toDiaryDateDTO(Diary diary){
+        return DiaryResponseDTO.DiaryDateDTO.builder()
+                .diaryId(diary.getId())
+                .date(diary.getCreatedAt())
+                .build();
+    }
+
+    public static DiaryResponseDTO.DiaryDateListDTO toDiaryDateListDTO(List<Diary> diaryList){
+
+        List<DiaryResponseDTO.DiaryDateDTO> diaryDateDTOList = diaryList.stream()
+                .map(DiaryConverter::toDiaryDateDTO).collect(Collectors.toList());
+
+        return DiaryResponseDTO.DiaryDateListDTO.builder()
+                .diaryDateList(diaryDateDTOList)
+                .listSize(diaryDateDTOList.size())
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.repository.diaryRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
+
+import java.util.List;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
+    List<Diary> findByUserIdAndYearAndMonth(@Param("userId") Long userId,
+                                            @Param("year") Integer year,
+                                            @Param("month") Integer month);
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.service.diaryService;
+
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+
+public interface DiaryQueryService {
+    public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId);
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package umc.GrowIT.Server.service.diaryService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.converter.DiaryConverter;
+import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
+import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryQueryServiceImpl implements DiaryQueryService{
+
+    private final DiaryRepository diaryRepository;
+    @Override
+    public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId) {
+        // Diary 리스트를 year와 month를 기준으로 필터링
+        List<Diary> diaryList = diaryRepository.findByUserIdAndYearAndMonth(userId, year, month);
+
+
+        return DiaryConverter.toDiaryDateListDTO(diaryList);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.service.diaryService.DiaryQueryService;
 import umc.GrowIT.Server.web.controller.specification.DiarySpecification;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -17,10 +18,13 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 @RequiredArgsConstructor
 @RequestMapping("/diaries")
 public class DiaryController implements DiarySpecification {
+    private final DiaryQueryService diaryQueryService;
     @GetMapping("/dates")
     public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month){
+        //userId는 임시로 1
+        Long userId = 1L;
 
-        return null;
+        return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("/")
     public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month){


### PR DESCRIPTION
## 📝 작업 내용
> 아래의 화면에서 사용할 YY년MM월에 작성한 일기의 날짜들을 조회하는 API를 구현하였습니다.
<img width="244" alt="image" src="https://github.com/user-attachments/assets/d2d4d5f8-9b8c-4c0b-bf07-6a49f2bc33e8" />



## 🔍 테스트 방법
> 1. 아래의 SQL문으로 데이터 삽입
```
insert into diary(id, created_at, updated_at, content, user_id) values
	(1, '2025-1-16 22:13:00', '2025-1-16 22:13:00', '유저1의 1월 첫번째 일기', 1),
    (2, '2025-1-17 22:13:00', '2025-1-17 22:13:00', '유저1의 1월 두번째 일기', 1),
    (3, '2025-1-18 22:13:00', '2025-1-18 22:13:00', '유저1의 1월 세번째 일기', 1),
    (4, '2025-1-18 22:13:00', '2025-1-18 22:13:00', '유저2의 1월 첫번째 일기', 2),
    (5, '2024-12-31 22:13:00', '2024-12-31 22:13:00', '유저 1의 12월 첫번째 일기', 1);

insert into user(id,created_at, updated_at, current_credit, email, name, password) values
	(1, NOW(), NOW(), 0, 'email', '유저1', 'pw'),
    (2, NOW(), NOW(), 0, 'email2', '유저2', 'pw');
```
-  유저의 정보는 임시로 userId를 1을 받도록 구현해놓았습니다.

> 2. 프로그램 실행 후 year와 month 입력 후 결과 확인

2-1. 2023년 1월 조회 결과 없음
<img width="849" alt="image" src="https://github.com/user-attachments/assets/f1523264-91b2-4fc8-877b-bfca0747c033" />
2-2. 2024년 12월 조회 결과
<img width="852" alt="image" src="https://github.com/user-attachments/assets/392347c7-d89d-48ce-a933-972d1e57fdc6" />
2-3. 2025년 1월 조회 결과
<img width="797" alt="image" src="https://github.com/user-attachments/assets/9c0f0111-d954-4272-b43f-179d9912b162" />

