### PR TITLE
[#160] Refactor: 그로&착용 아이템 이미지 조회 API 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/domain/Item.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Item.java
@@ -33,13 +33,7 @@ public class Item extends BaseEntity {
     private String shopBackgroundColor;
 
     @Column(nullable = false, columnDefinition = "TEXT")
-    private String imageUrl;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
     private String imageKey;
-
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String groImageUrl;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String groImageKey;

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -163,7 +163,7 @@ public class GroCommandServiceImpl implements GroCommandService{
                             // 프리사인드 URL 생성 (15분 유효 기간)
                             Date expiration = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(15));
 
-                            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, item.getImageKey())
+                            GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, item.getGroImageKey())
                                     .withMethod(HttpMethod.GET)
                                     .withExpiration(expiration);
 


### PR DESCRIPTION
## 📝 작업 내용
> 아이템 이미지를 '상점 썸네일/착용'에 따라 구분하기 위해 필드가 별도로 존재하게 되었습니다.
> 이에 따라서, 기존에 구현한 그로&착용 아이템 이미지 조회 API에서 착용 시를 위한 필드인 groImageKey를 사용하도록 변경하였습니다
> 추가적으로 진우님이 구현하신 상점 관련된 아이템 조회 API에서도 Pre-Signed URL 사용하는 방식으로 변경하셨다고 전해들어서, imageUrl과 groImageUrl 필드는 필요없다고 판단되어 삭제하였습니다.


## 🔍 테스트 방법
> 사용하는 필드만 변경된 것이기 때문에 특이사항 없습니다