### PR TITLE
[#143] Feat: 챌린지 인증 이미지 첨부(S3 활용)

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -91,8 +91,8 @@ public enum ErrorStatus implements BaseErrorCode {
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S3_4001", "파일 확장자가 잘못되었습니다."),
     S3_FILE_EMPTY(HttpStatus.BAD_REQUEST, "S3_4002", "파일이 비어 있습니다."),
     S3_FILE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3_5001", "파일 업로드에 실패했습니다."),
-    S3_FILE_OVER_SIZE(HttpStatus.BAD_REQUEST, "S3_4003", "파일 크기가 10MB를 초과했습니다.");
-
+    S3_FILE_OVER_SIZE(HttpStatus.BAD_REQUEST, "S3_4003", "파일 크기가 10MB를 초과했습니다."),
+    S3_FILE_DELETE_FAILED(HttpStatus.BAD_REQUEST, "S3_4004", "파일 삭제에 실패했습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/ImageHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/ImageHandler.java
@@ -1,0 +1,9 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class ImageHandler extends GeneralException {
+    public ImageHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -63,12 +63,12 @@ public class ChallengeConverter {
     }
 
     // 챌린지 인증 작성 결과 반환
-    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {
+    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge, String imageUrl) {
         return ChallengeResponseDTO.ProofDetailsDTO.builder()
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
                 .time(challenge.getTime())
-                .certificationImage(userChallenge.getCertificationImage())
+                .certificationImage(imageUrl)
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCreatedAt())
                 .build();

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -42,6 +42,10 @@ public class UserChallenge extends BaseEntity {
         this.challenge = challenge;
     }
 
+    public void setThoughts(String thoughts) { this.thoughts = thoughts; }
+
+    public void setCertificationImage(String certificationImage) { this.certificationImage = certificationImage; }
+    // 인증 작성 (최초 등록 또는 전체 업데이트용)
     public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest, String imageUrl){
         thoughts = proofRequest.getThoughts();
         certificationImage = imageUrl;

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -42,9 +42,9 @@ public class UserChallenge extends BaseEntity {
         this.challenge = challenge;
     }
 
-    public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest){
+    public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest, String imageUrl){
         thoughts = proofRequest.getThoughts();
-        certificationImage = proofRequest.getCertificationImage();
+        certificationImage = imageUrl;
         completed = true;
     }
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -4,7 +4,7 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 public interface ChallengeCommandService {
-    ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long challengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
-    ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long challengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
+    ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
+    ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
     ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -47,7 +47,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         userChallengeRepository.save(userChallenge);
 
         // 4️⃣ 응답 DTO 변환 및 반환
-        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge);
+        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge, imageUrl);
     }
 
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -74,13 +74,16 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     // 챌린지 인증 내역 조회
     @Override
     @Transactional(readOnly = true)
-    public ChallengeResponseDTO.ProofDetailsDTO getChallengeProofDetails(Long userId, Long challengeId) {
+    public ChallengeResponseDTO.ProofDetailsDTO getChallengeProofDetails(Long userId, Long userChallengeId) {
 
-        UserChallenge userChallenge = userChallengeRepository.findByIdAndUserId(challengeId, userId)
-                .orElseThrow(() -> new ChallengeHandler(ErrorStatus.CHALLENGE_VERIFY_NOT_EXISTS));
+        UserChallenge userChallenge = userChallengeRepository.findByIdAndUserId(userChallengeId, userId)
+                .orElseThrow(() -> new ChallengeHandler(ErrorStatus.USER_CHALLENGE_NOT_FOUND));
 
-        Challenge challenge = userChallenge.getChallenge();
-        return ChallengeConverter.toChallengeProofDetailsDTO(challenge, userChallenge);
+        String imageUrl = userChallenge.getCertificationImage();
+
+        //Challenge challenge = userChallenge.getChallenge();
+        //return ChallengeConverter.toChallengeProofDetailsDTO(challenge, userChallenge);
+        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge, imageUrl);
     }
 
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -80,9 +80,6 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
                 .orElseThrow(() -> new ChallengeHandler(ErrorStatus.USER_CHALLENGE_NOT_FOUND));
 
         String imageUrl = userChallenge.getCertificationImage();
-
-        //Challenge challenge = userChallenge.getChallenge();
-        //return ChallengeConverter.toChallengeProofDetailsDTO(challenge, userChallenge);
         return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge, imageUrl);
     }
 

