### PR TITLE
[#84] Feat: 일기 수정하기 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 import java.util.List;
@@ -42,6 +43,15 @@ public class DiaryConverter {
         return DiaryResponseDTO.DiaryListDTO.builder()
                 .diaryList(diaryDTOList)
                 .listSize(diaryDTOList.size())
+                .build();
+    }
+
+    public static DiaryResponseDTO.ModifyResultDTO toModifyResultDTO(Diary diary){
+
+        return DiaryResponseDTO.ModifyResultDTO.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .updatedAt(diary.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
+++ b/src/main/java/umc/GrowIT/Server/domain/common/BaseEntity.java
@@ -3,6 +3,7 @@ package umc.GrowIT.Server.domain.common;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 public class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.service.diaryService;
+
+import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+
+public interface DiaryCommandService {
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId);
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -3,11 +3,16 @@ package umc.GrowIT.Server.service.diaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.DiaryHandler;
+import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -17,9 +22,14 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     @Override
     public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId) {
 
-        Optional<Diary> diary = diaryRepository.findByUserIdAndId(diaryId, userId);
+        Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
+        Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
+        //Todo: 수정한 일기의 내용이 100자 이내인지 검사하는 로직 추가 필요(원활한 테스트를 위해 나중에 추가)
+        diary.setContent(request.getContent());
+        diary.setUpdatedAt(request.getDate());
 
-       return null;
+        diaryRepository.save(diary);
+        return DiaryConverter.toModifyResultDTO(diary);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.service.diaryService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryCommandServiceImpl implements DiaryCommandService{
+    private final DiaryRepository diaryRepository;
+    @Override
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId) {
+
+        Optional<Diary> diary = diaryRepository.findByUserIdAndId(diaryId, userId);
+
+
+       return null;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -6,8 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.service.diaryService.DiaryCommandService;
 import umc.GrowIT.Server.service.diaryService.DiaryQueryService;
 import umc.GrowIT.Server.web.controller.specification.DiarySpecification;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
@@ -19,6 +22,7 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 @RequestMapping("/diaries")
 public class DiaryController implements DiarySpecification {
     private final DiaryQueryService diaryQueryService;
+    private final DiaryCommandService diaryCommandService;
     @GetMapping("/dates")
     public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month){
         //userId는 임시로 2
@@ -42,9 +46,13 @@ public class DiaryController implements DiarySpecification {
     }
 
     @PutMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
-        return null;
+        return ApiResponse.onSuccess(diaryCommandService.modifyDiary(request, diaryId, userId));
     }
 
     @DeleteMapping("/{diaryId}")

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -24,28 +24,36 @@ public class DiaryController implements DiarySpecification {
     private final DiaryQueryService diaryQueryService;
     private final DiaryCommandService diaryCommandService;
     @GetMapping("/dates")
-    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month){
-        //userId는 임시로 2
-        Long userId = 2L;
+    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                       @RequestParam Integer year,
+                                                                       @RequestParam Integer month){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
         return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("/")
-    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month){
-        //userId는 임시로 2
-        Long userId = 2L;
+    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                   @RequestParam Integer year,
+                                                                   @RequestParam Integer month){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
         return ApiResponse.onSuccess(diaryQueryService.getDiaryList(year,month,userId));
     }
     @GetMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId){
-        //userId는 임시로 2
-        Long userId = 2L;
+    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                           @PathVariable("diaryId") Long diaryId){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
         return ApiResponse.onSuccess(diaryQueryService.getDiary(diaryId, userId));
     }
 
-    @PutMapping("/{diaryId}")
+    @PatchMapping("/{diaryId}")
     public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                      @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request){
         //accessToken에서 userId 추출

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -17,7 +17,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                @RequestParam Integer year, @RequestParam Integer month);
 
     @GetMapping("/")
     @Operation(summary = "일기 모아보기 API",description = "특정 사용자가 작성한 일기를 모아보는 API입니다. query string으로 year와 month를 넘겨주면 해당 월에 작성한 일기들의 리스트, 작성한 일기 수를 보내줍니다.")
@@ -25,7 +26,9 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                            @RequestParam Integer year,
+                                                            @RequestParam Integer month);
 
     @GetMapping("/{diaryId}")
     @Operation(summary = "특정 일기 조회 API",description = "특정 사용자가 작성한 특정 일기를 조회하는 API입니다. path variable로 일기의 id를 넘겨주면 해당 일기의 세부적인 내용을 보내줍니다.")
@@ -33,9 +36,10 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId);
+    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                    @PathVariable("diaryId") Long diaryId);
 
-    @PutMapping("/{diaryId}")
+    @PatchMapping("/{diaryId}")
     @Operation(summary = "일기 수정하기 API",description = "특정 사용자가 작성한 일기를 수정하는 API입니다. path variable로 일기의 id, RequestBody로 수정한 내용과 수정 시간을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -42,7 +42,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request);
+    public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class DiaryRequestDTO {
     @Getter
@@ -13,6 +14,6 @@ public class DiaryRequestDTO {
         @NotNull
         String content;
         @NotNull
-        LocalDate date;
+        LocalDateTime date;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 특정 사용자의 특정 일기를 수정하는 API를 구현하였습니다.
> + 기존 하드코딩된 userId를 accessToken을 통해 받아오도록 수정하였습니다.
> accessToken의 유효시간이 짧아서 테스트하실 때 시간이 지나면 오류가 발생합니다 참고해주세요.

## 🔍 테스트 방법
> 1. 이메일 로그인 API를 통해 로그인한 후 발급된 accessToken을 Authorize에 입력합니다.
> 1-1. 해당 user가 작성한 일기가 있어야 이후 과정을 테스트할 수 있습니다.
> 아래의 쿼리문을 변경하여 로그인할 user의 일기 데이터를 넣어주세요.
> ```
> insert into diary(id, user_id, content, created_at, updated_at)
>   values(6,32, '첫번째 일기 수정전', NOW(), NOW()),
>          (7,32, '두번째 일기 수정전', NOW(), NOW());
> ```
> <img width="957" alt="image" src="https://github.com/user-attachments/assets/e86f2271-f5b3-4200-9b6e-1f31eec1133d" />
> 2. 일기 수정 API에 토큰 내용과 DiaryId를 입력 후 수정 내용을 입력합니다.
> <img width="959" alt="image" src="https://github.com/user-attachments/assets/e64586fb-7978-4d92-b2f1-b5875c81f922" />
> 2-1. 수정된 것 확인
> <img width="701" alt="image" src="https://github.com/user-attachments/assets/acab2718-4184-4fc0-a01e-46553099404b" />
>
> 3. 일기 조회 API로 수정된 내용이 적용되었는지 확인
> 3-1. 일기 수정 전 조회 결과
> <img width="707" alt="image" src="https://github.com/user-attachments/assets/30e059b4-0463-4351-a3f4-d4ba46534eeb" />
>
> 3-2. 일기 수정 후 조회 결과
> <img width="709" alt="image" src="https://github.com/user-attachments/assets/ed68eede-ca89-447d-ae54-60d21186add3" />


