### PR TITLE
[#100] Setting : 빌드실패 오류 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -4,7 +4,7 @@ name: GrowIt CI/CD Pipeline
 # 워크플로우 트리거 조건 설정
 on:
   push:
-    branches: [ bug/#100 ]  # develop 브랜치에 push가 발생할 때만 실행
+    branches: [ develop ]  # develop 브랜치에 push가 발생할 때만 실행
 
 # 실행할 작업들을 정의
 jobs:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build  # gradle build 명령 실행
+          arguments: build -x test  # 테스트 제외하고 빌드
 
 
       # 6. 빌드된 JAR 파일을 아티팩트로 업로드

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -4,7 +4,7 @@ name: GrowIt CI/CD Pipeline
 # 워크플로우 트리거 조건 설정
 on:
   push:
-    branches: [ develop ]  # develop 브랜치에 push가 발생할 때만 실행
+    branches: [ bug/#100 ]  # develop 브랜치에 push가 발생할 때만 실행
 
 # 실행할 작업들을 정의
 jobs:


### PR DESCRIPTION
## 📝 작업 내용
> 빌드실패 오류 수정
build.gradle파일에 빌드전 테스트를 수행하는 부분이 있는데 ci/cd과정에서는 생략하도록 수정했습니다.

```
      # 5. Gradle을 사용하여 프로젝트 빌드
      - name: Build with Gradle
        uses: gradle/gradle-build-action@v2
        with:
          arguments: build -x test  # 테스트 제외하고 빌드
```

## 🔍 테스트 방법
> 
## develop브랜치로 merge되었을 때 CI/CD 파이프라인이 작동합니다.

![image](https://github.com/user-attachments/assets/ab8af00b-cd20-4060-9ec5-67ae50a4ad74)
- 노랑 : 진행중
- 초록 : 성공
- 빨강 : 실패