--- a/src/main/java/umc/GrowIT/Server/service/ImageService/ImageService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ImageService/ImageService.java
@@ -1,0 +1,88 @@
+package umc.GrowIT.Server.service.ImageService;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.ImageHandler;
+import umc.GrowIT.Server.utils.ImageUtils;
+import umc.GrowIT.Server.utils.SecurityUtils;
+import umc.GrowIT.Server.web.dto.ImageDTO.UploadImageResponse;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ImageService implements ImageUtils {
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.base-url}")
+    private String baseUrl;
+
+    private final AmazonS3 amazonS3;
+
+    public UploadImageResponse uploadImage(MultipartFile file) {
+        String url = upload(file);
+        return new UploadImageResponse(url);
+    }
+
+    public String upload(MultipartFile file) {
+
+        if (file.isEmpty() && file.getOriginalFilename() != null){
+            throw new ImageHandler(ErrorStatus.S3_FILE_EMPTY);
+        }
+
+        if (file.getSize() / (1024 * 1024) > 10) {
+            throw new ImageHandler(ErrorStatus.S3_FILE_OVER_SIZE);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String ext = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+
+        if (!(ext.equals("jpg")
+                || ext.equals("HEIC")
+                || ext.equals("jpeg")
+                || ext.equals("png")
+                || ext.equals("heic"))) {
+            throw new ImageHandler(ErrorStatus.S3_BAD_FILE_EXTENSION);
+        }
+
+        String randomName = UUID.randomUUID().toString();
+        String fileName = "challenges/" + SecurityUtils.getCurrentUserId() + "|" + randomName + "." + ext; // 경로 추가
+
+        try {
+            ObjectMetadata objMeta = new ObjectMetadata();
+            byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+            objMeta.setContentType(file.getContentType());
+            objMeta.setContentLength(bytes.length);
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), objMeta));
+            //amazonS3.putObject(
+                    //new PutObjectRequest(bucket, fileName, file.getInputStream(), objMeta)
+                            //.withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new ImageHandler(ErrorStatus.S3_FILE_UPLOAD_FAIL);
+        }
+        return baseUrl + "/" + fileName;
+    }
+
+    @Override
+    public void delete(String profilePath) {
+        String objectName = getBucketKey(profilePath);
+        amazonS3.deleteObject(bucket, objectName);
+    }
+
+    public String getBucketKey(String profilePath){
+        return profilePath.substring(profilePath.lastIndexOf('/') + 1);
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/ImageService/ImageService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ImageService/ImageService.java
@@ -83,6 +83,9 @@ public class ImageService implements ImageUtils {
     }
 
     public String getBucketKey(String profilePath){
-        return profilePath.substring(profilePath.lastIndexOf('/') + 1);
+        if(profilePath == null) {
+            throw new ImageHandler(ErrorStatus.S3_FILE_DELETE_FAILED);
+        }
+        return profilePath.replace(baseUrl + "/", "");
     }
 }

--- a/src/main/java/umc/GrowIT/Server/utils/ImageUtils.java
+++ b/src/main/java/umc/GrowIT/Server/utils/ImageUtils.java
@@ -1,0 +1,5 @@
+package umc.GrowIT.Server.utils;
+
+public interface ImageUtils {
+    void delete(String objectName);
+}

