### PR TITLE
[#124] Bug: 탈퇴 회원 처리 (토큰 인증 필터 및 API 수정)

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/ErrorReasonDTO.java
@@ -1,5 +1,7 @@
 package umc.GrowIT.Server.apiPayload.code;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -7,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Builder
 public class ErrorReasonDTO {
-
+    @JsonIgnore
     private HttpStatus httpStatus;
 
     private final boolean isSuccess;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -20,7 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호 확인이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER4002", "이메일 또는 패스워드가 일치하지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다."),
-    USER_STATUS_INACTIVE(HttpStatus.UNAUTHORIZED, "USER4004", "탈퇴한 회원입니다."),
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER4004", "탈퇴한 회원입니다."),
 
     //사용자 챌린지 관련 에러
     USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC4001", "사용자 챌린지가 존재하지 않습니다"),
@@ -40,6 +40,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "AUTH4006", "이메일 인증 타입이 잘못되었습니다."),
     AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4007", "유효한 인증번호가 없습니다."),
     AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH4008", "인증번호가 올바르지 않습니다."),
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4009", "토큰이 존재하지 않습니다."),
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "이메일 전송에 실패했습니다."),
     EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "이메일 내용 인코딩에 실패했습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4007", "데이터베이스에서 refreshToken을 찾을 수 없습니다."),

--- a/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
@@ -10,9 +10,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import umc.GrowIT.Server.apiPayload.exception.CustomAuthenticationEntryPoint;
-import umc.GrowIT.Server.filter.JwtAuthenticationFilter;
-import umc.GrowIT.Server.service.authService.CustomUserDetailsService;
+import umc.GrowIT.Server.jwt.CustomAuthenticationEntryPoint;
+import umc.GrowIT.Server.jwt.JwtAuthenticationFilter;
+import umc.GrowIT.Server.jwt.CustomUserDetailsService;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/umc/GrowIT/Server/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/CustomAuthenticationEntryPoint.java
@@ -1,31 +1,33 @@
-package umc.GrowIT.Server.apiPayload.exception;
+package umc.GrowIT.Server.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import umc.GrowIT.Server.apiPayload.code.ErrorReasonDTO;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ErrorStatus errorStatus = (ErrorStatus) request.getAttribute("errorStatus");
+        ErrorReasonDTO errorReasonDTO = errorStatus.getReasonHttpStatus();
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(errorReasonDTO.getHttpStatus().value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        response.getWriter().write(new ObjectMapper().writeValueAsString(new LinkedHashMap<String, Object>() {{
-            put("isSuccess", false);
-            put("code", "AUTH401");
-            put("message", "토큰이 유효하지 않습니다.");
-        }}));
+        response.getWriter().write(objectMapper.writeValueAsString(errorReasonDTO));
     }
 }

