### PR TITLE
[#148] 카카오 로그인 API - 로그인 처리 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
 	// WebClient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/ApiResponse.java
@@ -27,12 +27,12 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
-    public static <T> ApiResponse<T> onSuccess(){
-        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), null);
+    public static <T> ApiResponse<T> onSuccess(BaseCode code, T result){
+            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }
 
-    public static <T> ApiResponse<T> of(BaseCode code, T result){
-            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    public static <T> ApiResponse<T> onSuccess(){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), null);
     }
 
 

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/SuccessStatus.java
@@ -11,7 +11,10 @@ import umc.GrowIT.Server.apiPayload.code.ReasonDTO;
 public enum SuccessStatus implements BaseCode {
 
     // 일반적인 응답
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+    // 카카오 로그인 -> 회원가입 요청
+    NEED_TO_ACCEPT_TERMS(HttpStatus.ACCEPTED, "TERM2001", "회원가입을 위해 약관 동의 목록이 추가적으로 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/CustomAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.apiPayload.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/JwtAuthenticationException.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/JwtAuthenticationException.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.apiPayload.exception;
 
 import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/TermHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/TermHandler.java
@@ -3,7 +3,6 @@ package umc.GrowIT.Server.apiPayload.exception;
 import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
 
 public class TermHandler extends GeneralException {
-
     public TermHandler(BaseErrorCode code) {
         super(code);
     }

--- a/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
@@ -10,14 +10,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
-import umc.GrowIT.Server.jwt.CustomAuthenticationEntryPoint;
-import umc.GrowIT.Server.jwt.JwtAuthenticationFilter;
-import umc.GrowIT.Server.jwt.CustomUserDetailsService;
-
-import java.util.List;
+import umc.GrowIT.Server.apiPayload.exception.CustomAuthenticationEntryPoint;
+import umc.GrowIT.Server.filter.JwtAuthenticationFilter;
+import umc.GrowIT.Server.service.userService.CustomUserDetailsService;
 
 @Configuration
 @EnableWebSecurity
@@ -66,7 +62,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() //인증 없이 접근 가능
-                        .requestMatchers("/auth/login/email", "/auth/login/kakao", "/auth/kakao/test", "/auth/email", "/users/password", "/auth/users", "/terms", "/auth/verification", "/auth/reissue").permitAll() //인증 없이 접근 가능
+                        .requestMatchers("/auth/**", "/users/password", "/terms").permitAll() //인증 없이 접근 가능
                         .anyRequest().authenticated() //나머지 요청은 인증 필요
                 );
 

--- a/src/main/java/umc/GrowIT/Server/converter/OAuthAccountConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/OAuthAccountConverter.java
@@ -1,0 +1,18 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.OAuthAccount;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
+
+import static umc.GrowIT.Server.domain.enums.Provider.KAKAO;
+
+public class OAuthAccountConverter {
+    public static OAuthAccount toOAuthAccount(OAuthResponseDTO.KakaoUserInfoResponseDTO kakaoUserInfo, User user) {
+        return OAuthAccount.builder()
+                .providerId(kakaoUserInfo.getId())
+                .provider(KAKAO)
+                .email(kakaoUserInfo.getKakao_account().getEmail())
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -1,22 +1,23 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.User;
-import umc.GrowIT.Server.domain.enums.Role;
-import umc.GrowIT.Server.domain.enums.UserStatus;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+import static umc.GrowIT.Server.domain.enums.Role.USER;
+import static umc.GrowIT.Server.domain.enums.UserStatus.ACTIVE;
 
 public class UserConverter {
 
     public static User toUser(UserRequestDTO.UserInfoDTO userInfoDTO) {
         return User.builder()
                 .name(userInfoDTO.getName())
-                .email(userInfoDTO.getEmail())
+                .primaryEmail(userInfoDTO.getEmail())
                 .password(userInfoDTO.getPassword())
-                .status(UserStatus.ACTIVE)
-                .role(Role.USER)
                 .currentCredit(0)
                 .totalCredit(0)
+                .role(USER)
+                .status(ACTIVE)
                 .build();
     }
 
@@ -24,7 +25,13 @@ public class UserConverter {
         return UserResponseDTO.DeleteUserResponseDTO.builder()
                 .name(deleteUser.getName())
                 .message("회원탈퇴가 완료되었어요")
-                .build()
-                ;
+                .build();
+    }
+
+    public static UserResponseDTO.KakaoLoginDTO toKakaoLoginDTO(Boolean signupRequired, UserResponseDTO.TokenDTO tokens) {
+        return UserResponseDTO.KakaoLoginDTO.builder()
+                .signupRequired(signupRequired)
+                .tokens(tokens)
+                .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/CustomUserDetails.java
+++ b/src/main/java/umc/GrowIT/Server/domain/CustomUserDetails.java
@@ -1,9 +1,8 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.domain;
 
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import umc.GrowIT.Server.domain.enums.UserStatus;
 
 import java.util.Collection;
 

--- a/src/main/java/umc/GrowIT/Server/domain/OAuthAccount.java
+++ b/src/main/java/umc/GrowIT/Server/domain/OAuthAccount.java
@@ -1,0 +1,29 @@
+package umc.GrowIT.Server.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.Provider;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OAuthAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long providerId;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    private String email;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -10,6 +10,8 @@ import umc.GrowIT.Server.domain.enums.UserStatus;
 
 import java.util.List;
 
+import static umc.GrowIT.Server.domain.enums.UserStatus.ACTIVE;
+
 @Entity
 @Getter
 @Builder
@@ -22,9 +24,8 @@ public class User extends BaseEntity {
     private Long id;
 
     @Column(unique = true, length = 50)
-    private String email;
+    private String primaryEmail;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false, length = 20)
@@ -43,9 +44,6 @@ public class User extends BaseEntity {
     private Integer totalCredit;
 
     @Enumerated(EnumType.STRING)
-    private Provider provider;
-
-    @Enumerated(EnumType.STRING)
     private Role role;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -58,6 +56,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Diary> diaries;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<OAuthAccount> oAuthAccounts;
+
     @Setter
     @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "refresh_token_id")
@@ -68,7 +69,7 @@ public class User extends BaseEntity {
     }
 
     public void deleteAccount() {
-        if (this.status == UserStatus.ACTIVE) {
+        if (this.status == ACTIVE) {
             this.status = UserStatus.INACTIVE;
         }
     }

--- a/src/main/java/umc/GrowIT/Server/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/GrowIT/Server/filter/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.filter;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -15,6 +15,8 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import io.jsonwebtoken.SignatureException;
+import umc.GrowIT.Server.apiPayload.exception.JwtAuthenticationException;
+import umc.GrowIT.Server.util.JwtTokenUtil;
 
 import static umc.GrowIT.Server.apiPayload.code.status.ErrorStatus.*;
 

--- a/src/main/java/umc/GrowIT/Server/repository/OAuthAccountRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/OAuthAccountRepository.java
@@ -1,0 +1,12 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.OAuthAccount;
+
+import java.util.Optional;
+
+public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
+    @EntityGraph(attributePaths = {"user"})
+    Optional<OAuthAccount> findByProviderId(Long providerId);
+}

--- a/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>  {
 
-    Optional<User> findByEmail(String email);
+    Optional<User> findByPrimaryEmail(String primaryEmail);
 }

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
@@ -77,7 +77,7 @@ public class AuthServiceImpl implements AuthService {
 
     // 이메일 체크
     public void checkEmail(AuthType type, String email) {
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByPrimaryEmail(email)
                 .orElse(null); // 사용자가 존재하지 않으면 null을 반환
 
         if (type == AuthType.SIGNUP) { //회원가입 (이메일이 존재하면 X)

--- a/src/main/java/umc/GrowIT/Server/service/oAuthService/OAuthService.java
+++ b/src/main/java/umc/GrowIT/Server/service/oAuthService/OAuthService.java
@@ -1,0 +1,8 @@
+package umc.GrowIT.Server.service.oAuthService;
+
+import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+public interface OAuthService {
+    UserResponseDTO.TokenDTO signupSocial(UserRequestDTO.UserTermsDTO userTermsDTO);
+}

--- a/src/main/java/umc/GrowIT/Server/service/oAuthService/OAuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/oAuthService/OAuthServiceImpl.java
@@ -1,0 +1,13 @@
+package umc.GrowIT.Server.service.oAuthService;
+
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+@Service
+public class OAuthServiceImpl implements OAuthService {
+
+    public UserResponseDTO.TokenDTO signupSocial(UserRequestDTO.UserTermsDTO userTermsDTO){
+        return null;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoService.java
+++ b/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoService.java
@@ -1,7 +1,8 @@
-package umc.GrowIT.Server.service.kakaoService;
+package umc.GrowIT.Server.service.oAuthService.kakaoService;
 
 import reactor.core.publisher.Mono;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 
 public interface KakaoService {
@@ -9,4 +10,5 @@ public interface KakaoService {
     Mono<OAuthResponseDTO.KakaoTokenResponseDTO> requestKakaoToken(String code);
     Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> requestKakaoUserInfo(String accessToken);
     Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> getKakaoUserInfo(String code);
+    Mono<UserResponseDTO.KakaoLoginDTO> loginKakao(String code);
 }

--- a/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoService.java
+++ b/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoService.java
@@ -7,8 +7,8 @@ import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 public interface KakaoService {
 
-    Mono<OAuthResponseDTO.KakaoTokenResponseDTO> requestKakaoToken(String code);
-    Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> requestKakaoUserInfo(String accessToken);
-    Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> getKakaoUserInfo(String code);
-    Mono<UserResponseDTO.KakaoLoginDTO> loginKakao(String code);
+    OAuthResponseDTO.KakaoTokenResponseDTO requestKakaoToken(String code);
+    OAuthResponseDTO.KakaoUserInfoResponseDTO requestKakaoUserInfo(String accessToken);
+    OAuthResponseDTO.KakaoUserInfoResponseDTO saveKakaoUserInfo(String code);
+    UserResponseDTO.KakaoLoginDTO loginKakao(String code);
 }

--- a/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoServiceImpl.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.service.kakaoService;
+package umc.GrowIT.Server.service.oAuthService.kakaoService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -13,14 +14,24 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.http.HttpStatusCode;
 import reactor.core.publisher.Mono;
 import umc.GrowIT.Server.apiPayload.exception.AuthHandler;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.repository.OAuthAccountRepository;
+import umc.GrowIT.Server.service.userService.UserCommandService;
+import umc.GrowIT.Server.util.JwtTokenUtil;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import static umc.GrowIT.Server.apiPayload.code.status.ErrorStatus.KAKAO_AUTH_CODE_ERROR;
+import static umc.GrowIT.Server.converter.UserConverter.toKakaoLoginDTO;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class KakaoServiceImpl implements KakaoService {
+
+    private final OAuthAccountRepository oAuthAccountRepository;
+    private final UserCommandService userCommandService;
+    private final JwtTokenUtil jwtTokenUtil;
 
     private final WebClient kakaoAuthWebClient;
     private final WebClient kakaoApiWebClient;
@@ -32,9 +43,6 @@ public class KakaoServiceImpl implements KakaoService {
     private String redirectUri;
     @Value("${spring.oauth2.client.kakao.client-secret}")
     private String clientSecret;
-
-    private String accessToken;
-    private String refreshToken;
 
     /**
      * 인가 코드로 카카오 서버에서 Access Token, Refresh Token 을 얻어옵니다
@@ -57,8 +65,7 @@ public class KakaoServiceImpl implements KakaoService {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED) //요청 헤더
                 .bodyValue(requestBody) //요청 본문에 추가
                 .retrieve() //서버 응답 가져오기
-                .onStatus(
-                        HttpStatusCode::is4xxClientError,
+                .onStatus(HttpStatusCode::is4xxClientError,
                         response -> Mono.error(new AuthHandler(KAKAO_AUTH_CODE_ERROR)))
                 .bodyToMono(OAuthResponseDTO.KakaoTokenResponseDTO.class); //응답 본문 -> Mono
     }
@@ -80,11 +87,28 @@ public class KakaoServiceImpl implements KakaoService {
     public Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> getKakaoUserInfo(String code) {
         return requestKakaoToken(code)
                 .flatMap(tokenResponseBody -> { //비동기 작업 체이닝
-                    accessToken = tokenResponseBody.getAccess_token();
-                    refreshToken = tokenResponseBody.getRefresh_token();
+                    String accessToken = tokenResponseBody.getAccess_token();
                     log.info("AT : " + accessToken);
                     return requestKakaoUserInfo(accessToken);
                 });
+    }
+
+    @Transactional
+    public Mono<UserResponseDTO.KakaoLoginDTO> loginKakao(String code) {
+        return getKakaoUserInfo(code)
+                .flatMap(kakaoUserInfo ->
+                        Mono.justOrEmpty(oAuthAccountRepository.findByProviderId(kakaoUserInfo.getId()))
+                                .flatMap(oAuthAccount -> {
+                                    // 기존 계정이 있는 경우 로그인 처리 AT, RT 발급
+                                    User user = oAuthAccount.getUser();
+                                    UserResponseDTO.TokenDTO tokenDTO = jwtTokenUtil.generateToken(
+                                            userCommandService.createUserDetails(user));
+                                    userCommandService.setRefreshToken(tokenDTO.getRefreshToken(), user);
+                                    return Mono.just(toKakaoLoginDTO(false, tokenDTO));
+                                })
+                                // 기존 계정이 없을 경우 회원 가입에 필요한 약관 동의 목록 요청
+                                .switchIfEmpty(Mono.just(toKakaoLoginDTO(true, null)))
+                );
     }
 
 }

--- a/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
@@ -7,12 +7,12 @@ import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.AuthHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.TokenConverter;
-import umc.GrowIT.Server.jwt.CustomUserDetails;
+import umc.GrowIT.Server.domain.CustomUserDetails;
 import umc.GrowIT.Server.domain.RefreshToken;
 import umc.GrowIT.Server.domain.User;
-import umc.GrowIT.Server.jwt.JwtTokenUtil;
+import umc.GrowIT.Server.util.JwtTokenUtil;
 import umc.GrowIT.Server.repository.RefreshTokenRepository;
-import umc.GrowIT.Server.jwt.CustomUserDetailsService;
+import umc.GrowIT.Server.service.userService.CustomUserDetailsService;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
@@ -56,7 +56,7 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
             throw new AuthHandler(ErrorStatus.EXPIRED_TOKEN);
         }
 
-        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(storedRefreshToken.getUser().getEmail());
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(storedRefreshToken.getUser().getPrimaryEmail());
 
         String accessToken = jwtTokenUtil.generateAccessToken(customUserDetails); //액세스 토큰 생성
 

--- a/src/main/java/umc/GrowIT/Server/service/userService/CustomUserDetailsService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.service.userService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.CustomUserDetails;
 import umc.GrowIT.Server.repository.UserRepository;
 
 import java.util.Collections;
@@ -21,11 +22,11 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public CustomUserDetails loadUserByUsername(String email) throws UsernameNotFoundException { //AuthenticationManager 의 인증을 위임받은 DaoAuthenticationProvider 가 호출
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByPrimaryEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 이메일의 사용자를 찾을 수 없습니다 : " + email)); //사용자 정보 없을 시 예외 던짐
 
         return new CustomUserDetails(
-                user.getEmail(),
+                user.getPrimaryEmail(),
                 user.getPassword(),
                 Collections.singletonList(new SimpleGrantedAuthority(String.valueOf(user.getRole()))),
                 user.getId()

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserCommandService.java
@@ -1,5 +1,7 @@
 package umc.GrowIT.Server.service.userService;
 
+import umc.GrowIT.Server.domain.CustomUserDetails;
+import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
@@ -13,4 +15,10 @@ public interface UserCommandService {
     void updatePassword(UserRequestDTO.PasswordDTO passwordDTO);
 
     UserResponseDTO.DeleteUserResponseDTO delete(Long userId);
+
+    CustomUserDetails createUserDetails(User user);
+
+    void setRefreshToken(String refreshToken, User user);
+
+    UserResponseDTO.TokenDTO performAuthentication(String email, String password);
 }

--- a/src/main/java/umc/GrowIT/Server/util/JwtTokenUtil.java
+++ b/src/main/java/umc/GrowIT/Server/util/JwtTokenUtil.java
@@ -1,4 +1,4 @@
-package umc.GrowIT.Server.jwt;
+package umc.GrowIT.Server.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import umc.GrowIT.Server.domain.CustomUserDetails;
 import umc.GrowIT.Server.service.userService.UserQueryService;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -76,7 +76,7 @@ public class AuthController implements AuthSpecification {
     @Override
     @PostMapping("/login/kakao")
     public ApiResponse<UserResponseDTO.KakaoLoginDTO> loginKakao(@RequestParam(value = "code") String code) {
-        UserResponseDTO.KakaoLoginDTO kakaoLoginDTO = kakaoService.loginKakao(code).block();
+        UserResponseDTO.KakaoLoginDTO kakaoLoginDTO = kakaoService.loginKakao(code);
         if (kakaoLoginDTO.getSignupRequired())
             return ApiResponse.onSuccess(NEED_TO_ACCEPT_TERMS, kakaoLoginDTO);
         return ApiResponse.onSuccess(kakaoLoginDTO);

--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -4,22 +4,21 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.service.authService.AuthService;
-import umc.GrowIT.Server.service.kakaoService.KakaoService;
+import umc.GrowIT.Server.service.oAuthService.OAuthService;
+import umc.GrowIT.Server.service.oAuthService.kakaoService.KakaoService;
 import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.service.refreshTokenService.RefreshTokenCommandService;
 import umc.GrowIT.Server.web.controller.specification.AuthSpecification;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
-import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
+import static umc.GrowIT.Server.apiPayload.code.status.SuccessStatus.NEED_TO_ACCEPT_TERMS;
 
 @Slf4j
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -32,34 +31,27 @@ public class AuthController implements AuthSpecification {
     private final AuthService authService;
     private final RefreshTokenCommandService refreshTokenCommandService;
     private final KakaoService kakaoService;
+    private final OAuthService oAuthService;
 
-    @PostMapping("/login/email")
+    @Override
+    @PostMapping("/login")
     public ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO) {
         UserResponseDTO.TokenDTO tokenDTO = userCommandService.emailLogin(emailLoginDTO);
         return ApiResponse.onSuccess(tokenDTO);
     }
 
-    @PostMapping("/users")
-    public ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO) {
+    @Override
+    @PostMapping("/signup")
+    public ApiResponse<UserResponseDTO.TokenDTO> signupEmail(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO) {
         UserResponseDTO.TokenDTO tokenDTO = userCommandService.createUser(userInfoDTO);
         return ApiResponse.onSuccess(tokenDTO);
     }
 
-
+    @Override
     @PostMapping("/reissue")
     public ApiResponse<UserResponseDTO.AccessTokenDTO> reissueToken(@RequestBody @Valid UserRequestDTO.ReissueDTO reissueDTO) {
         UserResponseDTO.AccessTokenDTO accessTokenDTO = refreshTokenCommandService.reissueToken(reissueDTO);
         return ApiResponse.onSuccess(accessTokenDTO);
-    }
-
-    @Override
-    @PatchMapping("")
-    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
-        UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
-        return ApiResponse.onSuccess(deleteUser);
     }
 
     @Override
@@ -81,13 +73,19 @@ public class AuthController implements AuthSpecification {
         return ApiResponse.onSuccess(result);
     }
 
+    @Override
     @PostMapping("/login/kakao")
-    public ApiResponse<Void> kakaoLogin(@RequestParam(value = "code") String code) {
-        return ApiResponse.onSuccess();
+    public ApiResponse<UserResponseDTO.KakaoLoginDTO> loginKakao(@RequestParam(value = "code") String code) {
+        UserResponseDTO.KakaoLoginDTO kakaoLoginDTO = kakaoService.loginKakao(code).block();
+        if (kakaoLoginDTO.getSignupRequired())
+            return ApiResponse.onSuccess(NEED_TO_ACCEPT_TERMS, kakaoLoginDTO);
+        return ApiResponse.onSuccess(kakaoLoginDTO);
     }
 
-    @PostMapping("/kakao/test")
-    public Mono<OAuthResponseDTO.KakaoUserInfoResponseDTO> getKakaoToken(@RequestParam String code) {
-        return kakaoService.getKakaoUserInfo(code);
+    @Override
+    @PostMapping("/signup/social")
+    public ApiResponse<UserResponseDTO.TokenDTO> signupSocial(@RequestBody @Valid UserRequestDTO.UserTermsDTO userTermsDTO) {
+        UserResponseDTO.TokenDTO tokenDTO = oAuthService.signupSocial(userTermsDTO);
+        return ApiResponse.onSuccess(tokenDTO);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -24,6 +24,7 @@ public class ItemController implements ItemSpecification {
     private final ItemCommandService itemCommandService;
 
     @Override
+    @GetMapping("/items")
     public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(ItemCategory category) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
@@ -33,11 +34,13 @@ public class ItemController implements ItemSpecification {
     }
 
     @Override
+    @PatchMapping("/items/{itemId}")
     public ApiResponse<ItemEquipResponseDTO> updateItemStatus(Long itemId, ItemEquipRequestDTO request) {
         return ApiResponse.onSuccess(null);
     }
 
     @Override
+    @PostMapping("/items/{itemId}/purchase")
     public ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(Long itemId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id

--- a/src/main/java/umc/GrowIT/Server/web/controller/TermController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/TermController.java
@@ -18,6 +18,7 @@ public class TermController implements TermSpecification {
 
     private final TermQueryService termQueryService;
 
+    @Override
     @GetMapping("/terms")
     public ApiResponse<List<TermResponseDTO.TermDTO>> getTerms() {
         return ApiResponse.onSuccess(termQueryService.getTerms());

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -17,6 +17,7 @@ import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentRequestDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentResponseDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
@@ -29,15 +30,16 @@ public class UserController implements UserSpecification {
     private final ItemQueryServiceImpl itemQueryServiceImpl;
 
     @Override
+    @GetMapping("/items")
     public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(ItemCategory category) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
-
 
         return ApiResponse.onSuccess(itemQueryServiceImpl.getUserOwnedItemList(category, userId));
     }
 
     @Override
+    @GetMapping("/credits")
     public ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
@@ -45,6 +47,7 @@ public class UserController implements UserSpecification {
     }
 
     @Override
+    @GetMapping("/credits/total")
     public ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
@@ -52,13 +55,25 @@ public class UserController implements UserSpecification {
     }
 
     @Override
+    @PostMapping("/credits/payment")
     public ApiResponse<PaymentResponseDTO> purchaseCredits(PaymentRequestDTO request) {
         return ApiResponse.onSuccess(null);
     }
 
+    @Override
     @PatchMapping("/password")
     public ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO) {
         userCommandService.updatePassword(passwordDTO);
         return ApiResponse.onSuccess();
+    }
+
+    @Override
+    @PatchMapping("")
+    public ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
+        return ApiResponse.onSuccess(deleteUser);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -18,9 +18,9 @@ import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 public interface AuthSpecification {
 
-    @PostMapping("/users")
+    @PostMapping("/signup")
     @SecurityRequirement(name = "")
-    @Operation(summary = "이메일 회원가입 API", description = "약관 목록 입력할 때 termId 1~6 입력해 주세요. termId 1~4는 필수 동의 항목입니다. (임시 테스트할 때 termRepositoryTest 에서 DB에 약관 목록 추가해주세요.)", security = @SecurityRequirement(name = ""))
+    @Operation(summary = "이메일 회원가입 API", description = "약관 목록 입력할 때 termId 1~6 입력해 주세요. (termId 1~4는 필수 동의 항목입니다.)", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -29,10 +29,10 @@ public interface AuthSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TEMP4003", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 회원가입 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<UserResponseDTO.TokenDTO> createUser(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO);
+    ApiResponse<UserResponseDTO.TokenDTO> signupEmail(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO);
 
-    @PostMapping("/login/email")
-    @Operation(summary = "이메일 로그인 API", description = "", security = @SecurityRequirement(name = ""))
+    @PostMapping("/login")
+    @Operation(summary = "이메일 로그인 API", description = "이메일 로그인 API 입니다. AccessToken, RefreshToken 이 모두 만료되어 토큰 재발급 API 에서 AccessToken 재발급이 불가능하면 로그인 화면으로 이동합니다.", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -42,7 +42,7 @@ public interface AuthSpecification {
     ApiResponse<UserResponseDTO.TokenDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO);
 
     @PostMapping("/reissue")
-    @Operation(summary = "토큰 재발급 API", description = "")
+    @Operation(summary = "토큰 재발급 API", description = "AccessToken 이 만료되었다는 401 에러 발생 시 토큰 재발급을 요청하는 API 입니다. 로그인 또는 회원가입 시 얻은 RefreshToken 을 Request Body 에 담아 요청해 주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4002", description = "❌ 만료된 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -50,18 +50,8 @@ public interface AuthSpecification {
     })
     ApiResponse<UserResponseDTO.AccessTokenDTO> reissueToken(@RequestBody @Valid UserRequestDTO.ReissueDTO reissueDTO);
 
-    @PatchMapping("")
-    @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
-
     @PostMapping("/email")
-    @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API입니다.")
+    @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -77,7 +67,7 @@ public interface AuthSpecification {
     );
 
     @PostMapping("/verification")
-    @Operation(summary = "인증 번호 확인 API", description = "사용자가 입력한 인증 번호를 확인하는 API입니다.")
+    @Operation(summary = "인증 번호 확인 API", description = "사용자가 입력한 인증 번호를 확인하는 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4007", description = "❌ 유효한 인증번호가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -87,7 +77,12 @@ public interface AuthSpecification {
     ApiResponse<AuthResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(@RequestBody @Valid AuthRequestDTO.VerifyAuthCodeRequestDTO request);
 
     @PostMapping("/login/kakao")
-    @Operation(summary = "카카오 소셜 로그인", description = "", security = @SecurityRequirement(name = ""))
+    @Operation(summary = "카카오 소셜 로그인", description = "카카오 소셜 로그인 API 입니다. 인가 코드를 Query String 에 담아 요청해주세요.", security = @SecurityRequirement(name = ""))
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
-    ApiResponse<Void> kakaoLogin(@RequestParam(value = "code") String code);
+    ApiResponse<UserResponseDTO.KakaoLoginDTO> loginKakao(@RequestParam(value = "code") String code);
+
+    @PostMapping("/signup/social")
+    @Operation(summary = "소셜 간편 가입", description = "소셜 로그인 시 계정이 존재하지 않을 때 약관 목록으로 간편 가입을 진행하는 API 입니다. (termId 1~4는 필수 동의 항목입니다.)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS")
+    ApiResponse<UserResponseDTO.TokenDTO> signupSocial(@RequestBody @Valid UserRequestDTO.UserTermsDTO userTermsDTO);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -15,6 +15,7 @@ import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentRequestDTO;
 import umc.GrowIT.Server.web.dto.PaymentDTO.PaymentResponseDTO;
 import umc.GrowIT.Server.web.dto.UserDTO.UserRequestDTO;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 public interface UserSpecification {
 
@@ -65,4 +66,15 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PWD4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
+
+
+    @PatchMapping("")
+    @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/OAuthDTO/OAuthResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OAuthDTO/OAuthResponseDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
@@ -37,6 +37,15 @@ public class UserRequestDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UserTermsDTO {
+        @NotEmpty(message = "필수 입력 항목입니다.")
+        private List<TermRequestDTO.UserTermDTO> userTerms;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class EmailLoginDTO {
 
         @NotBlank(message = "필수 입력 항목입니다.")

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -1,8 +1,9 @@
 package umc.GrowIT.Server.web.dto.UserDTO;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
-import java.util.List;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class UserResponseDTO {
 
@@ -33,5 +34,17 @@ public class UserResponseDTO {
         // TODO 디테일하게 결정 필요
         private String name;
         private String message; // ex) 회원 탈퇴가 완료되었습니다
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoLoginDTO {
+
+        private Boolean signupRequired;
+
+        @JsonInclude(NON_NULL)
+        private UserResponseDTO.TokenDTO tokens;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
API 개발하면서 리팩토링 조금하다보니 변경된 파일이 35개네요 🥺

죄송합니다 🙇‍♀️ 최대한 정리를 해보겠습니다ㅠㅠ

## 리팩토링
1. **jwt** 패키지 관련 파일 -> **기능에 맞춰 exception, filter, service, domain 패키지로 이동**

2. **SecurityConfig** 파일에서 auth 로 시작하는 api 경로를 **/auth/**** 로 통합해서 인증이 필요없도록 함 (AT 필요X)

3. User 엔티티 email -> **primaryEmail 필드 이름 변경** (소셜 로그인 하게 되면 한 명의 사용자에게 여러 이메일이 생기기 때문에 대표 이메일을 설정할 필요가 있다고 판단해서 네이밍 함)

4. Controller 에서 각자 맡은 부분이 다르다보니 통일성 없이 작성 되었는데, **Controller 에서 @PostMapping(/items) 과 같이 엔드포인트를 명시하는 코드**는 있어야 가독성이 좋다고 판단해서 없는 부분에 추가

5. 회원가입 / 로그인 관련 Swagger 명세에 설명 추가

6. [#110], [#142] 에서 카카오 서버에 API 호출하는 부분 비동기적으로 처리하던 부분 -> block() 사용해서 동기적으로 수정 (비동기 처리 방식이 성능 측면에서 더 좋을 것 같다고 생각해서 작성을 했는데, JPA 와 호환이 되지 않는다는 점도 있고, 비동기 처리를 제대로 하려면 WebFlux, R2DBC 등을 사용해야 하는데 저희 프로젝트와 기술 스택이 잘 맞지 않다고 판단했습니다..)

## 개발 : 카카오 로그인 API - 로그인 처리
### 카카오 로그인 처리 흐름
- 카카오에서 인가 코드 얻어오기 (프론트에서 처리할 예정)
- 인가 코드로 카카오에 토큰 발급 요청 
- 액세스 토큰으로 카카오에 사용자 이메일 요청
- **가입한 사용자라면 로그인 (-> 이 부분을 구현했습니다)**, 가입하지 않았다면 회원가입 처리

### 엔티티 관련
1. src/main/java/umc/GrowIT/Server/converter/OAuthAccountConverter.java
    src/main/java/umc/GrowIT/Server/domain/OAuthAccount.java
  | 카카오 서버에서 사용자 정보(이메일, 닉네임, 고유ID)를 가져오고 나서, **DB 저장을 위해 엔티티로 변환**
  - User 와 OAuthAccount 엔티티의 관계는 일대다 입니다. 한 명의 사용자가 여러 소셜 계정을 가질 수 있음

### 핵심 로직
1. src/main/java/umc/GrowIT/Server/service/oAuthService/kakaoService/KakaoServiceImpl.java
 | 카카오 로그인 API - 로그인 처리를 하는 핵심 로직 부분
- loginKakao() 메소드만 보시면 됩니다.
- 고유 ID 가 저장되어 있는지 확인
  - 고유 ID 존재 O : AT, RT 생성 -> RT DB 에 저장 -> 응답 _(회원가입 필요 여부(FALSE), 토큰(AT/RT))_
  - 고유 ID 존재 X : 응답 _(회원가입 필요 여부(TRUE), 토큰(NULL))_

2. src/main/java/umc/GrowIT/Server/repository/OAuthAccountRepository.java
  | OAuthAccount 의 고유 ID 로 OAuthAccount 엔티티 가져오는 메소드
 - 카카오 로그인에서, 로그인 처리 할지 혹은 회원가입 처리를 해야할지를
 - 고유ID 가 저장되어 있는지 여부를 확인해서 판단

### 응답 관련
1.  src/main/java/umc/GrowIT/Server/converter/UserConverter.java
    src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
  | **카카오 로그인 API 에 대한 응답 DTO** 생성
  - _로그인 성공 : 회원가입 필요 여부(FALSE), 토큰(AT/RT)_
  - _회원가입 요청 : 회원가입 필요 여부(TRUE), 토큰(NULL)_

2. src/main/java/umc/GrowIT/Server/apiPayload/code/status/SuccessStatus.java
  | 카카오 로그인 API 에서 추가적인 요청이 필요함을 나타내는 **202 상태 코드 응답** 추가한 부분 
  - 카카오 로그인 시, **기존 계정이 없는 경우 약관 동의는 받아서 가입 처리를 해야함**
  - 202 상태 코드를 통해 약관 목록, 소셜 회원가입 API 를 호출하도록 유도
  <img width="1049" alt="스크린샷 2025-02-04 오전 3 38 58" src="https://github.com/user-attachments/assets/538cf745-a54e-4cf8-a403-98134a19fe49" />


## 기타
간편 회원가입도 같이 PR 하려다가 많아지는 것 같아서 명세 부분만 만들었습니다.
1. src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
- 카카오 회원가입 처리할 때, 확장성을 고려해서 API 를 /auth/signup/kakao 가 아닌 **/auth/signup/social** 로 만듦
- 다른 소셜 계정도 약관 동의 목록만 받으면 바로 회원가입 처리를 할 수 있겠다고 판단

2. src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserRequestDTO.java
  | /auth/signup/social 의 요청 DTO (userTerms), **약관 동의 목록만 넘겨줌**

## 소셜 로그인 한계
현재 이메일로 회원가입 하고, 카카오로 로그인 했을 때

**동일한 사용자** 계정이 여러 개 생긴다는 문제점이 있는데 해결이 어려울 것 같습니다.

예를들어서 제가 email@gmail.com 이라는 계정으로 이메일 회원가입을 했습니다.
나중에 카카오 로그인을 하는데 카카오 사용자 정보에서 이메일이 동일하게 email@gmail.com 이라면 동일한 사용자라는 것을 판단하고, User, OAuthAccount 엔티티를 연결해주면서 기존 계정으로 통합할 수 있습니다.

하지만 kakao@gmail.com 이라면? 기존에 email@gmail.com 이라는 계정이 있는데도 불구하고 같은 사용자임을 판단하지 못해서 **동일한 사용자** 계정이 여러 개 생길 수 밖에 없습니다. 그래서 이메일로 비교하는 건 계정 연동이 됐다 안됐다 하기 때문에 한계가 명확하다고 생각해서 구현에서 배제했습니다. 동일한 사용자인지 판단하려면 생년월일이나 휴대폰과 같은 본인인증 정보가 필수적입니다.
(카카오에서 얻을 수 있는 정보는 이메일, 닉네임 정도이고.. 생년월일과 같은 본인인증 정보를 가져오려면 심사를 거쳐야 합니다.)

저희 서비스가 여러 계정이 생겼을 때 사용자가 더 편리한 서비스인가? 그것도 아니라서 본인 인증 정보를 통해 계정을 통합해주는 것이 필요합니다..

첫 번째 방법은 회원가입 할 때 본인인증을 거쳐서 회원가입을 진행하고, 카카오에서 심사를 거쳐 API 로 사용자 정보를 요구할 때 본인인증 정보를 가져올 수 있다면 카카오 로그인 시점에 계정을 통합할 수 있습니다. 그런데 현재로서 둘 다 어려운 상황입니다. 

그래서 제가 생각한 것은 계정 연동을 수동으로 처리할 수 밖에 없다고 생각이 들었는데..
기존처럼 OAuthAccount 엔티티에서 고유 ID 가 없으면 회원가입 처리하고, 회원가입 후 기존에 갖고있는 이메일 인증을 통해 동일 사용자임을 판단하고 기존 계정의 Diary, Challenge, Gro, Item 등의 정보를 합쳐주는 과정이 필요할 것 같습니다.
하지만 이때도 일기는 하루에 한 개밖에 못 쓰기 때문에 같은 날에 각 계정마다 썼다면 합쳐주는 것이 어려울 것 같습니다 ㅠㅠ
(사용자한테 merge 충돌 해결하라고 시켜야 함..)

## 🔍 테스트 방법
1. 카카오 로그인 성공
<img width="1084" alt="스크린샷 2025-02-04 오전 3 03 39" src="https://github.com/user-attachments/assets/ca11ab6c-f563-4931-8ac8-02c1e7265898" />
2. 간편가입 요청
<img width="1097" alt="스크린샷 2025-02-04 오전 3 04 42" src="https://github.com/user-attachments/assets/5c5e9c59-9d0a-4917-807d-1ef19eee31e1" />
