### PR TITLE
[#101] Feat: 일기 생성(수정 시) 날짜,글자 수 검사 기능 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -79,6 +79,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "존재하지 않는 일기입니다."),
     DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY4002", "100자 이내로 작성된 일기입니다."),
+    DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY4003", "해당날짜에 이미 일기가 존재합니다."),
 
     // s3 관련 에러
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S3_4001", "파일 확장자가 잘못되었습니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -68,6 +68,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 날짜 관련 에러
     DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE4001", "유효하지 않은 날짜입니다."),
+    DATE_IS_AFTER(HttpStatus.BAD_REQUEST, "DATE4002", "날짜는 오늘 이후로 설정할 수 없습니다."),
 
     //그로관련
     GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO4001", "이미 사용 중인 닉네임입니다."),

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import umc.GrowIT.Server.domain.common.BaseEntity;
 
@@ -23,7 +24,7 @@ public class Diary extends BaseEntity {
     private LocalDate date;
 
     @Lob // 필드를 TEXT로 매핑
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
@@ -7,6 +7,7 @@ import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
                                             @Param("month") Integer month);
 
     Optional<Diary> findByUserIdAndId(Long userId, Long diaryId);
+
+    boolean existsByUserIdAndDate(Long userId, LocalDate date);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -29,7 +29,11 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
-        //Todo: 수정한 일기의 내용이 100자 이내인지 검사하는 로직 추가 필요(원활한 테스트를 위해 나중에 추가)
+        //일기 내용이 100자 이상인지 검사
+        if(request.getContent().length()<100){
+            throw new UserHandler(ErrorStatus.DIARY_CHARACTER_LIMIT);
+        }
+
         diary.setContent(request.getContent());
 
         diaryRepository.save(diary);
@@ -42,7 +46,15 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         //유저 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        //Todo: request의 content가 100자 이내인지 검사하는 로직 추가
+        //일기 내용이 100자 이상인지 검사
+        if(request.getContent().length()<100){
+            throw new DiaryHandler(ErrorStatus.DIARY_CHARACTER_LIMIT);
+        }
+
+        //날짜 검사(오늘 이후의 날짜 x)
+        if (request.getDate().isAfter(LocalDate.now())) {
+            throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);
+        }
 
         //일기 생성
         Diary diary = Diary.builder()

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -56,6 +56,11 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
             throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);
         }
 
+        //날짜 검사(이미 해당 날짜에 작성된 일기가 존재)
+        if(diaryRepository.existsByUserIdAndDate(userId, request.getDate())){
+            throw new DiaryHandler(ErrorStatus.DIARY_ALREADY_EXISTS);
+        }
+
         //일기 생성
         Diary diary = Diary.builder()
                 .content(request.getContent())

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -62,7 +62,8 @@ public interface DiarySpecification {
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4002",description = "날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.CreateResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                     @RequestBody DiaryRequestDTO.DiaryDTO request);


### PR DESCRIPTION
## 📝 작업 내용
> ### 확인해주셔야할 내용들 입니다!
> 일기 생성 시 -> 날짜 검사, 글자 수 검사 기능 추가
> 날짜검사: 오늘 이후의 날짜 x, 해당 날짜에 이미 일기가 존재하는 지 확인
> 일기 수정 시  -> 글자 수 검사 기능 추가
> - 해당 기능을 추가함으로 오늘 이전의 날짜에만 일기를 작성(100자 이상)할 수 있고 같은 날에 두 개 이상의 일기가 작성불가합니다. 


## 🔍 테스트 방법
> 1. 현재 EC2 문제로 로컬 DB에서 테스트 하였습니다.
> 1-1. Diary 테이블의 content가 VARCHAR에서 TEXT형으로 변경되어야 합니다.
> 2. 로그인 후 테스트 진행
> 3. 생성 시
> 3-1. 100자 이내로 작성 후 생성 요청 시
<img width="794" alt="image" src="https://github.com/user-attachments/assets/e19196f0-34c8-484e-a2ff-271a36f679f7" />

> 3-2. 오늘 이후의 날짜와 함께 생성 요청 시(PR작성일: 2025-01-27)
<img width="794" alt="image" src="https://github.com/user-attachments/assets/a4b71ac1-0371-493e-b34c-556df3314fe4" />

> 3-3. 이미 해당 날짜에 일기가 존재할 때 생성 요청 시
<img width="845" alt="image" src="https://github.com/user-attachments/assets/216ecbec-a6fb-4f76-8b8d-9d137d765434" />

> 4. 수정 시
> 4-1. 100자 이내로 수정 후 수정 요청 시
<img width="704" alt="image" src="https://github.com/user-attachments/assets/7f631ed4-5699-4a3e-9434-a7c32792e1f7" />

