### PR TITLE
[#122] Feat : 상점 아이템 조회/보유중인 아이템 조회 api 관련코드 수정 및 요구사항 반영

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -14,6 +14,8 @@ public class ItemConverter {
 
     //아이템 1개 반환
     public static ItemResponseDTO.ItemDTO toItemDTO(Item item, Long userId, ItemRepository itemRepository) {
+        ItemStatus status = itemRepository.findStatusByUserIdAndItemId(userId, item.getId());
+
         return ItemResponseDTO.ItemDTO.builder()
                 .id(item.getId())
                 .name(item.getName())
@@ -21,6 +23,7 @@ public class ItemConverter {
                 .imageUrl(item.getImageUrl())
                 .shopBackgroundColor(item.getShopBackgroundColor())
                 .category(item.getCategory().toString())
+                .status(status != null ? status.toString() : null) //status가 null일 경우(보유하지않은 경우) >> 기본값 null로 설정
                 .purchased(itemRepository.existsByUserItemsUserIdAndId(userId, item.getId()))
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -12,19 +12,20 @@ import java.util.stream.Collectors;
 
 public class ItemConverter {
 
-    //미션 1개 반환
+    //아이템 1개 반환
     public static ItemResponseDTO.ItemDTO toItemDTO(Item item, Long userId, ItemRepository itemRepository) {
         return ItemResponseDTO.ItemDTO.builder()
                 .id(item.getId())
                 .name(item.getName())
                 .price(item.getPrice())
-                .imageUrl(item.getImageKey())
+                .imageUrl(item.getImageUrl())
+                .shopBackgroundColor(item.getShopBackgroundColor())
                 .category(item.getCategory().toString())
                 .purchased(itemRepository.existsByUserItemsUserIdAndId(userId, item.getId()))
                 .build();
     }
 
-    //미션리스트 반환
+    //아이템리스트 반환
     public static ItemResponseDTO.ItemListDTO toItemListDTO(List<Item> itemList, Long userId, ItemRepository itemRepository) {
         return ItemResponseDTO.ItemListDTO.builder()
                 .itemList(itemList.stream()

--- a/src/main/java/umc/GrowIT/Server/domain/Item.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Item.java
@@ -29,6 +29,9 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private ItemCategory category;
 
+    @Column(nullable = false)
+    private String shopBackgroundColor;
+
     @Column(nullable = false, columnDefinition = "TEXT")
     private String imageUrl;
 

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
@@ -1,10 +1,13 @@
 package umc.GrowIT.Server.repository.ItemRepository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
+import umc.GrowIT.Server.domain.enums.ItemStatus;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
@@ -14,4 +17,12 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);
 
     Optional<Item> findByName(String name);
+
+    //사용자가 보유한 아이템만 조회
+    @Query("SELECT ui.item FROM UserItem ui WHERE ui.user.id = :userId AND ui.item.category = :category")
+    List<Item> findItemsByUserIdAndCategory(Long userId, ItemCategory category);
+
+    //현재 사용자가 보유중인 아이템의 status만 조회
+    @Query("SELECT ui.status FROM UserItem ui WHERE ui.user.id = :userId AND ui.item.id = :itemId")
+    ItemStatus findStatusByUserIdAndItemId(Long userId, Long itemId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryService.java
@@ -5,4 +5,6 @@ import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 
 public interface ItemQueryService {
     public ItemResponseDTO.ItemListDTO getItemList(ItemCategory category, Long userId);
+
+    public ItemResponseDTO.ItemListDTO getUserOwnedItemList(ItemCategory category, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryServiceImpl.java
@@ -25,4 +25,9 @@ public class ItemQueryServiceImpl implements ItemQueryService {
     }
 
 
+    // 사용자가 보유한 아이템만 조회하는 메서드
+    public ItemResponseDTO.ItemListDTO getUserOwnedItemList(ItemCategory category, Long userId) {
+        List<Item> userItems = itemRepository.findItemsByUserIdAndCategory(userId, category);
+        return ItemConverter.toItemListDTO(userItems, userId, itemRepository);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -3,6 +3,8 @@ package umc.GrowIT.Server.web.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
@@ -23,8 +25,11 @@ public class ItemController implements ItemSpecification {
 
     @Override
     public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(ItemCategory category) {
-        return ApiResponse.onSuccess(itemQueryServiceImpl.getItemList(category, 13L));
-        //우선 id가 13인 사용자로 하드코딩하고 후에 사용자 토큰을 통해 사용자 판변하여 userId 전달
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+
+        return ApiResponse.onSuccess(itemQueryServiceImpl.getItemList(category, userId));
+
     }
 
     @Override
@@ -34,8 +39,8 @@ public class ItemController implements ItemSpecification {
 
     @Override
     public ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(Long itemId) {
-        // 임시로 사용자 ID 지정
-        Long userId = 17L;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
 
         ItemResponseDTO.PurchaseItemResponseDTO purchasedItem = itemCommandService.purchase(itemId, userId);
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.service.CreditService.CreditQueryServiceImpl;
+import umc.GrowIT.Server.service.ItemService.ItemQueryServiceImpl;
 import umc.GrowIT.Server.service.authService.UserCommandService;
 import umc.GrowIT.Server.web.controller.specification.UserSpecification;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
@@ -25,10 +26,15 @@ public class UserController implements UserSpecification {
 
     private final CreditQueryServiceImpl creditQueryService;
     private final UserCommandService userCommandService;
+    private final ItemQueryServiceImpl itemQueryServiceImpl;
 
     @Override
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(ItemCategory category) {
-        return ApiResponse.onSuccess(null);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+
+
+        return ApiResponse.onSuccess(itemQueryServiceImpl.getUserOwnedItemList(category, userId));
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroRequestDTO.java
@@ -19,6 +19,6 @@ public class GroRequestDTO {
     @Size(min = 2, max = 10, message = "2글자에서 20글자 사이로 입력해야합니다.")
     private String name;
 
-    @Schema(description = "배경아이템의 이름", example = "별")
+    @Schema(description = "배경아이템의 이름", example = "별 배경화면 / 하트 배경화면 / 나무 배경화면")
     private String backgroundItem;
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
@@ -36,6 +36,9 @@ public class ItemResponseDTO {
         @Schema(description = "이미지 URL")
         String imageUrl;
 
+        @Schema(description = "상점에서 사용될 경우 배경색")
+        String shopBackgroundColor;
+
         @Schema(description = "아이템 카테고리", allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"})
         String category;
 
@@ -44,6 +47,8 @@ public class ItemResponseDTO {
 
         @Schema(description = "구매 여부", example = "false")
         boolean purchased;
+
+
     }
 
     // 아이템 주문 응답 DTO


### PR DESCRIPTION
## 📝 작업 내용
- 상점에서 아이템마다의 배경색 설정을 위해 ItemDTO에 backgroundColor를 추가
- item 도메인에 background필드를 추가
- responseBody의 "imageUrl"에 image_key가 전달되는 문제 해결
- userController 하드코딩부분 userId를 사용하도록 수정
- ItemConverter에서 status(착용여부) 누락오류 수정


## 🔍 테스트 방법
- 그로 생성 api 명세서 예시값 추가
![스크린샷 2025-01-29 185248](https://github.com/user-attachments/assets/dcfc6782-8067-4683-b1ec-e00f765d70a9)
- 카테고리별 아이템 조회
![image](https://github.com/user-attachments/assets/550d42c7-80f1-41db-8201-b996839326da)
- 보유중인 아이템만 조회
![image](https://github.com/user-attachments/assets/5e531979-40ad-43b5-b024-e578facb49cd)