### PR TITLE
[#144] Refactor: 챌린지 현황 조회 메서드 및 쿼리문 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -14,15 +14,23 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     // 특정 챌린지 ID와 매핑된 인증 내역 조회
     Optional<UserChallenge> findByIdAndUserId(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 
-    // 유저의 완료/미완료 챌린지 현황 조회
+    // 1. 유저의 완료 또는 미완료 챌린지 조회 (dtype 무시)
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND uc.dtype = :dtype " +
             "AND uc.completed = :completed")
     List<UserChallenge> findChallengesByCompletionStatus(
             @Param("userId") Long userId,
-            @Param("dtype") UserChallengeType dtype,
             @Param("completed") Boolean completed);
+
+    // 2. 특정 dtype에 대해 미완료 챌린지 조회 (completed가 true인 챌린지는 제외)
+    @Query("SELECT uc FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId " +
+            "AND uc.dtype = :dtype " +
+            "AND uc.completed = false")  // 항상 미완료 챌린지만 조회
+    List<UserChallenge> findChallengesByDtypeAndCompletionStatus(
+            @Param("userId") Long userId,
+            @Param("dtype") UserChallengeType dtype);
+
 
 }
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -15,6 +15,7 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -62,8 +63,21 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
 
     @Override
     public ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed) {
-        // 완료된 챌린지 또는 미완료된 챌린지 조회
-        List<UserChallenge> userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, dtype, completed);
+        List<UserChallenge> userChallenges;
+
+        // dtype이 null이면 전체 챌린지 중 완료/미완료만 조회
+        if (dtype == null) {
+            userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, completed);
+        }
+        // dtype이 RANDOM 또는 DAILY인 경우 미완료 챌린지만 조회 (completed = false 고정)
+        else if (!completed) {
+            userChallenges = userChallengeRepository.findChallengesByDtypeAndCompletionStatus(userId, dtype);
+        }
+        // dtype이 RANDOM 또는 DAILY인데 completed가 true이면 빈 리스트 반환 (잘못된 요청 방지)
+        else {
+            userChallenges = Collections.emptyList();
+        }
+
         List<ChallengeResponseDTO.ChallengeStatusDTO> challenges = ChallengeConverter.toChallengeStatusListDTO(userChallenges);
 
         return ChallengeResponseDTO.ChallengeStatusListDTO.builder()


### PR DESCRIPTION
## 📝 작업 내용
> 
- [ ] 챌린지 현황 조회 메서드 및 쿼리문 수정
1. dtype x, completed true -> 완료한 챌린지 조회
2. dtype x, completed false -> 전체(미완료한) 챌린지 조회
3. dtype RANDOM, completed false -> 미완료한 랜덤챌린지 조회
4. dtype DAILY, completed false -> 미완료한 데일리챌린지 조회

기존의 코드로는 dtype에 RANDOM 또는 DAILY 값을 넣고 completed에 true값을 주면 완료한 랜덤챌린지, 완료한 데일리챌린지가 각각 조회되는 상황이었습니다. 그러나 카테고리상 완료 부분에서는 "완료한 전체 챌린지"만 있지, "완료한 랜덤챌린지" 또는 "완료한 데일리챌린지"는 존재하지 않다고 생각하였습니다. 그래서 하나로 통합하였던 메서드를 **1. 완료/미완료 챌린지 조회(dtype 무시) 2. dtype에 대해 미완료챌린지 조회** 이렇게 나누는 식으로 수정하게 되었습니다. 코드에 주석 달아놨으니 이해 안되시면 말씀해주시고 수정해야 할 부분 또한 말씀해주세요! 

## 🔍 테스트 방법
> 1. dtype x, completed true -> 완료한 챌린지 조회
![image](https://github.com/user-attachments/assets/8fa40f66-6480-4eae-8461-566f8996ea82)

2. dtype x, completed false -> 전체(미완료한) 챌린지 조회
![image](https://github.com/user-attachments/assets/f74a41fe-4375-4c04-baee-a906e6d34516)

3. dtype RANDOM, completed false -> 미완료한 랜덤챌린지 조회
![image](https://github.com/user-attachments/assets/0ecfc8f0-3a81-4a8f-b7dd-62f7d0d878f0)

4. dtype DAILY, completed false -> 미완료한 데일리챌린지 조회(유저챌린지에 미완료한 데일리챌린지 데이터가 없어 빈 리스트가 반환되는 것입니다 -> 데이터가 존재한다면 미완료한 랜덤챌린지를 조회할때처럼 챌린지 목록이 반환됨)
![image](https://github.com/user-attachments/assets/3fb5d49e-d1c9-44ca-93da-2c48566f391c)
5. dtype에 RANDOM 또는 DAILY 값을 주고 completed에 true 값을 주게 되었을 때
![image](https://github.com/user-attachments/assets/9f9f85b6-7fce-493e-94c9-ca75d3f116dd)
둘 다 빈 리스트가 반환되게 구현하였는데
```java
        // dtype이 RANDOM 또는 DAILY인데 completed가 true이면 빈 리스트 반환 (잘못된 요청 방지)
        else {
            userChallenges = Collections.emptyList();
        }
``` 
참고로 이 코드를 삭제하게 되면 userChallenges 변수가 초기화되지 않았기 때문에
`ChallengeConverter.toChallengeStatusListDTO(userChallenges)` 의 userChallenges 부분에서 에러가 뜹니다.