### PR TITLE
[#135] Refactor : 착용용 이미지 응답 추가 및 이미지url 전달방식 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -19,11 +19,10 @@ public class ItemConverter {
     public static ItemResponseDTO.ItemDTO toItemDTO(
             Item item,
             Long userId,
-            ItemRepository itemRepository,
+            ItemStatus status,
+            boolean isPurchased,
             String itemUrl,
             String groItemUrl) {
-
-        ItemStatus status = itemRepository.findStatusByUserIdAndItemId(userId, item.getId());
 
         return ItemResponseDTO.ItemDTO.builder()
                 .id(item.getId())
@@ -34,14 +33,15 @@ public class ItemConverter {
                 .shopBackgroundColor(item.getShopBackgroundColor())
                 .category(item.getCategory().toString())
                 .status(status != null ? status.toString() : null)
-                .purchased(itemRepository.existsByUserItemsUserIdAndId(userId, item.getId()))
+                .purchased(isPurchased)
                 .build();
     }
 
     public static ItemResponseDTO.ItemListDTO toItemListDTO(
             List<Item> itemList,
             Long userId,
-            ItemRepository itemRepository,
+            Map<Long, ItemStatus> itemStatuses,
+            Map<Long, Boolean> purchaseStatuses,
             Map<Item, String> itemUrls,
             Map<Item, String> groItemUrls) {
 
@@ -50,7 +50,8 @@ public class ItemConverter {
                         .map(item -> toItemDTO(
                                 item,
                                 userId,
-                                itemRepository,
+                                itemStatuses.get(item.getId()),
+                                purchaseStatuses.get(item.getId()),
                                 itemUrls.get(item),
                                 groItemUrls.get(item)))
                         .collect(Collectors.toList()))

--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -10,31 +10,49 @@ import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipResponseDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ItemConverter {
 
     //아이템 1개 반환
-    public static ItemResponseDTO.ItemDTO toItemDTO(Item item, Long userId, ItemRepository itemRepository) {
+    public static ItemResponseDTO.ItemDTO toItemDTO(
+            Item item,
+            Long userId,
+            ItemRepository itemRepository,
+            String itemUrl,
+            String groItemUrl) {
+
         ItemStatus status = itemRepository.findStatusByUserIdAndItemId(userId, item.getId());
 
         return ItemResponseDTO.ItemDTO.builder()
                 .id(item.getId())
                 .name(item.getName())
                 .price(item.getPrice())
-                .imageUrl(item.getImageUrl())
+                .imageUrl(itemUrl)
+                .groImageUrl(groItemUrl)
                 .shopBackgroundColor(item.getShopBackgroundColor())
                 .category(item.getCategory().toString())
-                .status(status != null ? status.toString() : null) //status가 null일 경우(보유하지않은 경우) >> 기본값 null로 설정
+                .status(status != null ? status.toString() : null)
                 .purchased(itemRepository.existsByUserItemsUserIdAndId(userId, item.getId()))
                 .build();
     }
 
-    //아이템리스트 반환
-    public static ItemResponseDTO.ItemListDTO toItemListDTO(List<Item> itemList, Long userId, ItemRepository itemRepository) {
+    public static ItemResponseDTO.ItemListDTO toItemListDTO(
+            List<Item> itemList,
+            Long userId,
+            ItemRepository itemRepository,
+            Map<Item, String> itemUrls,
+            Map<Item, String> groItemUrls) {
+
         return ItemResponseDTO.ItemListDTO.builder()
                 .itemList(itemList.stream()
-                        .map(item -> toItemDTO(item, userId, itemRepository))
+                        .map(item -> toItemDTO(
+                                item,
+                                userId,
+                                itemRepository,
+                                itemUrls.get(item),
+                                groItemUrls.get(item)))
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
@@ -28,4 +28,5 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("SELECT ui.status FROM UserItem ui WHERE ui.user.id = :userId AND ui.item.id = :itemId")
     ItemStatus findStatusByUserIdAndItemId(Long userId, Long itemId);
 
+
 }

--- a/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserItemRepository.java
@@ -2,10 +2,12 @@ package umc.GrowIT.Server.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserItem;
+import umc.GrowIT.Server.domain.enums.ItemCategory;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +21,8 @@ public interface UserItemRepository extends JpaRepository<UserItem, Long>  {
 
     //해당 아이템을 사용자가 보유했는지 (userId, itemId)
     Optional<UserItem> findByUserIdAndItemId(Long userId, Long itemId);
+
+        @Query("SELECT ui.item FROM UserItem ui WHERE ui.user.id = :userId AND ui.item.category = :category")
+        List<Item> findItemsByUserIdAndCategory(@Param("userId") Long userId, @Param("category") ItemCategory category);
+
 }

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemCommandServiceImpl.java
@@ -63,30 +63,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         return ItemConverter.toPurchaseItemResponseDTO(savedUserItem);
     }
 
-//    @Override
-//    public ItemEquipResponseDTO updateItemStatus(Long userId, Long itemId, String status) {
-//
-//        UserItem userItem = userItemRepository.findByUserIdAndItemId(userId, itemId)
-//                .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_OWNED));
-//
-//        // 오류 코드를 구분하기위한 조건문
-//        if (userItem.getStatus() != ItemStatus.valueOf(status)) {
-//            // 사용자가 현재 상태를 해제상태(UNEQUIPPED)로 전달했는데 실제로는 해제상태가 아닌 경우 -> 실제로는 착용중인 아이템인데 해제상태라고 잘못 전달한 경우
-//            if (ItemStatus.valueOf(status) == ItemStatus.UNEQUIPPED && userItem.getStatus() != ItemStatus.UNEQUIPPED) {
-//                throw new ItemHandler(ErrorStatus.ITEM_ALREADY_EQUIPPED);
-//            }
-//
-//            // 사용자가 현재 상태를 착용상태(EQUIPPED)로 전달했는데 실제로는 착용상태가 아닌 경우 -> 실제로는 해제상태인 아이템인데 착용상태라고 잘못 전달한 경우
-//            if(ItemStatus.valueOf(status) == ItemStatus.EQUIPPED && userItem.getStatus() != ItemStatus.EQUIPPED) {
-//                throw new ItemHandler(ErrorStatus.ITEM_NOT_EQUIPPED);
-//            }
-//        }
-//
-//        userItem.toggleStatus();
-//
-//        return ItemConverter.itemEquipDTO(userItem);
-//    }
-
 
     @Override
     public ItemEquipResponseDTO updateItemStatus(Long userId, Long itemId, String requestStatus) {

--- a/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ItemService/ItemQueryServiceImpl.java
@@ -49,14 +49,15 @@ public class ItemQueryServiceImpl implements ItemQueryService {
     @Override
     @Transactional(readOnly = true)
     public ItemResponseDTO.ItemListDTO getUserOwnedItemList(ItemCategory category, Long userId) {
-        // 사용자가 보유한 아이템 목록 조회
-        List<Item> ownedItemList = userItemRepository.findItemsByUserIdAndCategory(userId, category);
+        // 기존의 잘 작동하던 코드 유지
+        List<Item> userItems = itemRepository.findItemsByUserIdAndCategory(userId, category);
 
-        // 각 아이템에 대한 Pre-signed URL 생성
-        Map<Item, String> itemUrls = createItemPreSignedUrl(ownedItemList);
-        Map<Item, String> groItemUrls = createGroItemPreSignedUrl(ownedItemList);
+        // Pre-signed URL 생성 로직만 추가
+        Map<Item, String> itemUrls = createItemPreSignedUrl(userItems);
+        Map<Item, String> groItemUrls = createGroItemPreSignedUrl(userItems);
 
-        return ItemConverter.toItemListDTO(ownedItemList, userId, itemRepository, itemUrls, groItemUrls);
+        // converter에 URL 맵 전달
+        return ItemConverter.toItemListDTO(userItems, userId, itemRepository, itemUrls, groItemUrls);
     }
 
     // 상점 리스트용 이미지의 Pre-signed URL 생성

--- a/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ItemDTO/ItemResponseDTO.java
@@ -33,8 +33,11 @@ public class ItemResponseDTO {
         @Schema(description = "아이템 가격 (크레딧)", example = "120")
         Integer price;
 
-        @Schema(description = "이미지 URL")
+        @Schema(description = "상점 리스트용 이미지 URL")
         String imageUrl;
+
+        @Schema(description = "그로 착용용 이미지 URL")
+        String groImageUrl;
 
         @Schema(description = "상점에서 사용될 경우 배경색")
         String shopBackgroundColor;
@@ -47,8 +50,6 @@ public class ItemResponseDTO {
 
         @Schema(description = "구매 여부", example = "false")
         boolean purchased;
-
-
     }
 
     // 아이템 주문 응답 DTO


### PR DESCRIPTION
## 📝 작업 내용
### 착용용이미지(groImageUrl)를 응답에 추가시켰습니다
- ItemResponseDTO
  -  __`String groImageUrl;`__ 추가
- ItemCommandServiceImpl
  - updateItemStatus 주석처리 되어있던 기존코드 제거
### 이미지 url 전달방식 변경
기존에 s3에 저장된 이미지의 실제 url을 직접 전달하는 방식에서 Pre-signed URL을 생성해서 전달하는 방식으로 변경하였습니다. 코드는 기존에 진성님께서 구현하셨던 _`GroCommandServiceImpl`_을 참고했습니다.
- ItemQueryServiceImpl
  -  createItemPreSignedUrl <- 리스트용 이미지 Pre - sigened url생성
  - createGroItemPreSignedUrl <- 착용용 이미지 Pre - sigened url생성
-----
### 영향을 받은 api
- 보유중인 아이템 조회 (GET - /users/items)
- 카테고리별 아이템 조회 (GET - /items)

## 🔍 테스트 방법
![스크린샷 2025-02-04 165512](https://github.com/user-attachments/assets/db3cd7d7-97c4-4c3d-96ed-2ef89c3ba60d)
