### PR TITLE
[#66] Feat: 인증 메일 전송 API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### 추가
-/src/main/resources/*
+/src/main/resources/*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -44,6 +45,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// 이메일 전송
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	// 문자열 자동 생성
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,9 @@ public enum ErrorStatus implements BaseErrorCode {
     UNSUPPORTED_TOKEN(HttpStatus.NOT_FOUND, "AUTH4003", "지원하지 않는 JWT 토큰입니다."),
     EMPTY_CLAIMS(HttpStatus.NOT_FOUND, "AUTH4004", "JWT 토큰의 클레임 문자열이 비어 있습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH4005", "이메일 인증을 완료해주세요."),
+    INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "AUTH4006", "이메일 인증 타입이 잘못되었습니다."),
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "이메일 전송에 실패했습니다."),
+    EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "이메일 내용 인코딩에 실패했습니다."),
 
     //기타 에러
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD4001", "비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/umc/GrowIT/Server/converter/AuthenticationCodeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/AuthenticationCodeConverter.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.AuthenticationCode;
+import umc.GrowIT.Server.domain.enums.CodeStatus;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class AuthenticationCodeConverter {
+    public static AuthenticationCode toAuthenticationCode(String email, String authCode) {
+        return AuthenticationCode.builder()
+                .email(email)
+                .code(authCode)
+                .isVerified(false)
+                .codeStatus(CodeStatus.ACTIVE)
+                .expirationDate(LocalDateTime.now().plusMinutes(5)) // 유효기간 5분
+                .build()
+                ;
+    }
+
+    public static AuthResponseDTO.SendAuthEmailResponseDTO toAuthCodeResponse(AuthenticationCode authCode) {
+        return AuthResponseDTO.SendAuthEmailResponseDTO.builder()
+                .email(authCode.getEmail())
+                .message("이메일로 인증번호가 전송되었습니다.")
+                .code(authCode.getCode())
+                .expiration(authCode.getExpirationDate())
+                .build()
+                ;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/AuthenticationCodeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/AuthenticationCodeConverter.java
@@ -12,7 +12,7 @@ public class AuthenticationCodeConverter {
                 .email(email)
                 .code(authCode)
                 .isVerified(false)
-                .codeStatus(CodeStatus.ACTIVE)
+                .status(CodeStatus.ACTIVE)
                 .expirationDate(LocalDateTime.now().plusMinutes(5)) // 유효기간 5분
                 .build()
                 ;

--- a/src/main/java/umc/GrowIT/Server/domain/AuthenticationCode.java
+++ b/src/main/java/umc/GrowIT/Server/domain/AuthenticationCode.java
@@ -32,13 +32,13 @@ public class AuthenticationCode extends BaseEntity {
 
     // 사용 가능 여부
     @Enumerated(EnumType.STRING)
-    private CodeStatus codeStatus;
+    private CodeStatus status;
 
     // 인증 유효기간
     @Column(nullable = false)
     private LocalDateTime expirationDate;
 
-    public void updateCodeStatus(CodeStatus codeStatus) {
-        this.codeStatus = codeStatus;
+    public void updateStatus(CodeStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/AuthenticationCode.java
+++ b/src/main/java/umc/GrowIT/Server/domain/AuthenticationCode.java
@@ -1,0 +1,44 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.CodeStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AuthenticationCode extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 이메일
+    @Column(length = 50, nullable = false)
+    private String email;
+
+    // 인증 코드
+    @Column(unique = true, nullable = false)
+    private String code;
+
+    // 인증 여부
+    @Column(nullable = false)
+    private Boolean isVerified;
+
+    // 사용 가능 여부
+    @Enumerated(EnumType.STRING)
+    private CodeStatus codeStatus;
+
+    // 인증 유효기간
+    @Column(nullable = false)
+    private LocalDateTime expirationDate;
+
+    public void updateCodeStatus(CodeStatus codeStatus) {
+        this.codeStatus = codeStatus;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/AuthType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/AuthType.java
@@ -1,0 +1,6 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum AuthType {
+    SIGNUP,        // 회원가입
+    PASSWORD_RESET // 비밀번호 변경
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/CodeStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/CodeStatus.java
@@ -1,0 +1,6 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum CodeStatus {
+    ACTIVE, // 유효
+    EXPIRED // 만료 or 새로운 코드 발행
+}

--- a/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface AuthenticationCodeRepository extends JpaRepository<AuthenticationCode, Integer> {
-    // 특정 이메일의 end_date가 지금 이후 & status가 유효한 데이터 찾기
-    Optional<AuthenticationCode> findByEmailAndExpirationDateAfterAndCodeStatus(String email, LocalDateTime currentDateTime, CodeStatus codeStatus);
+    // 특정 이메일의 expirationDate가 지금 이후 & status가 유효한 데이터 찾기
+    Optional<AuthenticationCode> findByEmailAndExpirationDateAfterAndStatus(String email, LocalDateTime currentDateTime, CodeStatus codeStatus);
 }

--- a/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
@@ -1,0 +1,13 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.AuthenticationCode;
+import umc.GrowIT.Server.domain.enums.CodeStatus;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface AuthenticationCodeRepository extends JpaRepository<AuthenticationCode, Integer> {
+    // 특정 이메일의 end_date가 지금 이후 & status가 유효한 데이터 찾기
+    Optional<AuthenticationCode> findByEmailAndExpirationDateAfterAndCodeStatus(String email, LocalDateTime currentDateTime, CodeStatus codeStatus);
+}

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthService.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthService.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.service.authService;
+
+import umc.GrowIT.Server.domain.enums.AuthType;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+
+public interface AuthService {
+    AuthResponseDTO.SendAuthEmailResponseDTO sendAuthEmail(AuthType type, AuthRequestDTO.SendAuthEmailRequestDTO request);
+}

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
@@ -117,9 +117,9 @@ public class AuthServiceImpl implements AuthService {
     private AuthenticationCode saveAuthenticationCode(String email, String authenticationCode) {
         // 1. 이전 유효한 인증 코드가 있는지 확인 & 있다면 무효화
         authenticationCodeRepository
-                .findByEmailAndExpirationDateAfterAndCodeStatus(email, LocalDateTime.now(), CodeStatus.ACTIVE)
+                .findByEmailAndExpirationDateAfterAndStatus(email, LocalDateTime.now(), CodeStatus.ACTIVE)
                         .ifPresent(authCode -> {
-                            authCode.updateCodeStatus(CodeStatus.EXPIRED);
+                            authCode.updateStatus(CodeStatus.EXPIRED);
                             authenticationCodeRepository.save(authCode);
                         });
 

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
@@ -1,0 +1,130 @@
+package umc.GrowIT.Server.service.authService;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.AuthHandler;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.converter.AuthenticationCodeConverter;
+import umc.GrowIT.Server.domain.AuthenticationCode;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.enums.AuthType;
+import umc.GrowIT.Server.domain.enums.CodeStatus;
+import umc.GrowIT.Server.repository.AuthenticationCodeRepository;
+import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+import java.io.UnsupportedEncodingException;
+import java.time.LocalDateTime;
+
+
+import org.springframework.beans.factory.annotation.Value;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserRepository userRepository;
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+    private final AuthenticationCodeRepository authenticationCodeRepository;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+        @Override
+        public AuthResponseDTO.SendAuthEmailResponseDTO sendAuthEmail(AuthType type, AuthRequestDTO.SendAuthEmailRequestDTO request) {
+            // 1. type 구분해서 email 체크
+            checkEmail(type, request.getEmail());
+
+            // 2. 랜덤 번호 생성
+            String authenticationCode = createAuthenticationCode();
+
+            // 3. 이메일 전송
+            sendEmail(request.getEmail(), authenticationCode);
+
+            // 4. 인증코드 유효성 체크 & 저장
+            AuthenticationCode authCode = saveAuthenticationCode(request.getEmail(), authenticationCode);
+            return AuthenticationCodeConverter.toAuthCodeResponse(authCode);
+        }
+
+    // 이메일 체크
+    public void checkEmail(AuthType type, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElse(null); // 사용자가 존재하지 않으면 null을 반환
+
+        if (type == AuthType.SIGNUP) { //회원가입 (이메일이 존재하면 X)
+            if (user != null) {
+                throw new UserHandler(ErrorStatus.EMAIL_ALREADY_EXISTS);
+            }
+        } else if (type == AuthType.PASSWORD_RESET) { //비밀번호 변경 (이메일이 존재해야 함)
+            if (user == null) {
+                throw new UserHandler(ErrorStatus.USER_NOT_FOUND);
+            }
+        } else { //type이 잘못됨
+            throw new AuthHandler(ErrorStatus.INVALID_AUTH_TYPE);
+        }
+    }
+
+    // 랜덤번호 생성
+    private String createAuthenticationCode() {
+        // 8자리, 문자, 숫자 포함 문자열 생성
+        return RandomStringUtils.random(8, true, true);
+    }
+
+    // 이메일 전송
+    private void sendEmail(String email, String authenticationCode) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            // 이메일 제목 설정
+            message.setSubject("GrowIT 인증번호입니다.");
+
+            // 이메일 수신자 설정
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(email, "", "UTF-8"));
+
+            // 이메일 발신자 설정
+            message.setFrom(new InternetAddress(fromEmail, "GrowIT", "UTF-8"));
+
+            // 이메일 내용 설정
+            message.setText(setContext(authenticationCode), "UTF-8", "html");
+
+            // 전송
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new AuthHandler(ErrorStatus.EMAIL_SEND_FAIL);
+        } catch (UnsupportedEncodingException e) {
+            throw new AuthHandler(ErrorStatus.EMAIL_ENCODING_FAIL);
+        }
+    }
+
+    // 생성해놓은 html에 인증 코드를 넣어서 반환
+    private String setContext(String authenticationCode) {
+        Context context = new Context();
+        context.setVariable("authenticationCode", authenticationCode);
+        return templateEngine.process("email-authentication", context);
+    }
+
+    // 유효성 체크 & 저장
+    private AuthenticationCode saveAuthenticationCode(String email, String authenticationCode) {
+        // 1. 이전 유효한 인증 코드가 있는지 확인 & 있다면 무효화
+        authenticationCodeRepository
+                .findByEmailAndExpirationDateAfterAndCodeStatus(email, LocalDateTime.now(), CodeStatus.ACTIVE)
+                        .ifPresent(authCode -> {
+                            authCode.updateCodeStatus(CodeStatus.EXPIRED);
+                            authenticationCodeRepository.save(authCode);
+                        });
+
+        // 2. 새 인증 코드 저장
+        AuthenticationCode newAuthenticationCode = AuthenticationCodeConverter.toAuthenticationCode(email, authenticationCode);
+        return authenticationCodeRepository.save(newAuthenticationCode);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -3,10 +3,15 @@ package umc.GrowIT.Server.web.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.domain.enums.AuthType;
+import umc.GrowIT.Server.service.authService.AuthService;
 import umc.GrowIT.Server.web.controller.specification.AuthSpecification;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 import umc.GrowIT.Server.service.userService.UserCommandService;
@@ -17,6 +22,7 @@ import umc.GrowIT.Server.service.userService.UserCommandService;
 public class AuthController implements AuthSpecification {
 
     private final UserCommandService userCommandService;
+    private final AuthService authService;
 
     @PostMapping("/login/email")
     public ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO) {
@@ -37,5 +43,32 @@ public class AuthController implements AuthSpecification {
     public ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO) {
         userCommandService.updatePassword(passwordDTO);
         return ApiResponse.onSuccess();
+    }
+
+    @Override
+    @PatchMapping("")
+    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser() {
+        // 임시로 사용자 ID 지정
+        Long userId = 16L;
+
+        UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
+
+        return ApiResponse.onSuccess(deleteUser);
+    }
+
+    @Override
+    @PostMapping("/email")
+    public ApiResponse<AuthResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(
+            @RequestParam AuthType type,
+            @RequestBody @Valid AuthRequestDTO.SendAuthEmailRequestDTO request) {
+        AuthResponseDTO.SendAuthEmailResponseDTO result = authService.sendAuthEmail(type, request);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Override
+    @PostMapping("/verification")
+    public ApiResponse<AuthResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(AuthRequestDTO.VerifyAuthCodeRequestDTO request) {
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -1,26 +1,16 @@
 package umc.GrowIT.Server.web.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.service.CreditService.CreditQueryServiceImpl;
-import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.web.controller.specification.UserSpecification;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentRequestDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentResponseDTO;
-import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
-import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
@@ -29,7 +19,6 @@ import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 public class UserController implements UserSpecification {
 
     private final CreditQueryServiceImpl creditQueryService;
-    private final UserCommandService userCommandService;
 
     @Override
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(ItemCategory category) {
@@ -50,26 +39,6 @@ public class UserController implements UserSpecification {
 
     @Override
     public ApiResponse<PaymentResponseDTO> purchaseCredits(PaymentRequestDTO request) {
-        return ApiResponse.onSuccess(null);
-    }
-
-    @Override
-    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser() {
-        // 임시로 사용자 ID 지정
-        Long userId = 16L;
-
-        UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
-
-        return ApiResponse.onSuccess(deleteUser);
-    }
-
-    @Override
-    public ApiResponse<UserResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(UserRequestDTO.SendAuthEmailRequestDTO request) {
-        return ApiResponse.onSuccess(null);
-    }
-
-    @Override
-    public ApiResponse<UserResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(UserRequestDTO.VerifyAuthCodeRequestDTO request) {
         return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -9,7 +9,11 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.domain.enums.AuthType;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
+import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
@@ -50,4 +54,40 @@ public interface AuthSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PWD4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
+
+    @PatchMapping("")
+    @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
+
+    @PostMapping("/email")
+    @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4006", description = "❌ 이메일 인증 타입이 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH5001", description = "❌ 이메일 전송에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH5002", description = "❌ 이메일 내용 인코딩에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<AuthResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(
+            @RequestParam AuthType type,
+            @RequestBody @Valid AuthRequestDTO.SendAuthEmailRequestDTO request
+    );
+
+    @PostMapping("/verification")
+    @Operation(summary = "인증 번호 확인 API", description = "사용자가 입력한 인증 번호를 확인하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<AuthResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(@RequestBody AuthRequestDTO.VerifyAuthCodeRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
@@ -13,8 +12,6 @@ import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentRequestDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentResponseDTO;
-import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
-import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 public interface UserSpecification {
 
@@ -54,29 +51,4 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAYMENT4001", description = "❌ 결제정보다 정확하지않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<PaymentResponseDTO> purchaseCredits(@RequestBody PaymentRequestDTO request);
-
-
-    @PatchMapping("")
-    @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
-
-    @PostMapping("/email")
-    @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
-    })
-    ApiResponse<UserResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(@RequestBody UserRequestDTO.SendAuthEmailRequestDTO request);
-
-    @PostMapping("/verification")
-    @Operation(summary = "인증 번호 확인 API", description = "사용자가 입력한 인증 번호를 확인하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
-    })
-    ApiResponse<UserResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(@RequestBody UserRequestDTO.VerifyAuthCodeRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/AuthDTO/AuthRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/AuthDTO/AuthRequestDTO.java
@@ -1,0 +1,32 @@
+package umc.GrowIT.Server.web.dto.AuthDTO;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+public class AuthRequestDTO {
+
+    // 이메일 인증 전송 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SendAuthEmailRequestDTO {
+        @NotBlank
+        @Email
+        private String email; // 인증번호 받을 이메일
+    }
+
+    // 인증 코드 확인 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VerifyAuthCodeRequestDTO {
+        private String authCode; // 인증 번호
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/AuthDTO/AuthResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/AuthDTO/AuthResponseDTO.java
@@ -1,0 +1,34 @@
+package umc.GrowIT.Server.web.dto.AuthDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class AuthResponseDTO {
+
+    // 이메일 인증 전송 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SendAuthEmailResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String email;
+        private String message; // ex) 인증 이메일이 발송되었습니다
+        private String code;
+        private LocalDateTime expiration;
+    }
+
+    // 인증 코드 확인 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VerifyAuthCodeResponseDTO {
+        // TODO 디테일하게 결정 필요
+        private String message; // ex) 인증이 완료되었습니다, 인증번호가 올바르지 않습니다
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
@@ -67,22 +67,4 @@ public class UserRequestDTO {
         @Size(min = 8, max = 30, message = "크기는 8에서 30 사이입니다.")
         private String passwordCheck;
     }
-
-    // 이메일 인증 전송 요청 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SendAuthEmailRequestDTO {
-        private String email; // 인증번호 받을 이메일
-    }
-
-    // 인증 코드 확인 요청 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class VerifyAuthCodeRequestDTO {
-        private String authCode; // 인증 번호
-    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -18,26 +18,6 @@ public class UserResponseDTO {
         private String refreshToken;
     }
 
-    // 이메일 인증 전송 응답 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SendAuthEmailResponseDTO {
-        // TODO 디테일하게 결정 필요
-        private String message; // ex) 인증 이메일이 발송되었습니다
-    }
-
-    // 인증 코드 확인 응답 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class VerifyAuthCodeResponseDTO {
-        // TODO 디테일하게 결정 필요
-        private String message; // ex) 인증이 완료되었습니다, 인증번호가 올바르지 않습니다
-    }
-
     // 회원 탈퇴 응답 DTO
     @Getter
     @Builder

--- a/src/main/resources/templates/email-authentication.html
+++ b/src/main/resources/templates/email-authentication.html
@@ -1,0 +1,52 @@
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>인증 페이지</title>
+    <style>
+        /* 모바일 반응형 디자인 */
+        @media only screen and (max-width: 600px) {
+            body, table, td {
+                width: 100% !important;
+                padding: 0;
+            }
+
+            .email-container {
+                max-width: 100% !important;
+            }
+
+            h1 {
+                font-size: 20px !important;
+            }
+
+            .auth-code {
+                font-size: 18px !important;
+            }
+        }
+    </style>
+</head>
+<body style="font-family: 'Arial', sans-serif; background-color: #2ECC71; color: white; text-align: center; margin: 0; padding: 0; height: 100%; width: 100%;">
+
+<table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" class="email-container" style="margin: auto; max-width: 700px; background-color: #A9DFBF; border-radius: 5px;">
+    <tr>
+        <td style="padding: 40px; text-align: center;">
+
+            <div style="margin-bottom: 30px;">
+                <!-- 여기에 로고 이미지를 삽입하거나 로고 텍스트를 사용하세요 -->
+                <strong style="font-size: 24px; color: #1D8348;">GrowIT</strong>
+            </div>
+
+            <h1 style="color: white; font-size: 24px; margin: 0 0 10px 0;">안녕하세요!</h1>
+            <p style="margin: 0 0 20px 0; color: white; line-height: 1.5; font-size: 16px; ">인증 코드 보내드립니다.</p>
+
+            <!-- 인증 코드 -->
+            <div class="auth-code" style="background-color: #F4F6F7; color: black; padding: 10px 20px; display: inline-block; border-radius: 4px; font-size: 20px; font-weight: bold;" th:text="${authenticationCode}">
+                [인증 코드]
+            </div>
+
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## 📝 작업 내용
> 인증 메일 전송 API 개발
> - application.yml 파일 변경 (노션에 업데이트하겠습니다)
> - build.gradle 의존성 추가 (이메일 전송, 랜덤 인증번호 생성 관련)
> - 인증번호 전송용 템플릿 추가로 인해 yml만 제외하도록 .gitignore 변경
> - 인증번호 저장을 위한 entity 추가
> - 이메일 전송 관련 controller, service, repository, 에러 등 작성
> - 회원탈퇴, 인증메일전송, 인증번호확인 user -> auth로 도메인 변경

## 🔍 테스트 방법
> 1. 인증 이메일 전송은 회원가입과 비밀번호 변경 2가지 경우가 존재합니다.
> 회원가입은 입력 이메일이 기존에 존재하지 않아야 하며, 비밀번호 변경은 입력 이메일이 기존에 존재해야 합니다.
> 따라서 각 경우를 type이라는 파라미터로 받아서 구분하였습니다. 또한, 인증번호를 서버에서 저장하고 관리하여야 하는데 redis 등의 선택지가 있었지만, 우선 기존 DB에 별도의 테이블을 생성하는 방식으로 정하였습니다.
> ![image](https://github.com/user-attachments/assets/b60ef485-aeca-4f00-b270-4046d059ada2)
> 2. 실행결과
> (a) 일반적인 경우
> ![image](https://github.com/user-attachments/assets/4276fabb-a7d3-4890-9a58-62fc2304bbeb)
> response는 마땅히 필요한 것이 없다고 생각되지만, 확인하기 좋도록 DB에 저장된 수신 이메일, 인증번호, 만료기간 등을 전송하였습니다
> ![image](https://github.com/user-attachments/assets/c2398f65-af1c-4212-837c-8080e598c205)
> 참고한 velog와 gpt로 이메일 내용 템플릿을 만든 것이기 때문에 추후 수정해도 좋을 거 같습니다
> ![image](https://github.com/user-attachments/assets/322f4466-d7a4-434a-ae75-66092f0c8b25)
> 인증번호 유효기간은 전송으로부터 5분으로, 5분이 지나지 않고 인증메일을 재전송한다면 기존 인증번호의 status를 Expired로 변경시킵니다
> ![image](https://github.com/user-attachments/assets/04ee1330-32f5-44d2-9f39-49f3cfda6394)
> (b) 회원가입 시, 기존 존재하는 이메일 입력
> ![image](https://github.com/user-attachments/assets/59b9797a-974e-46c8-b0ba-55e3a112e5e7)
> (c) 비밀번호 변경 시, 기존 존재하지 않는 이메일 입력
> ![image](https://github.com/user-attachments/assets/d56251cf-a421-42de-8f11-7de7f378e532)
> (d) 이외, type이 잘못된 경우/이메일 전송 실패/이메일 내용 인코딩 실패 오류도 존재합니다

## 🚨 특이사항 ##
> 이후에 시간이 남게된다면, 스프링배치나 스케줄러를 이용해서 회원탈퇴는 특정기간 이후 완전히 삭제, 인증번호는 만료기간 이후 status를 Expired로 변경하는 것을 고려 중입니다. 하지만, 우선순위는 낮다고 생각되기 때문에 이후 인증번호 확인 API 개발에서는 status가 Active이면서 유효기간 이내인지를 체크하여 검증할 계획입니다.