### PR TITLE
[#155] Refactor: 선택한 챌린지 저장 API 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -57,11 +57,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CHALLENGE_VERIFY_NOT_EXISTS(HttpStatus.BAD_REQUEST, "CHALLENGE4002", "챌린지 인증 내역이 존재하지 않습니다."),
     CHALLENGE_NOT_COMPLETE(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "미완료한 챌린지입니다."),
     CHALLENGE_VERIFY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "이미 완료된 챌린지입니다."),
-    CHALLENGE_ALREADY_SAVED(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "이미 저장된 챌린지입니다."),
-    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "챌린지는 3개까지 저장 가능합니다."),
-    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "최소 하나의 챌린지를 선택해야 합니다."),
-    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4008", "데일리 챌린지는 최대 2개까지만 저장 가능합니다."),
-    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4009", "랜덤 챌린지는 1개만 저장 가능합니다."),
+    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "챌린지는 3개까지 저장 가능합니다."),
+    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "최소 하나의 챌린지를 선택해야 합니다."),
+    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "데일리 챌린지는 최대 2개까지만 저장 가능합니다."),
+    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4008", "랜덤 챌린지는 1개만 저장 가능합니다."),
 
     //기타 에러
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD4001", "비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -58,6 +58,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CHALLENGE_NOT_COMPLETE(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "미완료한 챌린지입니다."),
     CHALLENGE_VERIFY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "이미 완료된 챌린지입니다."),
     CHALLENGE_ALREADY_SAVED(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "이미 저장된 챌린지입니다."),
+    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "챌린지는 3개까지 저장 가능합니다."),
+    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "최소 하나의 챌린지를 선택해야 합니다."),
+    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4008", "데일리 챌린지는 최대 2개까지만 저장 가능합니다."),
+    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4009", "랜덤 챌린지는 1개만 저장 가능합니다."),
 
     //기타 에러
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD4001", "비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -86,13 +86,20 @@ public class ChallengeConverter {
     }
 
     // 선택한 챌린지 저장
