### PR TITLE
[#105] Feat: 그로와 착용 아이템 이미지 조회 API 개발

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -55,6 +55,10 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM4002", "보유하지 않은 아이템입니다."),
     ITEM_OWNED(HttpStatus.BAD_REQUEST, "ITEM4003", "이미 보유 중인 아이템입니다."),
 
+    // 사용자 아이템 관련 에러
+    USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI4001", "사용자 아이템이 존재하지 않습니다."),
+    EQUIPPED_USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI4002", "착용 중인 사용자 아이템이 존재하지 않습니다."),
+
     //결제관련에러
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT4001", "결제정보가 정확하지 않습니다."),
 
@@ -68,6 +72,8 @@ public enum ErrorStatus implements BaseErrorCode {
     //그로관련
     GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO4001", "이미 사용 중인 닉네임입니다."),
     GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "Gro4002", "닉네임은 2글자에서 20글자 사이여야 합니다."),
+    GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO4003", "그로에 대한 정보가 존재하지 않습니다."),
+    GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO5001", "그로 레벨이 유효하지 않습니다."),
 
     //일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "존재하지 않는 일기입니다."),

--- a/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
@@ -1,14 +1,19 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Gro;
+import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class GroConverter {
 
 
-    public static GroResponseDTO toGroResponseDTO(Gro gro) {
-        return GroResponseDTO.builder()
+    public static GroResponseDTO.CreateResponseDTO toGroResponseDTO(Gro gro) {
+        return GroResponseDTO.CreateResponseDTO.builder()
                 .id(gro.getId())
                 .user_id(gro.getUser().getId())
                 .name(gro.getName())
@@ -22,6 +27,31 @@ public class GroConverter {
                 .user(user)
                 .name(name)
                 .level(1)
+                .build();
+    }
+
+    public static GroResponseDTO.GroAndEquippedItemsDTO toGroAndEquippedItemsDTO(Gro gro, String groImageUrl, Map<Item, String> itemUrls) {
+        // 1. GroDTO 생성
+        GroResponseDTO.GroDTO groDTO = GroResponseDTO.GroDTO.builder()
+                .id(gro.getId())
+                .level(gro.getLevel())
+                .groImageUrl(groImageUrl)
+                .build();
+
+        // 2. EquippedItemsDTO 리스트 생성
+        List<GroResponseDTO.EquippedItemsDTO> equippedItems = itemUrls.entrySet().stream()
+                .map(item -> GroResponseDTO.EquippedItemsDTO.builder()
+                        .id(item.getKey().getId())
+                        .name(item.getKey().getName())
+                        .category(item.getKey().getCategory())
+                        .itemImageUrl(item.getValue())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 3. GroAndEquippedItemsDTO 생성 후 반환
+        return GroResponseDTO.GroAndEquippedItemsDTO.builder()
+                .gro(groDTO)
+                .equippedItems(equippedItems)
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -18,7 +18,7 @@ public class ItemConverter {
                 .id(item.getId())
                 .name(item.getName())
                 .price(item.getPrice())
-                .imageUrl(item.getImageUrl())
+                .imageUrl(item.getImageKey())
                 .category(item.getCategory().toString())
                 .purchased(itemRepository.existsByUserItemsUserIdAndId(userId, item.getId()))
                 .build();

--- a/src/main/java/umc/GrowIT/Server/domain/Item.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Item.java
@@ -32,6 +32,9 @@ public class Item extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String imageKey;
+
     @OneToMany(mappedBy = "item")
     private List<UserItem> userItems;
 }

--- a/src/main/java/umc/GrowIT/Server/repository/GroRepository/GroRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/GroRepository/GroRepository.java
@@ -10,4 +10,6 @@ public interface GroRepository extends JpaRepository<Gro, Long> {
     Optional<Gro> findByName(String name);
 
     boolean existsByName(@Param("name")String nickname);
+
+    Optional<Gro> findByUserId(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
@@ -1,12 +1,17 @@
 package umc.GrowIT.Server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserItem;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserItemRepository extends JpaRepository<UserItem, Long>  {
     Optional<UserItem> findByUserAndItem(User user, Item item);
+
+    @Query("SELECT ui FROM UserItem ui JOIN FETCH ui.item WHERE ui.user.id = :userId")
+    List<UserItem> findAllWithItemsByUserId(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandService.java
@@ -3,5 +3,7 @@ package umc.GrowIT.Server.service.GroService;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 
 public interface GroCommandService {
-    public GroResponseDTO createGro(Long userId, String nickname, String backgroundItem);
+    public GroResponseDTO.CreateResponseDTO createGro(Long userId, String nickname, String backgroundItem);
+
+    GroResponseDTO.GroAndEquippedItemsDTO getGroAndEquippedItems(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -1,7 +1,11 @@
 package umc.GrowIT.Server.service.GroService;
 
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
@@ -14,27 +18,37 @@ import umc.GrowIT.Server.domain.Gro;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
 import umc.GrowIT.Server.repository.GroRepository.GroRepository;
 import umc.GrowIT.Server.repository.ItemRepository.ItemRepository;
 import umc.GrowIT.Server.repository.UserItemRepository;
 import umc.GrowIT.Server.repository.UserRepository;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GroCommandServiceImpl implements GroCommandService{
 
+    private final AmazonS3 amazonS3;
     private final GroRepository groRepository;
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final UserItemRepository userItemRepository;
 
+    @Value("${s3.bucket}")
+    private String bucketName;
+
     @Override
     @Transactional
-    public GroResponseDTO createGro(Long userId, String nickname, String backgroundItem) {
+    public GroResponseDTO.CreateResponseDTO createGro(Long userId, String nickname, String backgroundItem) {
         // 닉네임 체크
         checkNickname(nickname);
 
@@ -57,6 +71,7 @@ public class GroCommandServiceImpl implements GroCommandService{
         return GroConverter.toGroResponseDTO(savedGro);
     }
 
+
     @Transactional(readOnly = true)
     public void checkNickname(String nickname){
 
@@ -70,6 +85,90 @@ public class GroCommandServiceImpl implements GroCommandService{
         if (gro.isPresent()){
             throw new GroHandler(ErrorStatus.GRO_NICKNAME_ALREADY_EXISTS);
         }
+    }
 
+
+    @Override
+    public GroResponseDTO.GroAndEquippedItemsDTO getGroAndEquippedItems(Long userId) {
+        // 1. userId 조회하고 없으면 오류
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+
+        // 2. userId를 통해서 그로 조회하고 없으면 오류
+        Gro gro = groRepository.findByUserId(userId)
+                .orElseThrow(() -> new GroHandler(ErrorStatus.GRO_NOT_FOUND));
+
+
+        // 3. userId를 통해서 사용자 아이템 조회하고 없으면 오류
+        List<UserItem> userItems = userItemRepository.findAllWithItemsByUserId(userId);
+        if (userItems.isEmpty()) {
+            throw new ItemHandler(ErrorStatus.USER_ITEM_NOT_FOUND);
+        }
+
+
+        // 4. 사용자 아이템 중 착용한 것에 대해 필터링하고 없으면 오류
+        List<UserItem> equippedUserItems = userItems.stream()
+                .filter(userItem -> ItemStatus.EQUIPPED.equals(userItem.getStatus()))
+                .collect(Collectors.toList());
+        if (equippedUserItems.isEmpty()) {
+            throw new ItemHandler(ErrorStatus.EQUIPPED_USER_ITEM_NOT_FOUND);
+        }
+
+
+        // 5. 착용한 아이템을 이용하여 Item 접근
+        List<Item> equippedItems = equippedUserItems.stream()
+                .map(userItem -> userItem.getItem())
+                .collect(Collectors.toList());
+
+
+        // 6. 프리사인드 URL 생성
+        // 레벨에 맞는 이미지 선택하여 프리사인드 URL 생성
+        String groUrl = createGroPreSignedUrl(gro.getLevel());
+
+        // Item의 image_key값 얻어서 프리사인드 URL 생성
+        Map<Item, String> itemUrls = createItemPreSignedUrl(equippedItems);
+
+
+        // 7. converter 작업
+        return GroConverter.toGroAndEquippedItemsDTO(gro, groUrl, itemUrls);
+    }
+
+    // 레벨에 맞는 imageKey로 프리사인드 URL 생성
+    private String createGroPreSignedUrl(Integer groLevel) {
+        // 레벨에 따른 그로 이미지가 제작되지 않은 관계로 일단 레벨 1에 대해서만 설정
+        String imageKey = switch (groLevel) {
+            case 1 -> "Gro/그로_1.png";
+//            case 2 -> "Gro/그로_2.png";
+            default -> throw new GroHandler(ErrorStatus.GRO_LEVEL_INVALID);
+        };
+
+        // 프리사인드 URL 생성 (15분 유효 기간)
+        Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
+
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucketName, imageKey)
+                        .withMethod(HttpMethod.GET)
+                        .withExpiration(expiration);
+
+        return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+    }
+
+    // imageKey를 통해 S3 이미지 접근하여 프리사인드 URL 생성
+    private Map<Item, String> createItemPreSignedUrl(List<Item> equippedItems) {
+        return equippedItems.stream()
+                .collect(Collectors.toMap(
+                        item -> item, // key
+                        item -> { // value
+                            // 프리사인드 URL 생성 (15분 유효 기간)
+                            Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
+
+                            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, item.getImageKey())
+                                    .withMethod(HttpMethod.GET)
+                                    .withExpiration(expiration);
+
+                            return amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
+                        }
+                ));
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -144,7 +144,7 @@ public class GroCommandServiceImpl implements GroCommandService{
         };
 
         // 프리사인드 URL 생성 (15분 유효 기간)
-        Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
+        Date expiration = new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucketName, imageKey)
@@ -161,7 +161,7 @@ public class GroCommandServiceImpl implements GroCommandService{
                         item -> item, // key
                         item -> { // value
                             // 프리사인드 URL 생성 (15분 유효 기간)
-                            Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
+                            Date expiration = new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
 
                             GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, item.getImageKey())
                                     .withMethod(HttpMethod.GET)

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -43,7 +43,7 @@ public class GroCommandServiceImpl implements GroCommandService{
     private final ItemRepository itemRepository;
     private final UserItemRepository userItemRepository;
 
-    @Value("${s3.bucket}")
+    @Value("${aws.s3.bucket}")
     private String bucketName;
 
     @Override
@@ -144,7 +144,7 @@ public class GroCommandServiceImpl implements GroCommandService{
         };
 
         // 프리사인드 URL 생성 (15분 유효 기간)
-        Date expiration = new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
+        Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucketName, imageKey)
@@ -161,7 +161,7 @@ public class GroCommandServiceImpl implements GroCommandService{
                         item -> item, // key
                         item -> { // value
                             // 프리사인드 URL 생성 (15분 유효 기간)
-                            Date expiration = new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1));
+                            Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
 
                             GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, item.getImageKey())
                                     .withMethod(HttpMethod.GET)

--- a/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,10 +13,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.service.GroService.GroCommandService;
 import umc.GrowIT.Server.web.controller.specification.GroSpecification;
@@ -30,7 +26,7 @@ import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 public class GroController implements GroSpecification {
     private final GroCommandService groCommandService;
 
-    public ApiResponse<GroResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request) {
+    public ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
@@ -39,7 +35,20 @@ public class GroController implements GroSpecification {
         String backgroundItem = request.getBackgroundItem();
 
         // Service에서 반환된 DTO를 ApiResponse로 감싸서 리턴
-        GroResponseDTO responseDTO = groCommandService.createGro(userId, name, backgroundItem);
+        GroResponseDTO.CreateResponseDTO responseDTO = groCommandService.createGro(userId, name, backgroundItem);
         return ApiResponse.onSuccess(responseDTO);
     }
+
+    @Override
+    @GetMapping("")
+    public ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems() {
+        //AccessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        GroResponseDTO.GroAndEquippedItemsDTO result = groCommandService.getGroAndEquippedItems(userId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
@@ -1,13 +1,18 @@
 package umc.GrowIT.Server.web.controller.specification;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.GroDTO.GroRequestDTO;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 
@@ -31,5 +36,23 @@ public interface GroSpecification {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))
             ),
     })
-    ApiResponse<GroResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request);
+    ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@Valid @RequestBody GroRequestDTO request);
+
+    @GetMapping("")
+    @Operation(
+            summary = "그로와 착용 아이템 이미지 조회 API",
+            description = "그로와 착용한 아이템 목록의 이미지 URL들을 조회하는 API입니다.<br>" +
+                    "❗Request Header에 JWT Access Token 값을 넣어야 합니다.❗"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4003", description = "❌ 그로에 대한 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UI4001", description = "❌ 사용자 아이템이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UI4002", description = "❌ 착용 중인 사용자 아이템이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO5001", description = "❌ 그로 레벨이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+
+    })
+    ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems();
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
@@ -1,25 +1,64 @@
 package umc.GrowIT.Server.web.dto.GroDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
+
+import java.util.List;
 
 @Getter
 @Builder
 public class GroResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateResponseDTO {
+        @Schema(description = "그로 id")
+        private Long id;
+
+        @Schema(description = "사용자 id")
+        private Long user_id;
+
+        @Schema(description = "사용자가 입력한 그로의 이름")
+        private String name;
+
+        @Schema(description = "초기 레벨")
+        private Integer level;
+    }
 
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroAndEquippedItemsDTO {
+        private GroDTO gro;
+        private List<EquippedItemsDTO> equippedItems;
+    }
 
-    @Schema(description = "그로 id")
-    private Long id;
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroDTO {
+        private Long id; // 그로 ID
+        private Integer level; // 그로 ID
+        private String groImageUrl; // 그로 이미지 URL
+    }
 
-    @Schema(description = "사용자 id")
-    private Long user_id;
-
-    @Schema(description = "사용자가 입력한 그로의 이름")
-    private String name;
-
-    @Schema(description = "초기 레벨")
-    private Integer level;
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EquippedItemsDTO {
+        private Long id; // 아이템 ID
+        private String name; // 아이템 이름
+        private ItemCategory category; // 아이템 이름
+        private String itemImageUrl; // 아이템 이미지 URL
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 홈화면과 아이템샵에서 사용할 그로 이미지와 착용한 아이템들 이미지들을 조회하는 API입니다.
> 
> 진행 단계는 다음과 같습니다.
> 스프링부트에서 사용자의 그로 레벨을 판단 + 착용시켜 놓은 아이템들을 조회
> -> S3 key값을(그로의 경우에 하드코딩 / 아이템의 경우 DB 조회) 통해 해당 이미지들에 접근할 수 있는 Pre-Signed URL을 발급
> -> 프론트엔드에 반환
> 
> 여기에서 객체 URL이 아닌 Pre-Signed URL을 사용하였습니다.
> Pre-Signed URL은 만료기간이 존재하는 S3 임시 접근 URL이라고 이해하면 될 것 같습니다.
> 이미지 업로드의 경우에 가장 효율적이지만, 이미지 불러오기의 경우에도 보안 측면에서 좋을 것이라 판단하여 사용하였습니다.
> 
> 홈화면으로 이동 or 아이템샵으로 이동할 때마다 URL을 새로 발급받아 해당 URL로 접근한다면 만료된 URL에 대해서 재접근하여 이미지를 못 얻는 일은 없을 것이라 생각합니다. 일단, 유효기간을 1일로 설정해 두었지만 이후 분 단위로 짧게 변경할 것 같습니다.
> 
> 개념에 대해서는 아래 자료에서 간단하게 확인해주세요
> https://inpa.tistory.com/entry/AWS-%F0%9F%93%9A-S3-Pre-signed-URL-%EA%B3%B5%EC%9C%A0%ED%95%98%EA%B8%B0


## 🔍 테스트 방법
> 1. JWT 토큰 연동한 상태에서 해당 API를 실행하면 아래와 같은 결과를 얻을 수 있습니다.
> ![image](https://github.com/user-attachments/assets/8ab295b0-69bb-482c-8019-1c31dabfcde9)
>
> 2. 해당 URL로 접근하면 이미지 확인이 가능합니다.
> ![image](https://github.com/user-attachments/assets/9ca70277-352a-4b6b-9cdb-672af3ec8c92)
>
> 3. 유효기간이 만료된 상태에서 해당 URL로 다시 접근하면 다음과 같은 창이 뜨게 됩니다.
> ![image](https://github.com/user-attachments/assets/7184af33-4569-48e9-bea9-1b50e426de4c)