### PR TITLE
[#152] Feat: AI 일기 생성 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
@@ -1,0 +1,21 @@
+package umc.GrowIT.Server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class OpenAiConfig {
+    @Value("${openai.api.key}")
+    private String openAiKey;
+    @Bean
+    public RestTemplate template(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + openAiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -68,4 +68,11 @@ public class DiaryConverter {
                 .message("일기를 삭제했어요.")
                 .build();
     }
+
+    public static DiaryResponseDTO.VoiceChatResultDTO toVoiceChatResultDTO(String aiChat){
+
+        return DiaryResponseDTO.VoiceChatResultDTO.builder()
+                .chat(aiChat)
+                .build();
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -75,4 +75,13 @@ public class DiaryConverter {
                 .chat(aiChat)
                 .build();
     }
+
+    public static DiaryResponseDTO.SummaryResultDTO toSummaryResultDTO(Diary diary){
+
+        return DiaryResponseDTO.SummaryResultDTO.builder()
+                .diaryId(diary.getId())
+                .content(diary.getContent())
+                .date(diary.getDate())
+                .build();
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -10,4 +10,6 @@ public interface DiaryCommandService {
     public DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId);
 
     public DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId);
+
+    public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -12,4 +12,6 @@ public interface DiaryCommandService {
     public DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId);
 
     public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
+
+    public DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -41,6 +41,9 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     @Override
     public DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId) {
 
+        //유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
@@ -91,6 +94,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
     @Override
     public DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId) {
+        //유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
@@ -102,6 +107,9 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
     @Override
     public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId) {
+
+        //유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         String userChat = request.getChat();
 
@@ -135,6 +143,58 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         System.out.println(messages);
 
         return DiaryConverter.toVoiceChatResultDTO(aiChat);
+    }
+
+    @Override
+    public DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId) {
+
+        //유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 기존 대화 목록 가져오기
+        List<ChatGPTRequest> messages = conversationHistory.get(userId);
+
+        // AI에게 대화내용 요약
+        messages.add(new ChatGPTRequest("user", "지금까지의 대화 내용을 요약해서 일기를 생성해줘. 가능하면 100자 이상으로 만들어줘."));
+
+        // ChatGPT 요청 생성
+        ChatGPTRequest gptRequest = new ChatGPTRequest(model, messages.toString());
+
+        // API 요청 및 응답 처리
+        ChatGPTResponse chatGPTResponse = template.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
+
+        if (chatGPTResponse == null || chatGPTResponse.getChoices().isEmpty()) {
+            //Todo: 응답이 없을 때 예외 처리
+        }
+
+        String aiChat = chatGPTResponse.getChoices().get(0).getMessage().getContent();
+
+        //날짜 검사(오늘 이후의 날짜 x)
+        if (request.getDate().isAfter(LocalDate.now())) {
+            throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);
+        }
+
+        //날짜 검사(이미 해당 날짜에 작성된 일기가 존재)
+        if(diaryRepository.existsByUserIdAndDate(userId, request.getDate())){
+            throw new DiaryHandler(ErrorStatus.DIARY_ALREADY_EXISTS);
+        }
+
+        //일기 생성
+        Diary diary = Diary.builder()
+                .content(aiChat)
+                .user(user)
+                .date(request.getDate())
+                .build();
+
+        //일기 저장
+        diary = diaryRepository.save(diary);
+
+        // 대화 기록 삭제
+        conversationHistory.remove(userId);
+
+        System.out.println(messages);
+
+        return DiaryConverter.toSummaryResultDTO(diary);
     }
 
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -1,7 +1,10 @@
 package umc.GrowIT.Server.service.diaryService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.DiaryHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
@@ -12,15 +15,29 @@ import umc.GrowIT.Server.repository.UserRepository;
 import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+import umc.GrowIT.Server.web.dto.OpenAIDTO.ChatGPTRequest;
+import umc.GrowIT.Server.web.dto.OpenAIDTO.ChatGPTResponse;
+import umc.GrowIT.Server.web.dto.OpenAIDTO.Message;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
+    @Autowired
+    private RestTemplate template;
+
+    private final Map<Long, List<ChatGPTRequest>> conversationHistory = new HashMap<>();
     @Override
     public DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId) {
 
@@ -82,4 +99,43 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         return DiaryConverter.toDeleteResultDTO(diary);
     }
+
+    @Override
+    public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId) {
+
+        String userChat = request.getChat();
+
+        // 사용자 대화 기록이 없으면 초기화
+        conversationHistory.putIfAbsent(userId, new ArrayList<>());
+
+        // 기존 대화 목록 가져오기
+        List<ChatGPTRequest> messages = conversationHistory.get(userId);
+
+        // 사용자의 입력을 대화 목록에 추가
+        messages.add(new ChatGPTRequest("user", userChat));
+
+        // ChatGPT 요청 생성
+        ChatGPTRequest gptRequest = new ChatGPTRequest(model, messages.toString());
+
+        // API 요청 및 응답 처리
+        ChatGPTResponse chatGPTResponse = template.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
+
+        if (chatGPTResponse == null || chatGPTResponse.getChoices().isEmpty()) {
+            return DiaryConverter.toVoiceChatResultDTO("응답이 없습니다.");
+        }
+
+        String aiChat = chatGPTResponse.getChoices().get(0).getMessage().getContent();
+
+        // AI의 응답을 대화 목록에 추가
+        messages.add(new ChatGPTRequest("assistant", aiChat));
+
+        // 대화 기록 유지
+        conversationHistory.put(userId, messages);
+
+        System.out.println(messages);
+
+        return DiaryConverter.toVoiceChatResultDTO(aiChat);
+    }
+
+
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -37,6 +37,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     @Autowired
     private RestTemplate template;
 