-    public static ChallengeResponseDTO.SelectChallengeDTO toSelectChallengeDTO(UserChallenge userChallenge) {
+    public static ChallengeResponseDTO.SelectChallengeDTO toSelectChallengeDTO(List<UserChallenge> userChallenges) {
+        List<ChallengeResponseDTO.SelectedChallengesInfo> selectedChallenges = userChallenges.stream()
+                .map(userChallenge -> ChallengeResponseDTO.SelectedChallengesInfo.builder()
+                        .id(userChallenge.getId()) // ✅ UserChallenge ID
+                        .challengeId(userChallenge.getChallenge().getId()) // ✅ Challenge ID
+                        .dtype(userChallenge.getDtype())
+                        .title(userChallenge.getChallenge().getTitle())
+                        .content(userChallenge.getChallenge().getContent())
+                        .time(userChallenge.getChallenge().getTime())
+                        .build())
+                .toList();
+
         return ChallengeResponseDTO.SelectChallengeDTO.builder()
-                .id(userChallenge.getChallenge().getId())
-                .dtype(userChallenge.getDtype())
-                .title(userChallenge.getChallenge().getTitle())
-                .content(userChallenge.getChallenge().getContent())
-                .time(userChallenge.getChallenge().getTime())
+                .selectedChallenges(selectedChallenges) // ✅ 여러 개의 챌린지 리스트 반환
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface ChallengeCommandService {
 
-    ChallengeResponseDTO.SelectChallengeDTO selectChallenge(Long userId, Long challengeId, UserChallengeType dtype);
+    ChallengeResponseDTO.SelectChallengeDTO selectChallenges(Long userId, List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
     ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
     ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
     ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -60,6 +60,11 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
                 }
             }
 
+            // 데일리 챌린지와 랜덤 챌린지 합쳐서 최소 1개 이상 선택
+            if (dailyChallengeCount == 0 && randomChallengeCount == 0) {
+                throw new ChallengeHandler(ErrorStatus.CHALLENGE_AT_LEAST);
+            }
+
             // 각 챌린지를 UserChallenge로 생성 및 저장
             List<UserChallenge> userChallenges = challengeIds.stream()
                     .map(challengeId -> {
@@ -75,16 +80,6 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
             savedUserChallenges.addAll(userChallenges);
         }
 
-        // 데일리와 랜덤 챌린지 합쳐서 최소 1개 이상 선택했는지 확인
-        int totalChallengesCount = dailyChallengeCount + randomChallengeCount;
-        if (totalChallengesCount == 0) {
-            throw new ChallengeHandler(ErrorStatus.CHALLENGE_AT_LEAST);
-        }
-
-        // 예외 처리: 최대 3개까지 선택 가능
-        if (totalChallengesCount > 3) {
-            throw new ChallengeHandler(ErrorStatus.CHALLENGE_SAVE_LIMIT);
-        }
 
         // DTO 변환 및 반환
         return ChallengeConverter.toSelectChallengeDTO(savedUserChallenges);

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -53,11 +53,11 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @PostMapping("/{challengeId}/select")
-    public ApiResponse<ChallengeResponseDTO.SelectChallengeDTO> selectChallenge(@PathVariable Long challengeId, @RequestParam UserChallengeType dtype) {
+    public ApiResponse<ChallengeResponseDTO.SelectChallengeDTO> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        ChallengeResponseDTO.SelectChallengeDTO response = challengeCommandService.selectChallenge(userId, challengeId, dtype);
+        ChallengeResponseDTO.SelectChallengeDTO response = challengeCommandService.selectChallenges(userId, selectRequestList);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -40,12 +40,28 @@ public interface ChallengeSpecification {
 
     @PostMapping("{challengeId}/select")
     @Operation(summary = "선택된 챌린지 저장 API", description = "사용자가 선택한 챌린지를 저장하는 API입니다. <br> " +
-            "저장하고 싶은 챌린지 ID를 path variable로 넘겨주세요.")
+            "DAILY와 RANDOM에 각각 저장하고 싶은 챌린지 아이디를 입력하여 리스트 형태로 보내주세요. <br> " +
+            "데일리챌린지는 최대 2개까지 저장할 수 있으며, 랜덤챌린지는 최대 1개까지 저장할 수 있습니다. <br> " +
+            "ex) [\n" +
+            "  {\n" +
+            "    \"challengeIds\": [\n" +
+            "      1,2\n" +
+            "    ],\n" +
+            "    \"dtype\": \"DAILY\"\n" +
+            "  },\n" +
+            "  {\n" +
+            "    \"challengeIds\": [\n" +
+            "      3\n" +
+            "    ],\n" +
+            "    \"dtype\": \"RANDOM\"\n" +
+            "  }\n" +
+            "]"
+    )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.SelectChallengeDTO> selectChallenge(@PathVariable Long challengeId, @RequestParam UserChallengeType dtype);
+    ApiResponse<ChallengeResponseDTO.SelectChallengeDTO> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
 
     @PostMapping(value = "{userChallengeId}/prove", consumes = "multipart/form-data")
     @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다. <br>" +

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -24,5 +24,13 @@ public class ChallengeRequestDTO {
         private String thoughts;
     }
 
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SelectChallengeRequestDTO {
+        private List<Long> challengeIds;
+        private UserChallengeType dtype;
+    }
 
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -107,13 +107,21 @@ public class ChallengeResponseDTO {
         private LocalDateTime certificationDate;
     }
 
-    // 선택한 챌린지 저장
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SelectChallengeDTO {
+        private List<SelectedChallengesInfo> selectedChallenges;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SelectedChallengesInfo {
         private Long id;
+        private Long challengeId;
         private UserChallengeType dtype;
         private String title;
         private String content;


### PR DESCRIPTION
## 📝 작업 내용
> 수정 내용이 너무 길어져서 새로 올립니다.
챌린지 인증 내역 수정 관련 부분(ex. dto 수정, oldImageUrl 변수 처리)은 따로 refactor 브랜치 파서 수정하겠습니다..

🐎 선택한 챌린지 저장 api 수정사항
- 기존: challengeId를 PathVariable로 입력하고 dtype을 DAILY, RANDOM 중 선택하여 넘기는 식
- 변경: challengeId를 dtype과 함께 RequestBody 리스트 형태로 넘기는 식(dtype은 STRING값으로 입력받음, "RANDOM" 또는 "DAILY"로 입력해야 하며 다른값을 입력하면 에러 발생)

ChallengeCommandServiceImpl 파일의 selectChallenges 코드 내용이 많이 수정되었는데 데일리챌린지는 최대 2개, 랜덤챌린지는 최대 1개.. 이런식으로 예외 처리를 다 하다보니 조금 길어지고 복잡해졌습니다. ai가 챌린지를 추천해주면 사용자가 그 중 챌린지를 1개~3개 선택하여 저장할 수 있다고 해서 dtype에 따라 예외 처리를 하였습니다.
(ex. 챌린지를 2개 선택하여 저장하는 경우 데일리챌린지2개를 선택해도 되고 데일리챌린지1개+랜덤챌린지1개 이런식으로 선택해도 된다고 합니다. -> 챌린지를 선택하여 저장하는 화면에서는 dtype이 데일리인지, 랜덤인지 따로 노출을 하지 않는다고 하여 챌린지 선택하여 저장 시 dtype 처리는 ai 챌린지 추천 기능 작업하면서 수정해야할 것 같습니다..)

데일리챌린지가 0개이고 동시에 랜덤챌린지가 0개이면 totalChallengesCount를 선언하지 않고도 예외 처리할 수 있을 것 같아 수정해보겠습니다. -> 수정 완료하였으나 totalChallengesCount를 따로 사용하는게 코드가 더 깔끔할 것 같으면 되돌리겠습니다! (데일리챌린지 3개 이상 선택하거나 랜덤챌린지 2개 이상 선택하면 예외가 발생하다보니 데일리챌린지+랜덤챌린지 4개 이상 선택하면 예외가 발생하지 않기 때문에 삭제하였습니다. -> ex. 데일리챌린지 3개, 랜덤챌린지 1개 선택하는 경우 데일리챌린지를 최대 2개 선택해야 한다는 예외 발생 )

dtype은 userChallenge에 데이터를 추가하기 위해 requestbody에 넣어둔 것이고 추후에 수정할 것.
(챌린지 홈 조회 시 '오늘의 추천 챌린지' 부분도 로컬에 저장했다가 정각이 지나면 로컬을 삭제하는 방식으로 구현할 것. -> 현재 쿼리문으로 0시~24시가 지나면 챌린지 목록이 초기화되게 수정하였는데 챌린지 홈 조회 refactor/#150 브랜치에서 작업중입니다.)

## 🔍 테스트 방법
> 처음 화면입니다. 데일리챌린지와 랜덤챌린지를 합쳐 최대 3개를 저장할 수 있습니다.
![image](https://github.com/user-attachments/assets/a9db9b21-2e3f-4699-bd4f-75f557291abc)
1. 랜덤챌린지를 1개만 선택한 경우(정상)
![image](https://github.com/user-attachments/assets/c107cc61-7ca6-42e0-afcf-ea4763b6be9d)
2. 랜덤챌린지를 2개 이상 선택한 경우(에러)
![image](https://github.com/user-attachments/assets/a337a65b-c50f-4007-a992-f76c82feb5da)
3. 데일리챌린지를 1개만 선택한 경우(정상)
![image](https://github.com/user-attachments/assets/6dd71e19-4e50-438a-86d2-0d22967a2044)
4. 데일리챌린지를 2개 선택한 경우(정상)
![image](https://github.com/user-attachments/assets/9e347557-2ad5-46b0-bcc2-2452cbc3e76b)
5. 데일리챌린지를 3개 선택한 경우(에러)
![image](https://github.com/user-attachments/assets/70a90fe8-d88b-4ea5-a120-2043723a1fa7)
6. 데일리챌린지 2개+랜덤챌린지 1개 선택한 경우(정상)
![image](https://github.com/user-attachments/assets/89d9e6f6-7afe-4675-90bc-7fe2e77a1112)
7. 챌린지를 선택하지 않은 경우(에러)
![image](https://github.com/user-attachments/assets/e6522069-ee1f-4cf9-8eac-4ff8a2ccb3fd)