--- a/src/main/java/umc/GrowIT/Server/utils/SecurityUtils.java
+++ b/src/main/java/umc/GrowIT/Server/utils/SecurityUtils.java
@@ -1,0 +1,16 @@
+package umc.GrowIT.Server.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+
+public class SecurityUtils {
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new UserHandler(ErrorStatus.USER_NOT_FOUND);
+        }
+        return Long.valueOf(authentication.getName());
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -55,7 +55,7 @@ public class ChallengeController implements ChallengeSpecification {
         return null;
     }
 
-    @PostMapping(value = "/{userChallengeId}/prove", consumes = "multipart/form-data")
+    @PostMapping(value = "{userChallengeId}/prove", consumes = "multipart/form-data")
     public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> createChallengeProof(@PathVariable Long userChallengeId, @ModelAttribute ChallengeRequestDTO.ProofRequestDTO proofRequest) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -75,9 +75,8 @@ public class ChallengeController implements ChallengeSpecification {
         return ApiResponse.onSuccess(response);
     }
 
-    @PatchMapping("{userChallengeId}")
-    public ApiResponse<ChallengeResponseDTO.ModifyProofDTO> updateChallengeProof(@PathVariable("userChallengeId") Long userChallengeId,
-                                                                  @RequestBody ChallengeRequestDTO.ProofRequestDTO updateRequest) {
+    @PatchMapping(value="{userChallengeId}", consumes = "multipart/form-data")
+    public ApiResponse<ChallengeResponseDTO.ModifyProofDTO> updateChallengeProof(@PathVariable("userChallengeId") Long userChallengeId, @ModelAttribute ChallengeRequestDTO.ProofRequestDTO updateRequest) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
         ChallengeResponseDTO.ModifyProofDTO response = challengeCommandService.updateChallengeProof(userId, userChallengeId, updateRequest);

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeCommandService;
 import umc.GrowIT.Server.service.ChallengeService.ChallengeQueryService;
+import umc.GrowIT.Server.service.ImageService.ImageService;
 import umc.GrowIT.Server.web.controller.specification.ChallengeSpecification;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.ImageDTO.UploadImageResponse;
 
 @Tag(name = "Challenge", description = "챌린지 관련 API")
 @RestController
@@ -25,6 +28,7 @@ public class ChallengeController implements ChallengeSpecification {
 
     private final ChallengeQueryService challengeQueryService;
     private final ChallengeCommandService challengeCommandService;
+    private final ImageService imageService;
 
     @GetMapping("summary")
     public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome() {
@@ -51,8 +55,8 @@ public class ChallengeController implements ChallengeSpecification {
         return null;
     }
 
-    @PostMapping("{userChallengeId}/prove")
-    public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> createChallengeProof(@PathVariable Long userChallengeId, @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest) {
+    @PostMapping(value = "/{userChallengeId}/prove", consumes = "multipart/form-data")
+    public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> createChallengeProof(@PathVariable Long userChallengeId, @ModelAttribute ChallengeRequestDTO.ProofRequestDTO proofRequest) {
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
@@ -41,8 +42,9 @@ public interface ChallengeSpecification {
     })
     ApiResponse<ChallengeResponseDTO> selectChallenge(@PathVariable Long challengeId);
 
-    @PostMapping("{userChallengeId}/prove")
-    @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다.")
+    @PostMapping(value = "/{userChallengeId}/prove", consumes = "multipart/form-data")
+    @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다. <br>" +
+            "multipart/form-data 형식의 이미지를 input으로 받습니다. 이때 key 값은 file 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -42,14 +42,14 @@ public interface ChallengeSpecification {
     })
     ApiResponse<ChallengeResponseDTO> selectChallenge(@PathVariable Long challengeId);
 
-    @PostMapping(value = "/{userChallengeId}/prove", consumes = "multipart/form-data")
+    @PostMapping(value = "{userChallengeId}/prove", consumes = "multipart/form-data")
     @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다. <br>" +
             "multipart/form-data 형식의 이미지를 input으로 받습니다. 이때 key 값은 file 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> createChallengeProof(@PathVariable Long userChallengeId, @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest);
+    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> createChallengeProof(@PathVariable Long userChallengeId, @ModelAttribute ChallengeRequestDTO.ProofRequestDTO proofRequest);
 
     @GetMapping("{userChallengeId}")
     @Operation(summary = "챌린지 인증 내용 조회 API", description = "특정 챌린지의 인증 내용을 조회합니다.")
@@ -59,14 +59,14 @@ public interface ChallengeSpecification {
     })
     ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long userChallengeId);
 