+    //userId-대화내용 저장용 HashMap
     private final Map<Long, List<ChatGPTRequest>> conversationHistory = new HashMap<>();
     @Override
     public DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId) {
@@ -140,8 +141,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         // 대화 기록 유지
         conversationHistory.put(userId, messages);
 
-        System.out.println(messages);
-
         return DiaryConverter.toVoiceChatResultDTO(aiChat);
     }
 
@@ -191,8 +190,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         // 대화 기록 삭제
         conversationHistory.remove(userId);
-
-        System.out.println(messages);
 
         return DiaryConverter.toSummaryResultDTO(diary);
     }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -84,9 +84,7 @@ public class DiaryController implements DiarySpecification {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        //Todo: 음성인식내용을 토대로 AI답변 생성, 대화내용 저장
-
-        return null;
+        return ApiResponse.onSuccess(diaryCommandService.chatByVoice(request, userId));
     }
 
     @PostMapping("/summary")

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -94,9 +94,7 @@ public class DiaryController implements DiarySpecification {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        //Todo: 저장된 대화 내용을 토대로 요약 및 일기 작성
-
-        return null;
+        return ApiResponse.onSuccess(diaryCommandService.createDiaryByVoice(request, userId));
     }
 
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -78,12 +78,28 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryCommandService.createDiary(request, userId));
     }
     @PostMapping("/voice")
-    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.CreateDiaryDTO request){
-        //Todo: 음성인식 결과를 다듬어주는 로직 필요
+    public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request){
+
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        //Todo: 음성인식내용을 토대로 AI답변 생성, 대화내용 저장
+
         return null;
     }
 
+    @PostMapping("/summary")
+    public ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(DiaryRequestDTO.SummaryDTO request) {
 
+        //accessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        //Todo: 저장된 대화 내용을 토대로 요약 및 일기 작성
+
+        return null;
+    }
 
 
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -20,8 +20,7 @@ public class DiaryController implements DiarySpecification {
     private final DiaryQueryService diaryQueryService;
     private final DiaryCommandService diaryCommandService;
     @GetMapping("/dates")
-    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                       @RequestParam Integer year,
+    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year,
                                                                        @RequestParam Integer month){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -30,8 +29,7 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("/")
-    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                   @RequestParam Integer year,
+    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year,
                                                                    @RequestParam Integer month){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -40,8 +38,7 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryQueryService.getDiaryList(year,month,userId));
     }
     @GetMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                           @PathVariable("diaryId") Long diaryId){
+    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
@@ -50,8 +47,7 @@ public class DiaryController implements DiarySpecification {
     }
 
     @PatchMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                          @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
@@ -60,8 +56,7 @@ public class DiaryController implements DiarySpecification {
     }
 
     @DeleteMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                          @PathVariable("diaryId") Long diaryId){
+    public ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
@@ -69,8 +64,7 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
     }
     @PostMapping("/text")
-    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                                @RequestBody DiaryRequestDTO.CreateDiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.CreateDiaryDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
@@ -88,7 +82,7 @@ public class DiaryController implements DiarySpecification {
     }
 
     @PostMapping("/summary")
-    public ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(DiaryRequestDTO.SummaryDTO request) {
+    public ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request) {
 
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -17,8 +17,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                @RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month);
 
     @GetMapping("/")
     @Operation(summary = "일기 모아보기 API",description = "특정 사용자가 작성한 일기를 모아보는 API입니다. query string으로 year와 month를 넘겨주면 해당 월에 작성한 일기들의 리스트, 작성한 일기 수를 보내줍니다.")
@@ -26,9 +25,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                            @RequestParam Integer year,
-                                                            @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month);
 
     @GetMapping("/{diaryId}")
     @Operation(summary = "특정 일기 조회 API",description = "특정 사용자가 작성한 특정 일기를 조회하는 API입니다. path variable로 일기의 id를 넘겨주면 해당 일기의 세부적인 내용을 보내줍니다.")
@@ -36,8 +33,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                    @PathVariable("diaryId") Long diaryId);
+    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId);
 
     @PatchMapping("/{diaryId}")
     @Operation(summary = "일기 수정하기 API",description = "특정 사용자가 작성한 일기를 수정하는 API입니다. path variable로 일기의 id, RequestBody로 수정한 내용과 수정 시간을 보내주세요")
