### PR TITLE
[#65] Feat: 일기 모아보기 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/DiaryHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/DiaryHandler.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class DiaryHandler extends GeneralException{
+    public DiaryHandler(BaseErrorCode errorcode) {
+        super(errorcode);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -24,4 +24,24 @@ public class DiaryConverter {
                 .listSize(diaryDateDTOList.size())
                 .build();
     }
+
+    public static DiaryResponseDTO.DiaryDTO toDiaryDTO(Diary diary){
+        //일기의 id, 내용, 생성일
+        return DiaryResponseDTO.DiaryDTO.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .date(diary.getCreatedAt())
+                .build();
+    }
+
+    public static DiaryResponseDTO.DiaryListDTO toDiaryListDTO(List<Diary> diaryList){
+
+        List<DiaryResponseDTO.DiaryDTO> diaryDTOList = diaryList.stream()
+                .map(DiaryConverter::toDiaryDTO).collect(Collectors.toList());
+
+        return DiaryResponseDTO.DiaryListDTO.builder()
+                .diaryList(diaryDTOList)
+                .listSize(diaryDTOList.size())
+                .build();
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
@@ -4,4 +4,6 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryQueryService {
     public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId);
+
+    public DiaryResponseDTO.DiaryListDTO getDiaryList(Integer year, Integer month, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -26,4 +26,12 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         return DiaryConverter.toDiaryDateListDTO(diaryList);
     }
+
+    @Override
+    public DiaryResponseDTO.DiaryListDTO getDiaryList(Integer year, Integer month, Long userId) {
+        // Diary 리스트를 year와 month를 기준으로 필터링
+        List<Diary> diaryList = diaryRepository.findByUserIdAndYearAndMonth(userId, year, month);
+
+        return DiaryConverter.toDiaryListDTO(diaryList);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -23,7 +23,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
         // Diary 리스트를 year와 month를 기준으로 필터링
         List<Diary> diaryList = diaryRepository.findByUserIdAndYearAndMonth(userId, year, month);
 
-
+        //DiaryDateListDTO로 변환
         return DiaryConverter.toDiaryDateListDTO(diaryList);
     }
 
@@ -32,6 +32,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
         // Diary 리스트를 year와 month를 기준으로 필터링
         List<Diary> diaryList = diaryRepository.findByUserIdAndYearAndMonth(userId, year, month);
 
+        //DiaryListDTO로 변환
         return DiaryConverter.toDiaryListDTO(diaryList);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -21,14 +21,14 @@ public class DiaryController implements DiarySpecification {
     private final DiaryQueryService diaryQueryService;
     @GetMapping("/dates")
     public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month){
-        //userId는 임시로 1
+        //userId는 임시로 2
         Long userId = 2L;
 
         return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("/")
     public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month){
-        //userId는 임시로 1
+        //userId는 임시로 2
         Long userId = 2L;
 
         return ApiResponse.onSuccess(diaryQueryService.getDiaryList(year,month,userId));

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -22,14 +22,16 @@ public class DiaryController implements DiarySpecification {
     @GetMapping("/dates")
     public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month){
         //userId는 임시로 1
-        Long userId = 1L;
+        Long userId = 2L;
 
         return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("/")
     public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month){
+        //userId는 임시로 1
+        Long userId = 2L;
 
-        return null;
+        return ApiResponse.onSuccess(diaryQueryService.getDiaryList(year,month,userId));
     }
     @GetMapping("/{diaryId}")
     public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId){

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -30,6 +30,7 @@ public class DiaryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DiaryDTO{
+        Long diaryId;
         String content;
         LocalDateTime date;    //일기 최종 수정 날짜
     }
@@ -40,10 +41,6 @@ public class DiaryResponseDTO {
     public static class DiaryListDTO{
         List<DiaryResponseDTO.DiaryDTO> diaryList;
         Integer listSize;
-        Integer totalPage;
-        Long totalElements;
-        Boolean isFirst;
-        Boolean isLast;
     }
     @Builder
     @Getter


### PR DESCRIPTION
## 📝 작업 내용
> 아래의 화면에서 사용할 YY년MM월에 작성한 일기들을 조회하는 API를 구현하였습니다.
<img width="235" alt="image" src="https://github.com/user-attachments/assets/6ce65f3c-86be-45cd-b7a6-c29e228d74c3" />



## 🔍 테스트 방법
> 1. RDS에 필요한 데이터들을 삽입하였습니다.
> 유저의 정보는 임시로 userId를 2를 받도록 구현해놓았습니다.
>
> 1-1. diary 테이블
> <img width="680" alt="image" src="https://github.com/user-attachments/assets/4f797156-130c-4fe3-97d2-9e4223865a4e" />
>
> 1-2. user 테이블
> <img width="848" alt="image" src="https://github.com/user-attachments/assets/8f8066c0-fa69-4e28-b0dd-0a0f2ed1b7a8" />
>
>
> 2. 프로그램 실행 후 year와 month 입력 후 결과 확인
>
> 2-1. 2023년 1월 조회 결과 없음
> <img width="797" alt="image" src="https://github.com/user-attachments/assets/6fd4d064-a7f4-425a-8bbb-fc80c77f94e4" />
> 2-2. 2024년 12월 조회 결과
> <img width="796" alt="image" src="https://github.com/user-attachments/assets/49121b30-aee2-4b45-9a34-7869983db6cb" />
>
> 2-3. 2025년 1월 조회 결과
> <img width="794" alt="image" src="https://github.com/user-attachments/assets/5b665c38-0ed7-4329-860d-0a255f0dcd83" />



