### PR TITLE
[#92] Setting : CI/CD파일 추가

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,0 +1,67 @@
+name: GrowIt CI/CD Pipeline
+
+on:
+  push:
+    branches: [ develop ]  # develop 브랜치에 push가 일어날 때 실행
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3  # 저장소 코드 체크아웃
+
+      - name: Set up JDK 17  # Java 개발 킷 설정
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Make application.yml  # application.yml 파일 생성
+        run: |
+          cd ./src/main/resources
+          echo "${{ secrets.APPLICATION_YML }}" > ./application.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew  # gradlew 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: Build with Gradle  # Gradle을 사용하여 프로젝트 빌드
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build # gradle build 명령어 실행
+
+      - name: Upload build artifact  # 빌드된 아티팩트 업로드
+        uses: actions/upload-artifact@v3
+        with:
+          name: umc7thServer
+          path: build/libs/*.jar
+
+  deploy:
+    needs: build  # build 작업이 성공적으로 완료된 후 실행
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifact  # 이전 단계에서 업로드한 아티팩트 다운로드
+        uses: actions/download-artifact@v3
+        with:
+          name: umc7thServer
+          path: build/libs/
+
+      - name: Deploy to EC2  # EC2에 배포
+        env:
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+          EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+        run: |
+          echo "$EC2_SSH_KEY" > private_key.pem
+          chmod 600 private_key.pem
+          jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
+          scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/umc7thServer.jar
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
+            pgrep java | xargs -r kill -15  # 기존에 실행 중인 Java 프로세스 종료
+            sleep 10
+            nohup java -jar /home/$EC2_USERNAME/umc7thServer.jar > app.log 2>&1 &  # 새 버전 애플리케이션 실행
+          "
+          rm -f private_key.pem  # 민감한 정보 삭제
+

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,67 +1,97 @@
+# GrowIt 프로젝트의 CI/CD 파이프라인 워크플로우
 name: GrowIt CI/CD Pipeline
 
+# 워크플로우 트리거 조건 설정
 on:
   push:
-    branches: [ develop ]  # develop 브랜치에 push가 일어날 때 실행
+    branches: [ develop ]  # develop 브랜치에 push가 발생할 때만 실행
 
+# 실행할 작업들을 정의
 jobs:
+  # 빌드 작업
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-latest  # Ubuntu 최신 버전에서 실행
+    
     steps:
-      - uses: actions/checkout@v3  # 저장소 코드 체크아웃
-
-      - name: Set up JDK 17  # Java 개발 킷 설정
+      # 1. 깃허브 저장소 코드를 워크플로우 환경으로 가져오기
+      - uses: actions/checkout@v3
+      
+      # 2. Java 개발 킷(JDK) 17 버전 설치 및 설정
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Make application.yml  # application.yml 파일 생성
+          distribution: 'temurin'    # Eclipse Temurin JDK 사용
+          java-version: '17'         # Java 17 버전 지정
+      
+      # 3. application.yml 설정 파일 생성
+      - name: Make application.yml
         run: |
-          cd ./src/main/resources
-          echo "${{ secrets.APPLICATION_YML }}" > ./application.yml
+          cd ./src/main/resources   # resources 디렉토리로 이동
+          echo "${{ secrets.APPLICATION_YML }}" > ./application.yml  # GitHub Secrets에서 설정값 가져와서 파일 생성
         shell: bash
-
-      - name: Grant execute permission for gradlew  # gradlew 실행 권한 부여
+      
+      # 4. gradlew 파일에 실행 권한 부여
+      - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-
-      - name: Build with Gradle  # Gradle을 사용하여 프로젝트 빌드
+      
+      # 5. Gradle을 사용하여 프로젝트 빌드
+      - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build # gradle build 명령어 실행
-
-      - name: Upload build artifact  # 빌드된 아티팩트 업로드
+          arguments: build  # gradle build 명령 실행
+      
+      # 6. 빌드된 JAR 파일을 아티팩트로 업로드
+      - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: GrowItServer
-          path: build/libs/*.jar
-
+          name: GrowItServer        # 아티팩트 이름 지정
+          path: build/libs/*.jar    # 업로드할 JAR 파일 경로
+  
+  # 배포 작업
   deploy:
-    needs: build  # build 작업이 성공적으로 완료된 후 실행
+    needs: build  # build 작업이 성공적으로 완료된 후에 실행
     runs-on: ubuntu-latest
-
+    
     steps:
-      - name: Download build artifact  # 이전 단계에서 업로드한 아티팩트 다운로드
+      # 1. 이전 빌드 작업에서 생성된 아티팩트 다운로드
+      - name: Download build artifact
         uses: actions/download-artifact@v3
         with:
-          name: GrowItServer
-          path: build/libs/
-
-      - name: Deploy to EC2  # EC2에 배포
+          name: GrowItServer    # 다운로드할 아티팩트 이름
+          path: build/libs/     # 저장할 경로
+      
+      # 2. EC2 인스턴스에 배포
+      - name: Deploy to EC2
         env:
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
-          EC2_HOST: ${{ secrets.EC2_HOST }}
+          # 환경 변수 설정 (GitHub Secrets에서 가져옴)
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}      # EC2 접속용 SSH 키
+          EC2_USERNAME: ${{ secrets.EC2_USERNAME }}    # EC2 사용자 이름
+          EC2_HOST: ${{ secrets.EC2_HOST }}           # EC2 호스트 주소
         run: |
+          # SSH 키 파일 생성
           echo "$EC2_SSH_KEY" > private_key.pem
+          
+          # SSH 키 파일 권한 설정 (소유자만 읽기/쓰기 가능)
           chmod 600 private_key.pem
+          
+          # 빌드된 JAR 파일 찾기 (*plain.jar 제외)
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
+          
+          # JAR 파일을 EC2로 전송 (StrictHostKeyChecking 무시)
           scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/GrowItServer.jar
+          
+          # EC2에 SSH 접속하여 애플리케이션 재시작
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
-            pgrep java | xargs -r kill -15  # 기존에 실행 중인 Java 프로세스 종료
+            # 실행 중인 Java 프로세스 종료
+            pgrep java | xargs -r kill -15
+          
+            # 프로세스 종료 대기
             sleep 10
-            nohup java -jar /home/$EC2_USERNAME/GrowItServer.jar > app.log 2>&1 &  # 새 버전 애플리케이션 실행
+          
+            # 새 버전 애플리케이션 실행 (백그라운드에서)
+            # app.log 파일에 표준 출력과 에러를 기록
+            nohup java -jar /home/$EC2_USERNAME/GrowItServer.jar > app.log 2>&1 &
           "
-          rm -f private_key.pem  # 민감한 정보 삭제
-
+          
+          # 보안을 위해 SSH 키 파일 삭제
+          rm -f private_key.pem

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload build artifact  # 빌드된 아티팩트 업로드
         uses: actions/upload-artifact@v3
         with:
-          name: umc7thServer
+          name: GrowItServer
           path: build/libs/*.jar
 
   deploy:
@@ -45,7 +45,7 @@ jobs:
       - name: Download build artifact  # 이전 단계에서 업로드한 아티팩트 다운로드
         uses: actions/download-artifact@v3
         with:
-          name: umc7thServer
+          name: GrowItServer
           path: build/libs/
 
       - name: Deploy to EC2  # EC2에 배포
@@ -57,11 +57,11 @@ jobs:
           echo "$EC2_SSH_KEY" > private_key.pem
           chmod 600 private_key.pem
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
-          scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/umc7thServer.jar
+          scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/GrowItServer.jar
           ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
             pgrep java | xargs -r kill -15  # 기존에 실행 중인 Java 프로세스 종료
             sleep 10
-            nohup java -jar /home/$EC2_USERNAME/umc7thServer.jar > app.log 2>&1 &  # 새 버전 애플리케이션 실행
+            nohup java -jar /home/$EC2_USERNAME/GrowItServer.jar > app.log 2>&1 &  # 새 버전 애플리케이션 실행
           "
           rm -f private_key.pem  # 민감한 정보 삭제
 

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -39,7 +39,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build  # gradle build 명령 실행
-      
+
+
       # 6. 빌드된 JAR 파일을 아티팩트로 업로드
       - name: Upload build artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -78,6 +78,13 @@ jobs:
           # 빌드된 JAR 파일 찾기 (*plain.jar 제외)
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
           
+          # 기존 JAR 파일 삭제
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
+            if [ -f /home/$EC2_USERNAME/GrowItServer.jar ]; then
+              rm -f /home/$EC2_USERNAME/GrowItServer.jar
+            fi
+          "
+          
           # JAR 파일을 EC2로 전송 (StrictHostKeyChecking 무시)
           scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/GrowItServer.jar
           


### PR DESCRIPTION
## 📝 작업 내용
> .github.workflows/dev_deploy.yml파일 추가

## CI/CD 흐름

1. Trigger
- develop 브랜치에 push 발생
- GitHub Actions 워크플로우 시작


2. Build Job
- 저장소 코드 체크아웃
- JDK 17 설정
- application.yml 파일 생성 (GitHub Secrets에서 설정값 가져옴)
- gradlew 실행 권한 부여
- Gradle로 프로젝트 빌드
- 빌드된 JAR 파일을 아티팩트로 업로드

3. Deploy Job
- build job 완료 후 시작
- 빌드된 JAR 파일 다운로드
- EC2 배포 과정
  - private_key.pem 생성
  - JAR 파일을 EC2로 전송(scp)
  - SSH로 EC2 접속
  - 기존 Java 프로세스 종료
  - 새 버전 애플리케이션 실행
  - 민감정보(private key) 삭제

## 🔍 테스트 방법
> github action 실행여부 확인예정