### PR TITLE
[#50] Feat: 회원탈퇴 API 개발

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -4,6 +4,7 @@ import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.enums.Role;
 import umc.GrowIT.Server.domain.enums.UserStatus;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 public class UserConverter {
 
@@ -17,5 +18,13 @@ public class UserConverter {
                 .currentCredit(0)
                 .totalCredit(0)
                 .build();
+    }
+
+    public static UserResponseDTO.DeleteUserResponseDTO toDeletedUser(User deleteUser) {
+        return UserResponseDTO.DeleteUserResponseDTO.builder()
+                .name(deleteUser.getName())
+                .message("회원탈퇴가 완료되었어요")
+                .build()
+                ;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -64,4 +64,10 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
+    public void deleteAccount() {
+        if (this.status == UserStatus.ACTIVE) {
+            this.status = UserStatus.INACTIVE;
+        }
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
@@ -11,4 +11,6 @@ public interface UserCommandService {
     UserResponseDTO.TokenDTO emailLogin(UserRequestDTO.EmailLoginDTO emailLoginDTO);
 
     void updatePassword(UserRequestDTO.PasswordDTO passwordDTO);
+
+    UserResponseDTO.DeleteUserResponseDTO delete(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandServiceImpl.java
@@ -167,4 +167,21 @@ public class UserCommandServiceImpl implements UserCommandService {
         );
         return authentication;
     }
+
+    @Override
+    public UserResponseDTO.DeleteUserResponseDTO delete(Long userId) {
+        // 1. userId를 통해 조회하고 없으면 오류
+        User deleteUser = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. soft delete로 진행하기 때문에 status를 inactive로 변경
+        if(deleteUser.getStatus()==UserStatus.INACTIVE) {
+            throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
+        }
+        deleteUser.deleteAccount();
+        userRepository.save(deleteUser);
+
+        // 3. converter 작업
+        return UserConverter.toDeletedUser(deleteUser);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.service.CreditService.CreditQueryServiceImpl;
+import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.web.controller.specification.UserSpecification;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
@@ -28,6 +29,7 @@ import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 public class UserController implements UserSpecification {
 
     private final CreditQueryServiceImpl creditQueryService;
+    private final UserCommandService userCommandService;
 
     @Override
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(ItemCategory category) {
@@ -52,8 +54,13 @@ public class UserController implements UserSpecification {
     }
 
     @Override
-    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser(UserRequestDTO.DeleteUserRequestDTO request) {
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser() {
+        // 임시로 사용자 ID 지정
+        Long userId = 16L;
+
+        UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
+
+        return ApiResponse.onSuccess(deleteUser);
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -59,9 +59,10 @@ public interface UserSpecification {
     @PatchMapping("")
     @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser(@RequestBody UserRequestDTO.DeleteUserRequestDTO request);
+    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
 
     @PostMapping("/email")
     @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API입니다.")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -60,6 +60,8 @@ public interface UserSpecification {
     @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
@@ -85,14 +85,4 @@ public class UserRequestDTO {
     public static class VerifyAuthCodeRequestDTO {
         private String authCode; // 인증 번호
     }
-
-    // 회원 탈퇴 요청 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class DeleteUserRequestDTO {
-        private String reason; // 탈퇴 사유
-    }
-
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -45,6 +45,7 @@ public class UserResponseDTO {
     @AllArgsConstructor
     public static class DeleteUserResponseDTO {
         // TODO 디테일하게 결정 필요
+        private String name;
         private String message; // ex) 회원 탈퇴가 완료되었습니다
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> soft delete로 회원탈퇴 API를 만들었습니다
> - RequestDTO 삭제
> 피그마를 살펴보면 회원탈퇴 UI가 없으며 회원탈퇴는 우선도가 낮을 것이라 생각하여 기존에 생성해 두었던 탈퇴사유를 적는 RequsetDTO를 삭제하였습니다
> - 에러코드와 핸들러는 기존에 구현되어있는 것을 재사용하였으며, 이외 회원탈퇴와 관련하여 controller, service, converter 부분의 코드를 작성하였습니다


## 🔍 테스트 방법
> 1. 탈퇴 테스트만을 위한 레코드를 RDS에 추가하였습니다
> (Datagrip UI로는 넣어졌는데 쿼리문으로 해보니 오류가 있어 UserId 16인 레코드 ACTIVE로 변경하여서 테스트하면 될 거 같습니다)
> 2. 실행 결과
>
> (a) 일반적인 경우
> 사용자 ID는 위의 쿼리문으로 생성된 ID로 임시 하드코딩되어 있습니다. 필요한 response형식이 명확하지 않아 탈퇴한 사용자의 name과 message를 전달하도록 하였습니다. 
> ![image](https://github.com/user-attachments/assets/5ad30117-5628-4672-bbbd-c65f738772e2)
> ![image](https://github.com/user-attachments/assets/c86bf48b-ace6-4292-8f21-bbe19af86d8d)
> (b) 탈퇴한 회원의 ID가 전달된 경우
> 이미 탈퇴한 회원인지를 체크하고 오류를 발생시킵니다
> ![image](https://github.com/user-attachments/assets/253ce17c-f125-4861-ab58-9ed41effe2dd)
> (c) 존재하지 않는 회원인 경우
> 임시 하드코딩되어 있는 사용자 ID를 존재하지 않는 ID로 변경시키고 실행시키면 오류가 발생합니다
> ![image](https://github.com/user-attachments/assets/bdbec320-05f5-4d5d-b4c1-58ba23512610)
> ![image](https://github.com/user-attachments/assets/8247a9c8-db84-47cb-b14f-c7da725f357b)

