### PR TITLE
[#82] Refactor: Challenge ID 문제 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/UserChallengeHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/UserChallengeHandler.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class UserChallengeHandler extends GeneralException {
+    public UserChallengeHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -5,5 +5,5 @@ import umc.GrowIT.Server.domain.UserChallenge;
 import java.util.Optional;
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
-    Optional<UserChallenge> findByIdAndUserId (Long userChallengeId, Long userId);
+    Optional<UserChallenge> findByChallengeIdAndUserId (Long challengeId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -7,5 +7,5 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 public interface ChallengeCommandService {
     void markChallengeAsCompleted(Long userId, Long challengeId);
     ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long challengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
-    ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
+    ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long challengeId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -58,10 +58,10 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         return ChallengeConverter.toProofDetailsDTO(userChallenge);
     }
 
-    public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId) {
+    public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long challengeId, Long userId) {
 
-        // 1. userId와 userChallengeId를 통해 조회하고 없으면 오류
-        UserChallenge userChallenge = userChallengeRepository.findByIdAndUserId(userChallengeId, userId)
+        // 1. userId와 challengeId를 통해 조회하고 없으면 오류
+        UserChallenge userChallenge = userChallengeRepository.findByChallengeIdAndUserId(challengeId, userId)
                 .orElseThrow(() -> new ChallengeHandler(ErrorStatus.USER_CHALLENGE_NOT_FOUND));
 
         // 2. 진행 중(false)인 챌린지인지 체크, 완료(true)한 챌린지면 오류
@@ -70,7 +70,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         }
 
         // 3. 삭제
-        userChallengeRepository.deleteById(userChallengeId);
+        userChallengeRepository.delete(userChallenge);
 
         // 4. converter 작업
         return ChallengeConverter.toDeletedUserChallenge(userChallenge);

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -70,11 +70,11 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @DeleteMapping("{challengeId}")
-    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long userChallengeId) {
+    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long challengeId) {
         // 임시로 사용자 ID 지정
         Long userId = 1L;
 
-        ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
+        ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(challengeId, userId);
         return ApiResponse.onSuccess(deleteChallenge);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -77,6 +77,8 @@ public interface ChallengeSpecification {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4001", description = "❌ 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4002", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))


### PR DESCRIPTION
## 📝 작업 내용
> 기존 API 세부 로직에서 실수한 부분이 있어 수정했습니다.
> 삭제하려는 챌린지 ID를 User Challenge의 ID로 구현한 것을 Challenge ID로 수정했습니다.


## 🔍 테스트 방법
> 1. 프론트엔드의 챌린지에는 Challenge 기본키 ID가 전달되어 있고 미완료한 챌린지를 삭제할 때에는 해당 ID를 전달받습니다. User Challenge DB는 아래와 같습니다.
> ![image](https://github.com/user-attachments/assets/b7a045eb-65c6-4ef0-a20c-f3d53a811028)
> 2. 실행 결과
> (a) 일반적인 경우
> Response에 있는 ID는 사용자 챌린지의 기본키 ID입니다
> ![image](https://github.com/user-attachments/assets/8ee5b172-dc08-43eb-8568-44cbca02d355)
> (b) 잘못된 ID를 전달받은 경우
> ![image](https://github.com/user-attachments/assets/c56f5047-cf51-406f-b99f-0babd5130385)
> (c) 완료한 챌린지인 경우
> ![image](https://github.com/user-attachments/assets/8361d804-8496-4a7b-9bc8-e470336f88d5)

## ❓ 고민
> 이런 경우에, 사용자/챌린지 Not_Found에 대한 오류 처리도 구현하셨나요?
> ex) User Challenge에서의 조회 이전에, 존재하는 사용자인지&존재하는 챌린지인지
> 중복 사항이라서 어노테이션 도입을 하는 게 좋았으려나 라는 생각이 들어서 궁금하여 적습니다!