### PR TITLE
[#90] Refactor: 일기를 작성하는 날짜 필드 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -11,7 +11,7 @@ public class DiaryConverter {
     public static DiaryResponseDTO.DiaryDateDTO toDiaryDateDTO(Diary diary){
         return DiaryResponseDTO.DiaryDateDTO.builder()
                 .diaryId(diary.getId())
-                .date(diary.getCreatedAt())
+                .date(diary.getDate())
                 .build();
     }
 
@@ -31,7 +31,7 @@ public class DiaryConverter {
         return DiaryResponseDTO.DiaryDTO.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
-                .date(diary.getCreatedAt())
+                .date(diary.getDate())
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -51,7 +51,6 @@ public class DiaryConverter {
         return DiaryResponseDTO.ModifyResultDTO.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
-                .updatedAt(diary.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.GrowIT.Server.domain.common.BaseEntity;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
@@ -17,6 +18,9 @@ public class Diary extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
 
     @Lob // 필드를 TEXT로 매핑
     @Column(nullable = false)

--- a/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
+    @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND YEAR(d.date) = :year AND MONTH(d.date) = :month")
     List<Diary> findByUserIdAndYearAndMonth(@Param("userId") Long userId,
                                             @Param("year") Integer year,
                                             @Param("month") Integer month);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -5,5 +5,5 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryCommandService {
-    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId);
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -20,14 +20,13 @@ import java.util.Optional;
 public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final DiaryRepository diaryRepository;
     @Override
-    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId) {
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId) {
 
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
         //Todo: 수정한 일기의 내용이 100자 이내인지 검사하는 로직 추가 필요(원활한 테스트를 위해 나중에 추가)
         diary.setContent(request.getContent());
-        diary.setUpdatedAt(request.getDate());
 
         diaryRepository.save(diary);
         return DiaryConverter.toModifyResultDTO(diary);

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -55,7 +55,7 @@ public class DiaryController implements DiarySpecification {
 
     @PatchMapping("/{diaryId}")
     public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request){
+                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -47,7 +47,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     public ApiResponse<DiaryResponseDTO.ModifyResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.DiaryDTO request);
+                                                                     @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -5,15 +5,14 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 public class DiaryRequestDTO {
     @Getter
     @Setter
     public static class DiaryDTO {
         @NotNull
-        String content;
+        String content; //작성 내용
         @NotNull
-        LocalDateTime date;
+        LocalDate date; //작성 날짜
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -15,4 +15,11 @@ public class DiaryRequestDTO {
         @NotNull
         LocalDate date; //작성 날짜
     }
+
+    @Getter
+    @Setter
+    public static class ModifyDTO{
+        @NotNull
+        String content; //수정 내용
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -15,7 +16,7 @@ public class DiaryResponseDTO {
     @AllArgsConstructor
     public static class DiaryDateDTO{
         Long diaryId;
-        LocalDateTime date;    //일기 최종 수정 날짜
+        LocalDate date;    //일기 최종 수정 날짜
     }
     @Builder
     @Getter
@@ -32,7 +33,7 @@ public class DiaryResponseDTO {
     public static class DiaryDTO{
         Long diaryId;
         String content;
-        LocalDateTime date;    //일기 최종 수정 날짜
+        LocalDate date;    //일기 최종 수정 날짜
     }
     @Builder
     @Getter
@@ -49,7 +50,6 @@ public class DiaryResponseDTO {
     public static class CreateResultDTO{
         Long diaryId;
         String content;
-        LocalDateTime createdAt;
     }
 
     @Builder
@@ -59,6 +59,5 @@ public class DiaryResponseDTO {
     public static class ModifyResultDTO{
         Long diaryId;
         String content;
-        LocalDateTime updatedAt;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 일기 엔티티에 작성하는 날짜를 기록할 필드를 추가하고
> 그에 맞게 API들을 수정하였습니다.
> (date값이 기존에는 created_at의 정보가 들어가는 것에서 사용자가 일기를 작성할 때 특정 날짜를 지정하고 작성하기 때문에 그 특정 날짜를 저장하는 date 값이 들어가도록 변경)


## 🔍 테스트 방법
> 1. 로그인 후 API 테스트
> 2. 로그인한 유저의 ID로 일기를 생성한 후 진행해야합니다.
> 3. Swagger 테스트
>
> 3-1. 특정 일기 조회 API에서 date 확인
<img width="564" alt="image" src="https://github.com/user-attachments/assets/d2ab7dca-0ad6-4f6f-987c-2e455abc93c8" />

 >3-2. 일기 작성 날짜 조회 API에서 date 확인
<img width="556" alt="image" src="https://github.com/user-attachments/assets/57abd8ce-5f74-405d-8c0f-8f5d587d255a" /> 

> 3-3. 일기 모아보기 API에서 date 확인
<img width="562" alt="image" src="https://github.com/user-attachments/assets/7e92d901-1ead-4060-b50b-c97858c8930a" />


