### PR TITLE
[#96] Feat: 일기 삭제하기 API 구현

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build  # gradle build 명령 실행
+          arguments: build -x test  # 테스트 제외하고 빌드
 
 
       # 6. 빌드된 JAR 파일을 아티팩트로 업로드

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -65,6 +65,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 날짜 관련 에러
     DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE4001", "유효하지 않은 날짜입니다."),
 
+    //그로관련
+    GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO4001", "이미 사용 중인 닉네임입니다."),
+    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "Gro4002", "닉네임은 2글자에서 20글자 사이여야 합니다."),
+
     //일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "존재하지 않는 일기입니다."),
     DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY4002", "100자 이내로 작성된 일기입니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/GroHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/GroHandler.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class GroHandler extends GeneralException{
+    public GroHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -53,4 +53,13 @@ public class DiaryConverter {
                 .content(diary.getContent())
                 .build();
     }
+
+    public static DiaryResponseDTO.CreateResultDTO toCreateResultDTO(Diary diary){
+
+        return DiaryResponseDTO.CreateResultDTO.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .date(diary.getDate())
+                .build();
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -62,4 +62,11 @@ public class DiaryConverter {
                 .date(diary.getDate())
                 .build();
     }
+
+    public static DiaryResponseDTO.DeleteResultDTO toDeleteResultDTO(Diary diary){
+
+        return DiaryResponseDTO.DeleteResultDTO.builder()
+                .message("일기를 삭제했어요.")
+                .build();
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -59,7 +59,6 @@ public class DiaryConverter {
         return DiaryResponseDTO.CreateResultDTO.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
-                .date(diary.getDate())
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
@@ -1,0 +1,27 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Gro;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
+
+public class GroConverter {
+
+
+    public static GroResponseDTO toGroResponseDTO(Gro gro) {
+        return GroResponseDTO.builder()
+                .id(gro.getId())
+                .user_id(gro.getUser().getId())
+                .name(gro.getName())
+                .level(gro.getLevel())
+                .build();
+    }
+
+
+    public static Gro toGro(User user, String name) {
+        return Gro.builder()
+                .user(user)
+                .name(name)
+                .level(1)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/UserItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserItemConverter.java
@@ -1,0 +1,16 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
+
+public class UserItemConverter {
+    public static UserItem toUserItem(User user, Item item) {
+        return UserItem.builder()
+                .user(user)
+                .item(item)
+                .status(ItemStatus.EQUIPPED)  // 초기 생성 시 착용 상태로 설정
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/repository/GroRepository/GroRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/GroRepository/GroRepository.java
@@ -1,0 +1,13 @@
+package umc.GrowIT.Server.repository.GroRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import umc.GrowIT.Server.domain.Gro;
+
+import java.util.Optional;
+
+public interface GroRepository extends JpaRepository<Gro, Long> {
+    Optional<Gro> findByName(String name);
+
+    boolean existsByName(@Param("name")String nickname);
+}

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
@@ -5,6 +5,7 @@ import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findAllByCategory(ItemCategory category);
@@ -12,4 +13,5 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     // UserItem을 통해 현재 사용자의 특정 아이템 구매여부 판별
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);
 
+    Optional<Item> findByName(String name);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -59,20 +59,23 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     }
 
     public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId) {
+        // 1. userId를 조회하고 없으면 오류
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 1. userId와 userChallengeId를 통해 조회하고 없으면 오류
+        // 2. userChallengeId와 userId를 통해 조회하고 없으면 오류
         UserChallenge userChallenge = userChallengeRepository.findByIdAndUserId(userChallengeId, userId)
                 .orElseThrow(() -> new ChallengeHandler(ErrorStatus.USER_CHALLENGE_NOT_FOUND));
 
-        // 2. 진행 중(false)인 챌린지인지 체크, 완료(true)한 챌린지면 오류
+        // 3. 진행 중(false)인 챌린지인지 체크, 완료(true)한 챌린지면 오류
         if(userChallenge.isCompleted()) {
             throw new ChallengeHandler(ErrorStatus.USER_CHALLENGE_COMPLETE);
         }
 
-        // 3. 삭제
+        // 4. 삭제
         userChallengeRepository.deleteById(userChallengeId);
 
-        // 4. converter 작업
+        // 5. converter 작업
         return ChallengeConverter.toDeletedUserChallenge(userChallenge);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandService.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.service.GroService;
+
+import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
+
+public interface GroCommandService {
+    public GroResponseDTO createGro(Long userId, String nickname, String backgroundItem);
+}

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -1,0 +1,75 @@
+package umc.GrowIT.Server.service.GroService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.GroHandler;
+import umc.GrowIT.Server.apiPayload.exception.ItemHandler;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.converter.GroConverter;
+import umc.GrowIT.Server.converter.UserItemConverter;
+import umc.GrowIT.Server.domain.Gro;
+import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.repository.GroRepository.GroRepository;
+import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
+import umc.GrowIT.Server.repository.UserItemRepository;
+import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GroCommandServiceImpl implements GroCommandService{
+
+    private final GroRepository groRepository;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final UserItemRepository userItemRepository;
+
+    @Override
+    @Transactional
+    public GroResponseDTO createGro(Long userId, String nickname, String backgroundItem) {
+        // 닉네임 체크
+        checkNickname(nickname);
+
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 배경 아이템 조회
+        Item item = itemRepository.findByName(backgroundItem)
+                .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
+
+        // Gro 생성 및 저장
+        Gro gro = GroConverter.toGro(user, nickname);
+        Gro savedGro = groRepository.save(gro);
+
+        // UserItem 생성 및 저장 (Converter 사용)
+        UserItem userItem = UserItemConverter.toUserItem(user, item);
+        userItemRepository.save(userItem);
+
+        return GroConverter.toGroResponseDTO(savedGro);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkNickname(String nickname){
+
+//        if (nickname.length() < 2 || nickname.length() > 10) {
+//
+//            throw new GroHandler(ErrorStatus.GRO_NICKNAME_LENGTH_INVALID);
+//        }
+
+        Optional<Gro> gro = groRepository.findByName(nickname);
+
+        if (gro.isPresent()){
+            throw new GroHandler(ErrorStatus.GRO_NICKNAME_ALREADY_EXISTS);
+        }
+
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -5,5 +5,8 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryCommandService {
-    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId);
+
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId);
+
+    public DiaryResponseDTO.CreateResultDTO createDiary(DiaryRequestDTO.DiaryDTO request, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -9,4 +9,6 @@ public interface DiaryCommandService {
     public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId);
 
     public DiaryResponseDTO.CreateResultDTO createDiary(DiaryRequestDTO.DiaryDTO request, Long userId);
+
+    public DiaryResponseDTO.DeleteResultDTO deleteDiary(Long diaryId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -6,7 +6,7 @@ import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryCommandService {
 
-    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.DiaryDTO request, Long diaryId, Long userId);
+    public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId);
 
     public DiaryResponseDTO.CreateResultDTO createDiary(DiaryRequestDTO.DiaryDTO request, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -32,7 +32,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         //Todo: 수정한 일기의 내용이 100자 이내인지 검사하는 로직 추가 필요(원활한 테스트를 위해 나중에 추가)
         diary.setContent(request.getContent());
 
-        diaryRepository.save(diary);
         return DiaryConverter.toModifyResultDTO(diary);
     }
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.DiaryHandler;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.repository.UserRepository;
 import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -19,6 +22,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
     @Override
     public DiaryResponseDTO.ModifyResultDTO modifyDiary(DiaryRequestDTO.ModifyDTO request, Long diaryId, Long userId) {
 
@@ -30,5 +34,26 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         diaryRepository.save(diary);
         return DiaryConverter.toModifyResultDTO(diary);
+    }
+
+    @Override
+    public DiaryResponseDTO.CreateResultDTO createDiary(DiaryRequestDTO.DiaryDTO request, Long userId) {
+
+        //유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        //Todo: request의 content가 100자 이내인지 검사하는 로직 추가
+
+        //일기 생성
+        Diary diary = Diary.builder()
+                .content(request.getContent())
+                .user(user)
+                .date(request.getDate())
+                .build();
+
+        //일기 저장
+        diary = diaryRepository.save(diary);
+
+        return DiaryConverter.toCreateResultDTO(diary);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -55,4 +55,16 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         return DiaryConverter.toCreateResultDTO(diary);
     }
+
+    @Override
+    public DiaryResponseDTO.DeleteResultDTO deleteDiary(Long diaryId, Long userId) {
+
+        Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
+        Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+        diaryRepository.delete(diary);
+
+        return DiaryConverter.toDeleteResultDTO(diary);
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ChallengeType;
@@ -69,10 +71,11 @@ public class ChallengeController implements ChallengeSpecification {
         return null;
     }
 
-    @DeleteMapping("{challengeId}")
-    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long userChallengeId) {
-        // 임시로 사용자 ID 지정
-        Long userId = 1L;
+    @DeleteMapping("{userChallengeId}")
+    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId) {
+        //AccessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
         ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
         return ApiResponse.onSuccess(deleteChallenge);

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -64,13 +64,13 @@ public class DiaryController implements DiarySpecification {
     }
 
     @DeleteMapping("/{diaryId}")
-    public void deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                      @PathVariable("diaryId") Long diaryId){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        diaryCommandService.deleteDiary(diaryId, userId);
+        return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
     }
     @PostMapping("/text")
     public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -64,8 +64,13 @@ public class DiaryController implements DiarySpecification {
     }
 
     @DeleteMapping("/{diaryId}")
-    public void deleteDiary(@PathVariable("diaryId") Long diaryId){
+    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                     @PathVariable("diaryId") Long diaryId){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
+        return null;
     }
     @PostMapping("/text")
     public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -64,13 +64,13 @@ public class DiaryController implements DiarySpecification {
     }
 
     @DeleteMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+    public void deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                      @PathVariable("diaryId") Long diaryId){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
+        diaryCommandService.deleteDiary(diaryId, userId);
     }
     @PostMapping("/text")
     public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -68,9 +68,13 @@ public class DiaryController implements DiarySpecification {
 
     }
     @PostMapping("/text")
-    public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.DiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                           @RequestBody DiaryRequestDTO.DiaryDTO request){
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
 
-        return null;
+        return ApiResponse.onSuccess(diaryCommandService.createDiary(request, userId));
     }
     @PostMapping("/voice")
     public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.DiaryDTO request){

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -70,7 +70,7 @@ public class DiaryController implements DiarySpecification {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        return null;
+        return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
     }
     @PostMapping("/text")
     public ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,

--- a/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
@@ -5,17 +5,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.service.GroService.GroCommandService;
 import umc.GrowIT.Server.web.controller.specification.GroSpecification;
 import umc.GrowIT.Server.web.dto.GroDTO.GroRequestDTO;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
@@ -25,11 +28,18 @@ import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 @RequiredArgsConstructor
 @RequestMapping("/characters")
 public class GroController implements GroSpecification {
+    private final GroCommandService groCommandService;
 
     public ApiResponse<GroResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request) {
 
-        // Service를 통해 엔티티 생성
-        //Gro gro = groService.createGro(request);
-        return ApiResponse.onSuccess(null);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+        System.out.println(userId);
+        String name = request.getName();
+        String backgroundItem = request.getBackgroundItem();
+
+        // Service에서 반환된 DTO를 ApiResponse로 감싸서 리턴
+        GroResponseDTO responseDTO = groCommandService.createGro(userId, name, backgroundItem);
+        return ApiResponse.onSuccess(responseDTO);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -3,6 +3,8 @@ package umc.GrowIT.Server.web.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
@@ -31,13 +33,15 @@ public class UserController implements UserSpecification {
 
     @Override
     public ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit() {
-        Long userId = 13L; // 임시로 13L 송진우 사용
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
         return ApiResponse.onSuccess(creditQueryService.getCurrentCredit(userId));
     }
 
     @Override
     public ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit() {
-        Long userId = 13L; // 임시로 13L 송진우 사용
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
         return ApiResponse.onSuccess(creditQueryService.getTotalCredit(userId));
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.web.controller.specification;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -70,18 +71,21 @@ public interface ChallengeSpecification {
     })
     ApiResponse<ChallengeResponseDTO> updateChallengeProof(@PathVariable Long challengeId, @RequestBody ChallengeRequestDTO.UpdateRequestDTO updateRequest);
 
-    @DeleteMapping("{challengeId}")
+    @DeleteMapping("{userChallengeId}")
     @Operation(
-            summary = "챌린지 삭제 API",
-            description = "특정 챌린지를 삭제하는 API입니다. 챌린지 ID를 path variable로 전달받아 해당 챌린지를 삭제합니다."
+            summary = "사용자 챌린지 삭제 API",
+            description = "사용자의 특정 챌린지를 삭제하는 API입니다.<br>" +
+                    "사용자 챌린지 ID를 path variable로 전달받아 해당 사용자 챌린지를 삭제합니다.<br>" +
+                    "❗Request Header에 JWT Access Token 값을 넣어야 합니다.❗"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4002", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
 
     })
-    @Parameter(name = "challengeId", description = "삭제할 챌린지의 ID", required = true)
-    ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("challengeId") Long challengeId);
+    @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", required = true)
+    ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -55,7 +55,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public void deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                      @PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -55,7 +55,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+    public void deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                      @PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -55,7 +55,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    void deleteDiary(@PathVariable("diaryId") Long diaryId);
+    public ApiResponse<DiaryResponseDTO.DeleteResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                     @PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -63,7 +63,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.DiaryDTO request);
+    ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+                                                                    @RequestBody DiaryRequestDTO.DiaryDTO request);
 
     @PostMapping("/voice")
     @Operation(summary = "음성으로 일기 작성하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용과 작성일자를 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
@@ -1,6 +1,8 @@
 package umc.GrowIT.Server.web.controller.specification;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -14,7 +16,20 @@ public interface GroSpecification {
     @PostMapping("")
     @Operation(summary = "그로 캐릭터 생성", description = "사용자의 그로 캐릭터를 생성합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "COMMON200",
+                    description = "⭕ SUCCESS"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "GRO4001",
+                    description = "❌ 이미 사용 중인 닉네임입니다.",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "GRO4002",
+                    description = "❌ 닉네임은 2자에서 8자 사이여야 합니다.",
+                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
+            ),
     })
     ApiResponse<GroResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -50,7 +50,6 @@ public class DiaryResponseDTO {
     public static class CreateResultDTO{
         Long diaryId;
         String content;
-        LocalDate date;
     }
 
     @Builder

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -61,4 +61,12 @@ public class DiaryResponseDTO {
         Long diaryId;
         String content;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteResultDTO{
+        Long diaryId;
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -67,6 +67,6 @@ public class DiaryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DeleteResultDTO{
-        Long diaryId;
+        String message;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -50,6 +50,7 @@ public class DiaryResponseDTO {
     public static class CreateResultDTO{
         Long diaryId;
         String content;
+        LocalDate date;
     }
 
     @Builder

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
@@ -3,13 +3,22 @@ package umc.GrowIT.Server.web.dto.GroDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GroRequestDTO {
 
     @Schema(description = "성장할 그로의 이름(최대 50자)", example = "그로이름")
     @NotBlank(message = "name은 필수 입력 항목입니다.")
-    @Size(max = 50, message = "name은 최대 50자까지 입력 가능합니다.")
+    @Size(min = 2, max = 10, message = "2글자에서 20글자 사이로 입력해야합니다.")
     private String name;
+
+    @Schema(description = "배경아이템의 이름", example = "별")
+    private String backgroundItem;
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Builder
 public class GroResponseDTO {
 
+
+
     @Schema(description = "그로 id")
     private Long id;
 
@@ -20,9 +22,4 @@ public class GroResponseDTO {
     @Schema(description = "초기 레벨")
     private Integer level;
 
-    @Schema(description = "생성 시간")
-    private String created_at;
-
-    @Schema(description = "수정 시간")
-    private String updated_at;
 }


### PR DESCRIPTION
## 📝 작업 내용
> 일기를 삭제하는 API를 구현하였습니다.
> 테스트 전에 로그인한 유저의 일기가 있어야 합니다.
> + 서영님이 말씀해주신 일기 수정 API에서 save부분 삭제하였습니다!


## 🔍 테스트 방법
> 1. 현재 유저의 일기 목록
<img width="932" alt="image" src="https://github.com/user-attachments/assets/3b7bdcbe-590c-4995-939b-e2d967041bea" />

> 2. 일기 삭제
<img width="956" alt="image" src="https://github.com/user-attachments/assets/fcfcda2c-e383-4014-83aa-8a72ab92c767" />

> 3. 삭제 후 유저의 일기 목록
<img width="947" alt="image" src="https://github.com/user-attachments/assets/1647e7d8-02cf-4452-a7bc-c0660ea15253" />

> 4. 일기 ID가 존재하지 않는 경우
<img width="956" alt="image" src="https://github.com/user-attachments/assets/09a6dc6d-13d4-42f8-87e8-19cf248e0194" />