--- a/src/main/java/umc/GrowIT/Server/jwt/CustomUserDetails.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/CustomUserDetails.java
@@ -1,9 +1,6 @@
-package umc.GrowIT.Server.domain;
+package umc.GrowIT.Server.jwt;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import umc.GrowIT.Server.domain.enums.UserStatus;
@@ -13,11 +10,9 @@ import java.util.Collection;
 @Getter
 public class CustomUserDetails extends User{
     private final Long id;
-    private final UserStatus status;
 
-    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, Long id, UserStatus status) {
+    public CustomUserDetails(String username, String password, Collection<? extends GrantedAuthority> authorities, Long id) {
         super(username, password, authorities);
         this.id = id;
-        this.status = status;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/jwt/CustomUserDetailsService.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/CustomUserDetailsService.java
@@ -1,20 +1,15 @@
-package umc.GrowIT.Server.service.authService;
+package umc.GrowIT.Server.jwt;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.GrowIT.Server.domain.CustomUserDetails;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.repository.UserRepository;
 
 import java.util.Collections;
-
-import static umc.GrowIT.Server.domain.enums.UserStatus.ACTIVE;
 
 @Service
 @RequiredArgsConstructor
@@ -33,8 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 user.getEmail(),
                 user.getPassword(),
                 Collections.singletonList(new SimpleGrantedAuthority(String.valueOf(user.getRole()))),
-                user.getId(),
-                user.getStatus()
+                user.getId()
         );
 
 

--- a/src/main/java/umc/GrowIT/Server/jwt/JwtAuthenticationException.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/JwtAuthenticationException.java
@@ -1,0 +1,16 @@
+package umc.GrowIT.Server.jwt;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+
+    private final ErrorStatus errorStatus;
+
+    public JwtAuthenticationException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/GrowIT/Server/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.filter;
+package umc.GrowIT.Server.jwt;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.security.core.Authentication;
@@ -10,9 +10,10 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import umc.GrowIT.Server.jwt.JwtTokenUtil;
 
 import java.io.IOException;
+
+import static umc.GrowIT.Server.apiPayload.code.status.ErrorStatus.*;
 
 @Component
 @RequiredArgsConstructor
@@ -27,13 +28,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = resolveToken(request); //Authorization 헤더에서 토큰 추출
 
-            if (token != null && jwtTokenUtil.validateToken(token)) {
+            if (token == null) {
+                throw new JwtAuthenticationException(MISSING_TOKEN);
+            }
+
+            if (jwtTokenUtil.validateToken(token)) { //토큰이 제공되고, 토큰 자체가 유효한지 확인
+                if (jwtTokenUtil.isUserInactive(token)) //토큰에서 사용자 정보 읽어서 탈퇴한 회원인지 확인
+                    throw new JwtAuthenticationException(USER_STATUS_INACTIVE);
                 Authentication authentication = jwtTokenUtil.getAuthentication(token); //토큰에서 사용자 정보 추출
                 SecurityContextHolder.getContext().setAuthentication(authentication); //SecurityContext 에 사용자 정보 저장
             }
 
         } catch (ExpiredJwtException e) {
-            //CustomAuthenticationEntryPoint 에서 처리
+            request.setAttribute("errorStatus", EXPIRED_TOKEN); //CustomAuthenticationEntryPoint 에서 처리
+        } catch (JwtAuthenticationException e) {
+            request.setAttribute("errorStatus", e.getErrorStatus());
         }
 
         filterChain.doFilter(request, response); //다음 필터로 요청 전달

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
@@ -28,6 +28,8 @@ import java.time.LocalDateTime;
 
 import org.springframework.beans.factory.annotation.Value;
 
+import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
+
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
@@ -82,10 +84,12 @@ public class AuthServiceImpl implements AuthService {
             if (user != null) {
                 throw new UserHandler(ErrorStatus.EMAIL_ALREADY_EXISTS);
             }
-        } else if (type == AuthType.PASSWORD_RESET) { //비밀번호 변경 (이메일이 존재해야 함)
+        } else if (type == AuthType.PASSWORD_RESET) { //비밀번호 변경 (이메일이 존재해야 함, 탈퇴하지 않은 회원이어야 함)
             if (user == null) {
                 throw new UserHandler(ErrorStatus.USER_NOT_FOUND);
             }
+            if (user.getStatus() == INACTIVE)
+                throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
         } else { //type이 잘못됨
             throw new AuthHandler(ErrorStatus.INVALID_AUTH_TYPE);
         }

--- a/src/main/java/umc/GrowIT/Server/service/kakaoService/KakaoService.java
+++ b/src/main/java/umc/GrowIT/Server/service/kakaoService/KakaoService.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.service.authService;
+package umc.GrowIT.Server.service.kakaoService;
 
 import umc.GrowIT.Server.web.dto.UserDTO.KakaoResponseDTO;
 

--- a/src/main/java/umc/GrowIT/Server/service/kakaoService/KakaoServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/kakaoService/KakaoServiceImpl.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.service.authService;
+package umc.GrowIT.Server.service.kakaoService;
 
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.web.dto.UserDTO.KakaoResponseDTO;

--- a/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
@@ -7,21 +7,21 @@ import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.AuthHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.TokenConverter;
-import umc.GrowIT.Server.domain.CustomUserDetails;
+import umc.GrowIT.Server.jwt.CustomUserDetails;
 import umc.GrowIT.Server.domain.RefreshToken;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.jwt.JwtTokenUtil;
 import umc.GrowIT.Server.repository.RefreshTokenRepository;
-import umc.GrowIT.Server.service.authService.CustomUserDetailsService;
+import umc.GrowIT.Server.jwt.CustomUserDetailsService;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
-import java.util.Optional;
 
 import static umc.GrowIT.Server.converter.TokenConverter.toAccessTokenDTO;
+import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +47,9 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
     public UserResponseDTO.AccessTokenDTO reissueToken(UserRequestDTO.ReissueDTO reissueDTO) {
         RefreshToken storedRefreshToken = refreshTokenRepository.findByRefreshToken(reissueDTO.getRefreshToken()) //요청한 refresh token 이 database 에 존재하는지 확인
                 .orElseThrow(() -> new AuthHandler(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
+
+        if (storedRefreshToken.getUser().getStatus() == INACTIVE)   //탈퇴한 회원은 accessToken 재발급 하지 않음
+            throw new UserHandler(ErrorStatus.USER_STATUS_INACTIVE);
 
         if (storedRefreshToken.getExpiryDate().isBefore(LocalDateTime.now())) { //refresh token 이 만료되었는지 확인
             storedRefreshToken.getUser().deleteRefreshToken();

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.service.authService;
+package umc.GrowIT.Server.service.userService;
 
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.service.userService;
+
+public interface UserQueryService {
+    boolean isUserInactive(Long userId);
+}

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package umc.GrowIT.Server.service.userService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.repository.UserRepository;
+
+import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    public boolean isUserInactive(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return user.getStatus() == INACTIVE;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.service.authService.AuthService;
-import umc.GrowIT.Server.service.authService.UserCommandService;
+import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.service.refreshTokenService.RefreshTokenCommandService;
 import umc.GrowIT.Server.web.controller.specification.AuthSpecification;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -10,7 +10,7 @@ import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.service.CreditService.CreditQueryServiceImpl;
 import umc.GrowIT.Server.service.ItemService.ItemQueryServiceImpl;
-import umc.GrowIT.Server.service.authService.UserCommandService;
+import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.web.controller.specification.UserSpecification;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;


### PR DESCRIPTION
## 📝 작업 내용
1. 회원탈퇴를 했는데도 accessToken 으로 인증 필터를 거치는 API 에 대해 요청 가능한 경우 (유효기간 남아서)
2. 회원탈퇴를 했는데도 인증 필터를 거치지 않는 API 에 대해 요청 가능한 경우

위와 같은 경우가 생겨서 코드를 업데이트 했습니다.

1번 해결 방법
- accessToken 에서 userId 값을 읽어온 후, userId 값으로 DB에서 user를 조회
- 유저의 상태값(ACTIVE, INACTIVE) 를 확인 후 INACTIVE 인 경우 예외처리를 했습니다.

2번 해결 방법 (accessToken 이 필요하지 않은 로그인, 인증번호 보내기(비밀번호 찾기를 위한), 토큰 재발급 API)
- 각각의 API 에서 유저의 상태값(ACTIVE, INACTIVE) 를 확인 후 INACTIVE 인 경우 예외처리를 했습니다.
-> 이 경우 서비스 단에서 "유저 상태값 확인 및 예외처리하는 코드"가 중복돼서 추후에 리팩토링 고려하겠습니다.


+) 추가 / 여담
- 기존 코드에서 토큰에 userStatus 값 넣어서 비교하려고 했는데 이 부분은 회원탈퇴 후 기존 accessToken 에는 userStatus 값이 ACTIVE 로 저장되어 있기 때문에 응답이 적절하지 않게 나와서 토큰에 userStatus 값 넣지 않고 DB 에 직접 접근해서 비교하는 방식으로 바꿨습니다.
- DB 에 직접 접근해서 비교하는 방식은 구현이 간단하지만 JWT 토큰의 Stateless 방식에 맞지 않는 다는 단점이 존재합니다. 따라서 추후에 Redis 를 사용해 블랙리스트에 accessToken 을 저장해서 accessToken 을 무효화하는 방식을 도입하여 성능을 개선하고자 합니다.

+) 질문
- 패키지 구조를 조금 변경했습니다. jwt 패키지에 관련 파일을 모두 모아놨는데 이전 패키지 구조가 나을지 의견 부탁드립니다. 



## 🔍 테스트 방법
1번 경우에 대한 테스트 결과
<img width="1051" alt="스크린샷 2025-01-30 오후 6 29 02" src="https://github.com/user-attachments/assets/a169cbd8-1115-49af-9bb0-fb78da80950f" />

2번 경우에 대한 테스트 결과
-토큰 재발급
<img width="1051" alt="스크린샷 2025-01-30 오후 6 29 14" src="https://github.com/user-attachments/assets/7ffb62c6-e74f-4d29-a85f-9b324ccf917b" />
-이메일 로그인
<img width="1044" alt="스크린샷 2025-01-30 오후 6 30 04" src="https://github.com/user-attachments/assets/06f368bc-e6e0-47b5-9eba-b6669888abe7" />
-비밀번호 변경을 위한 인증 메일 전송
<img width="1049" alt="스크린샷 2025-01-30 오후 6 51 30" src="https://github.com/user-attachments/assets/33fe81bc-55af-481b-8ff2-fa6c50d2e1a4" />

