### PR TITLE
[#108] Refactor: JWT 토큰 발급 코드 리팩토링

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/TokenConverter.java
@@ -22,4 +22,11 @@ public class TokenConverter {
                 .build();
     }
 
+    public static UserResponseDTO.TokenDTO toTokenDTO(String accessToken, String refreshToken){
+        return UserResponseDTO.TokenDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📝 작업 내용
1. 기존 코드
- 회원가입, 로그인 API는 응답으로 AT,RT 데이터를 주기때문에 accessToken, refreshToken 을 한번에 발급하는 generateToken() 메소드가 있었습니다.
- 토큰 재발급은 accessToken 만 발급해서 generateAccessToken() 메소드를 만들었는데, 기존 generateToken() 메소드와 코드가 중복되는 문제 발생했습니다.

2. 리팩토링
- accessToken, refreshToken 을 각각 발급하는 generateAccessToken(), generateRefreshToken() 메소드와 accessToken과 refreshToken 을 함께 발급하는 generateToken() 메소드를 만들어 코드 중복을 막고 기능을 분리했습니다.


## 🔍 테스트 방법
스웨거를 통해 회원가입, 로그인, 토큰 재발급 시 토큰이 정상적으로 발급되는 것을 확인했습니다.
- 회원가입
<img width="1051" alt="스크린샷 2025-01-25 오후 8 10 22" src="https://github.com/user-attachments/assets/b9ecfc1d-7d13-47dd-a2d8-ad867eb00bea" />

- 로그인
<img width="1054" alt="스크린샷 2025-01-25 오후 8 10 43" src="https://github.com/user-attachments/assets/f793d13e-7340-4880-9751-89053a0e4083" />

- 토큰 재발급
<img width="1048" alt="스크린샷 2025-01-25 오후 8 10 39" src="https://github.com/user-attachments/assets/b18d8872-4065-474e-9407-cac4b5aa81c1" />
