### PR TITLE
[#65] Feat: 특정 일기 조회 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
@@ -8,10 +8,13 @@ import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
     List<Diary> findByUserIdAndYearAndMonth(@Param("userId") Long userId,
                                             @Param("year") Integer year,
                                             @Param("month") Integer month);
+
+    Optional<Diary> findByUserIdAndId(Long userId, Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
@@ -6,4 +6,6 @@ public interface DiaryQueryService {
     public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId);
 
     public DiaryResponseDTO.DiaryListDTO getDiaryList(Integer year, Integer month, Long userId);
+
+    public DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -3,6 +3,9 @@ package umc.GrowIT.Server.service.diaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.DiaryHandler;
+import umc.GrowIT.Server.apiPayload.exception.GeneralException;
 import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
@@ -10,6 +13,7 @@ import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,5 +38,14 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
 
         //DiaryListDTO로 변환
         return DiaryConverter.toDiaryListDTO(diaryList);
+    }
+
+    @Override
+    public DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId){
+        Optional<Diary> diary = diaryRepository.findByUserIdAndId(userId, diaryId);
+
+
+        return diary.map(DiaryConverter::toDiaryDTO)
+                .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -35,8 +35,10 @@ public class DiaryController implements DiarySpecification {
     }
     @GetMapping("/{diaryId}")
     public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId){
+        //userId는 임시로 2
+        Long userId = 2L;
 
-        return null;
+        return ApiResponse.onSuccess(diaryQueryService.getDiary(diaryId, userId));
     }
 
     @PutMapping("/{diaryId}")


### PR DESCRIPTION
## 📝 작업 내용
> 특정 사용자의 특정 일기를 조회하는 API를 구현하였습니다.


## 🔍 테스트 방법
> 1. userId는 임시로 2를 사용하였습니다.
> 1-1. 정상적인 경우
> <img width="799" alt="image" src="https://github.com/user-attachments/assets/f4cac96e-2194-4efa-ab95-78121f03512f" />
> 1-2. 다른 사용자가 작성한 일기의 ID를 입력한 경우
> 현재 사용자의 ID는 2이지만 ID가 4인 일기를 작성한 사용자의 ID는 3입니다.
> <img width="684" alt="image" src="https://github.com/user-attachments/assets/4be1ac3a-c6e4-4ad6-8def-41e94a22e65d" />
> <img width="802" alt="image" src="https://github.com/user-attachments/assets/7da466b8-6020-42e5-88f8-1c82736ed723" />
> 1-2-1. userId를 3으로 변경하고 똑같이 실행시켜보았습니다.
> <img width="800" alt="image" src="https://github.com/user-attachments/assets/ca784d90-db3f-4c72-b1dd-b2e1803c4bcc" />
> 1-3. 존재하지 않는 일기의 ID를 입력한 경우
> <img width="797" alt="image" src="https://github.com/user-attachments/assets/a645ea1d-c37f-49f4-918f-185887703a81" />


