### PR TITLE
[#62] Feat: 아이템 구매 API 개발

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -40,6 +40,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 아이템 관련 에러
     ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM4001", "아이템을 찾을 수 없습니다."),
     ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM4002", "보유하지 않은 아이템입니다."),
+    ITEM_OWNED(HttpStatus.BAD_REQUEST, "ITEM4003", "이미 보유 중인 아이템입니다."),
 
     //결제관련에러
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT4001", "결제정보가 정확하지 않습니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/ItemHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/ItemHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class ItemHandler extends GeneralException {
+
+    public ItemHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -1,6 +1,9 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
 import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 
@@ -28,5 +31,20 @@ public class ItemConverter {
                         .map(item -> toItemDTO(item, userId, itemRepository))
                         .collect(Collectors.toList()))
                 .build();
+    }
+
+    public static UserItem toUserItem() {
+        return UserItem.builder()
+                .status(ItemStatus.UNEQUIPPED)
+                .build()
+                ;
+    }
+
+    public static ItemResponseDTO.PurchaseItemResponseDTO toPurchaseItemResponseDTO(UserItem userItem) {
+        return ItemResponseDTO.PurchaseItemResponseDTO.builder()
+                .itemId(userItem.getItem().getId())
+                .itemName(userItem.getItem().getName())
+                .build()
+                ;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -70,4 +70,7 @@ public class User extends BaseEntity {
         }
     }
 
+    public void updateCurrentCredit(Integer currentCredit) {
+        this.currentCredit = currentCredit;
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/UserItem.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserItem.java
@@ -27,4 +27,12 @@ public class UserItem extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ItemStatus status;
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
+
+import java.util.Optional;
+
+public interface UserItemRepository extends JpaRepository<UserItem, Long>  {
+}

--- a/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
@@ -1,10 +1,12 @@
 package umc.GrowIT.Server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserItem;
 
 import java.util.Optional;
 
 public interface UserItemRepository extends JpaRepository<UserItem, Long>  {
+    Optional<UserItem> findByUserAndItem(User user, Item item);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandService.java
@@ -1,4 +1,7 @@
 package umc.GrowIT.Server.service.ItemService;
 
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+
 public interface ItemCommandService {
+    ItemResponseDTO.PurchaseItemResponseDTO purchase(Long itemId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
@@ -3,9 +3,54 @@ package umc.GrowIT.Server.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.ItemHandler;
+import umc.GrowIT.Server.converter.ItemConverter;
+import umc.GrowIT.Server.converter.UserConverter;
+import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
+import umc.GrowIT.Server.repository.UserItemRepository;
+import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ItemCommandServiceImpl implements ItemCommandService {
+
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final UserItemRepository userItemRepository;
+
+    @Override
+    public ItemResponseDTO.PurchaseItemResponseDTO purchase(Long itemId, Long userId) {
+        // 1. 사용자 조회하고 없으면 오류
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ItemHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 아이템 조회하고 없으면 오류
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
+
+        // 3. 사용자의 현재 보유 중인 크레딧과 아이템의 가격을 비교
+        // 보유 크레딧 < 아이템 가격 = 오류 발생
+        if(user.getCurrentCredit() < item.getPrice()) {
+            throw new ItemHandler(ErrorStatus.INSUFFICIENT_CREDIT);
+        }
+
+        // 보유 크레딧 >= 아이템 가격 = 아이템 구매
+        // 보유 크레딧 최신화
+        user.updateCurrentCredit(user.getCurrentCredit() - item.getPrice());
+        userRepository.save(user);
+
+        // user_item에 저장
+        UserItem newUserItem = ItemConverter.toUserItem();
+        newUserItem.setUser(user);
+        newUserItem.setItem(item);
+        UserItem savedUserItem = userItemRepository.save(newUserItem);
+
+        // converter 작업
+        return ItemConverter.toPurchaseItemResponseDTO(savedUserItem);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
@@ -33,7 +33,13 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
 
-        // 3. 사용자의 현재 보유 중인 크레딧과 아이템의 가격을 비교
+        // 3. 사용자가 이미 보유 중인 아이템인지 체크
+        userItemRepository.findByUserAndItem(user, item)
+                .ifPresent(ownedItem -> {
+                    throw new ItemHandler(ErrorStatus.ITEM_OWNED);
+                });
+
+        // 4. 사용자의 현재 보유 중인 크레딧과 아이템의 가격을 비교
         // 보유 크레딧 < 아이템 가격 = 오류 발생
         if(user.getCurrentCredit() < item.getPrice()) {
             throw new ItemHandler(ErrorStatus.INSUFFICIENT_CREDIT);

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -1,17 +1,12 @@
 package umc.GrowIT.Server.web.controller;
 
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.service.ItemService.ItemCommandService;
 import umc.GrowIT.Server.service.ItemService.ItemQueryServiceImpl;
 import umc.GrowIT.Server.web.controller.specification.ItemSpecification;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
@@ -24,6 +19,7 @@ import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipResponseDTO;
 public class ItemController implements ItemSpecification {
 
     private final ItemQueryServiceImpl itemQueryServiceImpl;
+    private final ItemCommandService itemCommandService;
 
     @Override
     public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(ItemCategory category) {
@@ -37,7 +33,12 @@ public class ItemController implements ItemSpecification {
     }
 
     @Override
-    public ApiResponse<ItemResponseDTO.OrderItemResponseDTO> orderItem(Long itemId) {
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(Long itemId) {
+        // 임시로 사용자 ID 지정
+        Long userId = 17L;
+
+        ItemResponseDTO.PurchaseItemResponseDTO purchasedItem = itemCommandService.purchase(itemId, userId);
+
+        return ApiResponse.onSuccess(purchasedItem);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
@@ -51,6 +51,7 @@ public interface ItemSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4001", description = "❌ 아이템을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4003", description = "❌ 이미 보유 중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT4002", description = "❌ 보유 크레딧이 부족합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
@@ -45,11 +45,15 @@ public interface ItemSpecification {
 
 
 
-    @PostMapping("/items/{itemId}/order")
+    @PostMapping("/items/{itemId}/purchase")
     @Operation(summary = "아이템 구매 API", description = "특정 아이템을 구매하는 API입니다. 아이템 ID를 path variable로 전달받아 해당 아이템을 주문합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4001", description = "❌ 아이템을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT4002", description = "❌ 보유 크레딧이 부족합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "itemId", description = "주문할 아이템의 ID", required = true)
-    ApiResponse<ItemResponseDTO.OrderItemResponseDTO> orderItem(@PathVariable("itemId") Long itemId);
+    ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(@PathVariable("itemId") Long itemId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.GrowIT.Server.domain.enums.ItemStatus;
 
 import java.util.List;
 
@@ -52,7 +51,7 @@ public class ItemResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class OrderItemResponseDTO {
+    public static class PurchaseItemResponseDTO {
         private Long itemId;    // 구매한 아이템 ID
         private String itemName; // 구매한 아이템 이름
     }


### PR DESCRIPTION
## 📝 작업 내용
> 아이템 구매 API를 개발하였습니다
> - API와 관련한 controller, service, repository, converter 등의 코드를 작성하였습니다
> - 아이템 '구매'이기 때문에 엔드포인트 등을 order에서 purchase로 변경하였습니다


## 🔍 테스트 방법
> 1. 아이템 구매 테스트를 위해 RDS에 UserId 17인 레코드를 추가하였습니다
> current_credit을 변경해가며 테스트하면 됩니다
> ![image](https://github.com/user-attachments/assets/e761b36a-79b8-4edb-a138-6635472a8f71)
> 2. 실행결과
> (a) 일반적인 경우
> 사용자 ID는 하드코딩하였으며, path-variable로 아이템 ID를 넘기면 보유 중인 크레딧과 아이템의 가격을 비교하여 구매를 진행합니다
> ![image](https://github.com/user-attachments/assets/a3cdb7cf-1380-43b5-8cb9-50e1c8838715)
> ![image](https://github.com/user-attachments/assets/89ff1ddd-60c7-4ca7-8ba5-aa6c8c3632f4)
> ![image](https://github.com/user-attachments/assets/c68f31ef-798d-439b-8f5b-32961a634510)
> (b) 보유 중인 아이템을 구매하려는 경우
> ![image](https://github.com/user-attachments/assets/809594b1-ff71-4b45-a63a-aedecf1e590e)
> (c) 크레딧이 부족한 경우
> ![image](https://github.com/user-attachments/assets/d2148dc8-da0f-4f24-8887-05d222147cf4)
> (d) 존재하지 않는 아이템을 구매하려는 경우
> ![image](https://github.com/user-attachments/assets/ecd4bd8f-6c94-4a63-acd2-9e586f86fbed)
> (e) 사용자 ID가 잘못된 경우
> ![image](https://github.com/user-attachments/assets/f00dd30a-2c8d-4ffc-8dd5-73826f63a998)

