### PR TITLE
[#130] Feat: 일기 수정 API 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -83,6 +83,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "존재하지 않는 일기입니다."),
     DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY4002", "100자 이내로 작성된 일기입니다."),
     DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY4003", "해당날짜에 이미 일기가 존재합니다."),
+    DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY4004", "기존 일기와 동일한 내용입니다."),
 
     // s3 관련 에러
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S3_4001", "파일 확장자가 잘못되었습니다."),

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -27,9 +27,9 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
-        //일기 내용이 100자 이상인지 검사
-        if(request.getContent().length()<100){
-            throw new UserHandler(ErrorStatus.DIARY_CHARACTER_LIMIT);
+        //기존의 내용과 변경되지 않았을 경우
+        if(diary.getContent().equals(request.getContent())){
+            throw new DiaryHandler(ErrorStatus.DIARY_SAME_CONTENT);
         }
 
         diary.setContent(request.getContent());

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -44,7 +44,7 @@ public interface DiarySpecification {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004",description = "기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
                                                                           @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);


### PR DESCRIPTION
## 📝 작업 내용
> 1. 일기 수정 시 100자 제한이 없다고하여 해당 내용 반영
> 2. 기존 내용과 동일한 내용으로 수정 요청 시 에러코드 추가


## 🔍 테스트 방법
> 1. 유저의 현재 일기 목록
<img width="698" alt="image" src="https://github.com/user-attachments/assets/107a6782-f729-4b5f-962d-d08ed7840dd1" />

> 2. id가 8인 일기 변경 시
<img width="704" alt="image" src="https://github.com/user-attachments/assets/6db3c39f-971d-49f8-a95b-e193f16fa648" />

> 3. 동일한 내용으로 수정 시(2번 내용과 동일하게 한번 더 요청하면 됩니다.)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/e920e5b0-0df7-453b-8796-5e5e5b89fd8b" />