@@ -46,8 +42,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004",description = "기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                          @PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
+    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId,
+                                                                          @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")
@@ -55,8 +51,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                   @PathVariable("diaryId") Long diaryId);
+    ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")
@@ -65,8 +60,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4002",description = "날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestHeader(value = "Authorization", required = false) String authorizationHeader,
-                                                                         @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
     @PostMapping("/voice")
     @Operation(summary = "음성 대화하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용(STT)을 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -69,10 +69,16 @@ public interface DiarySpecification {
                                                                          @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
     @PostMapping("/voice")
-    @Operation(summary = "음성으로 일기 작성하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용과 작성일자를 보내주세요")
+    @Operation(summary = "음성 대화하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용(STT)을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.CreateDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request);
+
+    @PostMapping("/summary")
+    @Operation(summary = "음성대화 종료 및 요약 후 일기 생성 API",description = "음성 대화를 종료하면서 음성 대화하기 API를 사용하여 대화한 내용을 바탕으로 그 날의 일기를 작성해주는 API입니다. 작성 날짜를 보내주세요.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -22,4 +22,18 @@ public class DiaryRequestDTO {
         @NotNull
         String content; //수정 내용
     }
+
+    @Getter
+    @Setter
+    public static class VoiceChatDTO {
+        @NotNull
+        String chat; //사용자의 음성내용
+    }
+
+    @Getter
+    @Setter
+    public static class SummaryDTO {
+        @NotNull
+        String date;
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -34,6 +34,6 @@ public class DiaryRequestDTO {
     @Setter
     public static class SummaryDTO {
         @NotNull
-        String date;
+        LocalDate date;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -68,4 +68,22 @@ public class DiaryResponseDTO {
     public static class DeleteDiaryResultDTO {
         String message;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VoiceChatResultDTO {
+        String chat;    //AI의 답변내용
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SummaryResultDTO {
+        Long diaryId;
+        String content;
+        LocalDate date;
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTRequest.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTRequest.java
@@ -1,0 +1,20 @@
+package umc.GrowIT.Server.web.dto.OpenAIDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ChatGPTRequest {
+    private String model;
+    private List<Message> messages;
+
+    public ChatGPTRequest(String model, String prompt) {
+        this.model = model;
+        this.messages =  new ArrayList<>();
+        this.messages.add(new Message("user", prompt));
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTResponse.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTResponse.java
@@ -1,0 +1,24 @@
+package umc.GrowIT.Server.web.dto.OpenAIDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatGPTResponse {
+    private List<Choice> choices;
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/Message.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/Message.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.web.dto.OpenAIDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+    private String role;
+    private String content;
+
+}


### PR DESCRIPTION
## 📝 작업 내용
> 1. AI와 대화하는 API 구현 (POST /diaries/voice)
> 2. AI와 대화 종료하며 요약 일기 생성하는 API 구현 (POST /diaries/summary)
> - 테스트해보고 싶어 제 개인계정으로 API Key를 발급받아보았습니다. 
> - gpt-3.5-turbo 모델 사용해봤습니다.
> - application.yml 파일에 openai 관련 정보가 필요합니다. 우선 노션에 yml 업데이트 해놓겠습니다.


## 🔍 테스트 방법
> 1. 첫 대화
> 아직 파인튜닝, 프롬프트 엔지니어링을 하지 않아서 그냥 웹에서 gpt에게 말하는 것과 동일하다고 보시면 됩니다.
<img width="707" alt="image" src="https://github.com/user-attachments/assets/7d667517-871c-4070-a5c1-f83a40171ab3" />

> 2. 대화 이어가기
<img width="710" alt="image" src="https://github.com/user-attachments/assets/51917bf6-8a9b-4746-a4e9-5c6a0fad73c4" />

> 3. 대화 종료 후 요약
> 대화 종료 시에 date값을 전달받아 해당 날짜의 일기를 생성합니다.
<img width="706" alt="image" src="https://github.com/user-attachments/assets/46c39eee-b914-4516-8d18-6fb04f798893" />

> 4. 작성된 일기 조회
<img width="704" alt="image" src="https://github.com/user-attachments/assets/6f8d6d8d-4bb0-4f43-bc67-2a648f91572d" />

> 5. 새로 대화해보기
<img width="710" alt="image" src="https://github.com/user-attachments/assets/349f0d1e-c6d8-411d-ab83-2ea50601e81e" />

> 6. 대화 내용 확인하기
> 대화 종료 전까지 대화 내용이 저장되는지 확인해보겠습니다.
> 그냥 대화 내용을 쭉 이어붙여서 요청하기 때문에 약간 어색함이 있습니다.
<img width="709" alt="image" src="https://github.com/user-attachments/assets/8a16250a-3bf8-400b-b5ae-c67791fbdbf7" />
<img width="711" alt="image" src="https://github.com/user-attachments/assets/a40689c6-6091-4247-94de-8c549e234c4f" />

> 7. 두번째 대화 종료
<img width="704" alt="image" src="https://github.com/user-attachments/assets/c473278c-43a2-4552-8e45-b552b0d3d264" />

> 8. 두 번째 일기 확인
> 대화 종료하실 때 다른날짜를 주셔야합니다.
<img width="707" alt="image" src="https://github.com/user-attachments/assets/bd166741-67c4-46f7-95df-64d3f785b740" />








