### PR TITLE
[#127] Refactor: 그로 이미지 key값 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -138,7 +138,7 @@ public class GroCommandServiceImpl implements GroCommandService{
     private String createGroPreSignedUrl(Integer groLevel) {
         // 레벨에 따른 그로 이미지가 제작되지 않은 관계로 일단 레벨 1에 대해서만 설정
         String imageKey = switch (groLevel) {
-            case 1 -> "Gro/그로_1.png";
+            case 1 -> "gro/gro_head.png";
 //            case 2 -> "Gro/그로_2.png";
             default -> throw new GroHandler(ErrorStatus.GRO_LEVEL_INVALID);
         };


### PR DESCRIPTION
## 📝 작업 내용
> S3에서 폴더명/파일명이 변경됨에 따라, 하드코딩되어 있던 그로 이미지 키값을 수정하였습니다.
> 프론트엔드 연동을 고려하여 하드코딩 방식 자체는 유지한 채로 오류만 급히 수정하였습니다.
> 초기 ERD 설계 형태를 따르다보니 하드코딩 방식을 사용하였습니다만 추후에 그로 이미지의 경로도 DB에서 관리하는 방향으로 리팩토링하는 것이 낫지 않을까 합니다. 


## 🔍 테스트 방법
> 1. 로직 자체는 수정하지 않아서 실행에 이상 없습니다.
> 2. 참고로 관련 API는 '그로와 착용 아이템 이미지 조회 API'입니다.