### PR TITLE
[#49] Feat: 챌린지 삭제 API 개발

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다."),
     USER_STATUS_INACTIVE(HttpStatus.UNAUTHORIZED, "USER4004", "탈퇴한 회원입니다."),
 
+    //사용자 챌린지 관련 에러
+    USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC4001", "사용자 챌린지가 존재하지 않습니다"),
+    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC4002", "완료된 챌린지는 삭제가 불가합니다"),
+
     //약관 관련 에러
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),
     MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 약관에 반드시 동의해야 합니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/ChallengeHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/ChallengeHandler.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class ChallengeHandler extends GeneralException {
+    public ChallengeHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.ChallengeStatus;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
@@ -58,5 +59,13 @@ public class ChallengeConverter {
                         .completed(challenge.isCompleted()) // 완료 여부
                         .build())
                 .collect(Collectors.toList());
+    }
+
+
+    public static ChallengeResponseDTO.DeleteChallengeResponseDTO toDeletedUserChallenge(UserChallenge userChallenge) {
+        return ChallengeResponseDTO.DeleteChallengeResponseDTO.builder()
+                .id(userChallenge.getId())
+                .message("챌린지를 삭제했어요")
+                .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.UserChallenge;
+
+import java.util.Optional;
+
+public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
+    Optional<UserChallenge> findByIdAndUserId (Long userChallengeId, Long userId);
+}

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -1,5 +1,9 @@
 package umc.GrowIT.Server.service.ChallengeService;
 
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+
 public interface ChallengeCommandService {
     void markChallengeAsCompleted(Long userId, Long challengeId);
+
+    ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -1,15 +1,23 @@
 package umc.GrowIT.Server.service.ChallengeService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.ChallengeHandler;
+import umc.GrowIT.Server.converter.ChallengeConverter;
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.repository.ChallengeRepository;
+import umc.GrowIT.Server.repository.UserChallengeRepository;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 @Service
 @RequiredArgsConstructor
 public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
     private final ChallengeRepository challengeRepository;
+    private final UserChallengeRepository userChallengeRepository;
 
     @Override
     public void markChallengeAsCompleted(Long userId, Long challengeId) {
@@ -21,5 +29,24 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         // 변경된 챌린지 저장
         challengeRepository.save(challenge);
+    }
+
+    @Override
+    public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId) {
+
+        // 1. userId와 userChallengeId를 통해 조회하고 없으면 오류
+        UserChallenge userChallenge = userChallengeRepository.findByIdAndUserId(userChallengeId, userId)
+                .orElseThrow(() -> new ChallengeHandler(ErrorStatus.USER_CHALLENGE_NOT_FOUND));
+
+        // 2. 진행 중(false)인 챌린지인지 체크, 완료(true)한 챌린지면 오류
+        if(userChallenge.isCompleted()) {
+            throw new ChallengeHandler(ErrorStatus.USER_CHALLENGE_COMPLETE);
+        }
+
+        // 3. 삭제
+        userChallengeRepository.deleteById(userChallengeId);
+
+        // 4. converter 작업
+        return ChallengeConverter.toDeletedUserChallenge(userChallenge);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -1,16 +1,13 @@
 package umc.GrowIT.Server.web.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ChallengeType;
+import umc.GrowIT.Server.service.ChallengeService.ChallengeCommandService;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
+import umc.GrowIT.Server.web.controller.specification.ChallengeSpecification;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,24 +19,17 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/challenges")
-public class ChallengeController {
+public class ChallengeController implements ChallengeSpecification {
+
     private final ChallengeQueryService challengeQueryService;
+    private final ChallengeCommandService challengeCommandService;
+
     @GetMapping("/summary")
-    @Operation(summary = "챌린지 홈 조회 API", description = "사용자의 챌린지 홈 화면에 보여질 챌린지 요약 정보를 조회하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 홈 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@RequestParam Long userId) {
         return ApiResponse.onSuccess(challengeQueryService.getChallengeHome(userId));
     }
 
     @GetMapping
-    @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 현황 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
             @RequestParam Long userId,
             @RequestParam(required = false) ChallengeType status,
@@ -51,60 +41,34 @@ public class ChallengeController {
         return ApiResponse.onSuccess(challengeStatusList);
     }
 
-
-
     @PostMapping("/{challengeId}/select")
-    @Operation(summary = "선택된 챌린지 저장 API", description = "사용자가 선택한 챌린지를 저장합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 저장 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO> selectChallenge(@PathVariable Long challengeId) {
         return null;
     }
 
     @PostMapping("/{challengeId}/prove")
-    @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 인증 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO> createChallengeProof(@PathVariable Long challengeId,
                                                                   @RequestBody ChallengeRequestDTO.ProofRequest proofRequest) {
         return null;
     }
 
     @GetMapping("/{challengeId}")
-    @Operation(summary = "챌린지 인증 내용 조회 API", description = "특정 챌린지의 인증 내용을 조회합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 인증 내용 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long challengeId) {
         return null;
     }
 
     @PatchMapping("/{challengeId}")
-    @Operation(summary = "챌린지 인증 수정 API", description = "챌린지 인증을 수정하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 챌린지 인증 수정 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "BAD, 잘못된 요청"),
-    })
     public ApiResponse<ChallengeResponseDTO> updateChallengeProof(@PathVariable Long challengeId,
                                                                   @RequestBody ChallengeRequestDTO.UpdateRequest updateRequest) {
         return null;
     }
 
     @DeleteMapping("{challengeId}")
-    @Operation(
-            summary = "챌린지 삭제 API",
-            description = "특정 챌린지를 삭제하는 API입니다. 챌린지 ID를 path variable로 전달받아 해당 챌린지를 삭제합니다."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    @Parameter(name = "challengeId", description = "삭제할 챌린지의 ID", required = true)
-    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long challengeId) {
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long userChallengeId) {
+        // 임시로 사용자 ID 지정
+        Long userId = 1L;
+
+        ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
+        return ApiResponse.onSuccess(deleteChallenge);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -1,0 +1,87 @@
+package umc.GrowIT.Server.web.controller.specification;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.domain.enums.ChallengeType;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+public interface ChallengeSpecification {
+
+    @GetMapping("/summary")
+    @Operation(summary = "챌린지 홈 조회 API", description = "사용자의 챌린지 홈 화면에 보여질 챌린지 요약 정보를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@RequestParam Long userId);
+
+    @GetMapping
+    @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
+            @RequestParam Long userId,
+            @RequestParam(required = false) ChallengeType status,
+            @RequestParam(required = false) Boolean completed);
+
+
+
+    @PostMapping("/{challengeId}/select")
+    @Operation(summary = "선택된 챌린지 저장 API", description = "사용자가 선택한 챌린지를 저장합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO> selectChallenge(@PathVariable Long challengeId);
+
+    @PostMapping("/{challengeId}/prove")
+    @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO> createChallengeProof(@PathVariable Long challengeId, @RequestBody ChallengeRequestDTO.ProofRequest proofRequest);
+
+    @GetMapping("/{challengeId}")
+    @Operation(summary = "챌린지 인증 내용 조회 API", description = "특정 챌린지의 인증 내용을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long challengeId);
+
+    @PatchMapping("/{challengeId}")
+    @Operation(summary = "챌린지 인증 수정 API", description = "챌린지 인증을 수정하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<ChallengeResponseDTO> updateChallengeProof(@PathVariable Long challengeId, @RequestBody ChallengeRequestDTO.UpdateRequest updateRequest);
+
+    @DeleteMapping("{challengeId}")
+    @Operation(
+            summary = "챌린지 삭제 API",
+            description = "특정 챌린지를 삭제하는 API입니다. 챌린지 ID를 path variable로 전달받아 해당 챌린지를 삭제합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4002", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+
+    })
+    @Parameter(name = "challengeId", description = "삭제할 챌린지의 ID", required = true)
+    ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long challengeId);
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -96,6 +96,7 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class DeleteChallengeResponseDTO {
         // TODO 디테일하게 결정 필요
+        private Long id;
         private String message; // ex) 챌린지 삭제가 완료되었습니다
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 특정 사용자의 특정 챌린지를 삭제하는 API입니다
> (추가적으로 챌린지에도 specification을 적용시켰습니다)


## 🔍 테스트 방법
> 1. RDS user_challenge에 예외를 위한 레코드는 이미 존재합니다
> 정상 작동을 테스트하기 위해서는 아래 쿼리문만 실행하면 됩니다
> ```INSERT INTO `growit-dev-db`.user_challenge (completed, challenge_id, created_at, updated_at, user_id, thoughts, certification_image, status) VALUES (false, 4, null, null, 1, null, null, null)```
> <img width="945" alt="스크린샷 2025-01-18 오후 11 21 27" src="https://github.com/user-attachments/assets/61953898-a3ce-48a9-9462-6e6ecc288d9d" /><br>
>
> 2. 실행 결과
> 
> (a) 사용자의 ID가 잘못된 경우 (현재 임시로 1L로 하드코딩되어 있습니다)
> 사용자 챌린지 6번은 5번 user의 챌린지이기 때문에 오류가 발생합니다
> <img src="https://github.com/user-attachments/assets/1dc1460e-c85b-4bb7-b4fd-f45471587b19" alt="image">
> (b) 완료된 챌린지를 삭제하려는 경우
> 미완료한 챌린지만 삭제가 가능한 것으로 알고 있습니다. 프론트엔드에서 값이 잘못 전달되는 경우가 없겠지만, 혹시나하여 챌린지의 진행 상태를 체크하고 오류 발생하도록 하였습니다.
> <img src="https://github.com/user-attachments/assets/24d738da-1a8a-4561-a4db-57708e5d44cf">
> (c) 일반적인 경우
> response로 무엇을 주어야 할 지 확실하지 않아, 삭제된 챌린지의 ID와 message를 전달하였습니다. 추후에 확실해지면 변경하는 것을 생각 중입니다.
> <img src="https://github.com/user-attachments/assets/f922fe28-4874-4e55-8f2b-67231d80ec4d">