-    @PatchMapping("{userChallengeId}")
+    @PatchMapping(value="{userChallengeId}", consumes = "multipart/form-data")
     @Operation(summary = "챌린지 인증 수정 API", description = "챌린지 인증을 수정하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
 
-    ApiResponse<ChallengeResponseDTO.ModifyProofDTO> updateChallengeProof(@PathVariable Long userChallengeId, @RequestBody ChallengeRequestDTO.ProofRequestDTO updateRequest);
+    ApiResponse<ChallengeResponseDTO.ModifyProofDTO> updateChallengeProof(@PathVariable Long userChallengeId, @ModelAttribute ChallengeRequestDTO.ProofRequestDTO updateRequest);
 
 
     @DeleteMapping("{userChallengeId}")

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -1,9 +1,11 @@
 package umc.GrowIT.Server.web.dto.ChallengeDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 public class ChallengeRequestDTO {
 
@@ -12,7 +14,8 @@ public class ChallengeRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ProofRequestDTO {
-        private String certificationImage;
+        @Schema(description = "인증 이미지 파일 (multipart/form-data)", type = "string", format = "binary")
+        private MultipartFile certificationImage;
         private String thoughts;
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -18,6 +18,8 @@ public class ChallengeRequestDTO {
         @Schema(description = "인증 이미지 파일 (multipart/form-data)", type = "string", format = "binary")
         @Nullable // 클라이언트가 이미지를 업로드하지 않으면 null 허용
         private MultipartFile certificationImage;
+        @Schema(description = "소감 (텍스트)")
+        @Nullable
         private String thoughts;
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
 public class ChallengeRequestDTO {
@@ -15,6 +16,7 @@ public class ChallengeRequestDTO {
     @AllArgsConstructor
     public static class ProofRequestDTO {
         @Schema(description = "인증 이미지 파일 (multipart/form-data)", type = "string", format = "binary")
+        @Nullable // 클라이언트가 이미지를 업로드하지 않으면 null 허용
         private MultipartFile certificationImage;
         private String thoughts;
     }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -16,10 +16,8 @@ public class ChallengeRequestDTO {
     @AllArgsConstructor
     public static class ProofRequestDTO {
         @Schema(description = "인증 이미지 파일 (multipart/form-data)", type = "string", format = "binary")
-        @Nullable // 클라이언트가 이미지를 업로드하지 않으면 null 허용
         private MultipartFile certificationImage;
         @Schema(description = "소감 (텍스트)")
-        @Nullable
         private String thoughts;
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/ImageDTO/UploadImageResponse.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ImageDTO/UploadImageResponse.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.web.dto.ImageDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UploadImageResponse {
+    private final String imageUrl;
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이미지 첨부(S3 활용하여 이미지 첨부하는 기능 구현)
- [x] 챌린지 인증 작성
- [x] 챌린지 인증내역 조회
- [x] 챌린지 인증 수정

챌린지 인증 작성을 할때 이미지를 첨부하는 기능, 인증내역을 조회할때 이미지를 불러오는 기능, 챌린지 인증 내역을 수정할 때 이미지 수정하는 기능(이미지를 수정하지 않으면 이전 이미지가 그대로 적용) 이렇게 3가지를 aws s3를 활용하여 구현하였습니다.
s3 환경설정은 아래를 참고하시면 됩니다.
#91 
컨트롤러에서 @RequestBody 는 multipart/form-data 요청을 처리할 수 없기 때문에 @ModelAttribute 를 사용하였습니다.
인증 작성 부분에서 imageUrl은 처음에 null값이며 값이 들어오면 이를 유저챌린지에 저장하고, 인증 수정 부분에서 oldImageUrl과 newImageUrl로 나눠 사용자가 이미지를 수정하면 기존 이미지(oldImageUrl)는 s3에서 삭제되고 새로운 이미지(newImageUrl)가 업데이트되는 형식입니다.

send empty value 체크박스가 뜨지 않게 dto 스키마에 required=true를 넣어 해당 필드를 필수값으로 지정할 수 있으나
```java
@Schema(description = "인증 이미지 파일 (multipart/form-data)", required = true)
private MultipartFile certificationImage;
``` 
인증이미지만 수정하거나 소감만 수정하는 상황까지 생각하다보니 필수값으로 지정해버리면 이미지와 소감 둘 다 수정해야 하는 상황 하나로 제한되기 때문에 일단 체크박스가 존재하게 두었습니다. 그러나 저도 테스트할 때 체크박스가 헷갈려서 정보를 찾아보고 있긴한데 더 나은 방법 있으면 알려주시면 감사하겠습니다.

## 🔍 테스트 방법
> 1. UserChallenge 데이터를 보면 미완료한 챌린지 아이디가 5이기 때문에 아이디가 5인 챌린지 인증 작성 먼저 진행하겠습니다.
![image](https://github.com/user-attachments/assets/37040b98-ef13-4aa2-8ba8-321f20704050)
유저챌린지아이디가 8이기 때문에 8을 입력하고, 이미지를 선택하고 소감을 입력하면 DB에 저장됩니다.
![image](https://github.com/user-attachments/assets/0270b684-0837-48e9-908c-2ca0f2b1d330)
2. 챌린지 인증 내역 조회를 하면 certificationImage가 url 형식으로 나오는 것을 확인할 수 있습니다. (링크를 복붙하여 실행하면 이미지에 접근할 수 있습니다. s3에서도 객체 URL을 통해 접근 가능)
![image](https://github.com/user-attachments/assets/95f7f529-1f3d-4c4a-b865-83cd67c65adf)
3. 챌린지 인증 내역 수정
(1) 인증이미지만 수정하는 경우
처음에 리셋하면 아래의 이미지처럼 나오는데, 소감을 수정하지 않고 이전 값 그대로 가져간다면 소감 (테스트) 아래의 'Send empty value'를 체크해주셔야 합니다. (리셋하였을 때 소감 입력칸에 기본값으로 string이 써있는데 체크를 해야 이전에 작성한 소감 값을 저장합니다. 체크를 하지 않으면 소감이 "string"으로 저장됨.)
-> Send empty value를 체크하거나 안해도 code 200 응답이 뜨는 경우가 있더라고요
![image](https://github.com/user-attachments/assets/3c74b327-6ff9-4ae1-8b43-e605d4b04d25)
(2) 소감만 수정하는 경우
소감을 입력하고 테스트하면 responsebody에서 소감 부분이 수정된 것을 확인할 수 있습니다. (이미지를 수정하지 않는다면 send empty value 체크해제하고 테스트하기)
send empty value 체크하여 이미지에 null값 보내면 에러 발생
![image](https://github.com/user-attachments/assets/05bfe224-b4b8-4e0b-9e73-172c33b92c1e)
(3) 인증이미지, 소감 둘 다 수정하는 경우는 위와 동일

(수정 전 인증 내역 조회하였을 때)
![image](https://github.com/user-attachments/assets/3f8ea02c-ed1e-446c-8f7f-0802c320f795)
![image](https://github.com/user-attachments/assets/7651fc0a-9bc9-4a8a-9594-b39954e13a97)

(수정 후 인증 내역 조회하였을 때)
![image](https://github.com/user-attachments/assets/a88f4013-37ff-4145-8950-54579dd7987d)
![image](https://github.com/user-attachments/assets/1af41fa9-ba78-4e6b-b12d-c9f22c9d3a0a)

s3에서 이전 이미지가 삭제되는지 확인해주세요! (본인이 올린 파일이 2개가 존재한다면 해결 필요)