### PR TITLE
[#162] Feat : Gro 생성시에 핑크색 PLANT 설정 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
@@ -18,6 +18,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     // UserItem을 통해 현재 사용자의 특정 아이템 구매여부 판별
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);
 
+    Optional<Item> findById(Long id);
+
     Optional<Item> findByName(String name);
 
     //사용자가 보유한 아이템만 조회(userId, category)

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository/ItemRepository.java
@@ -18,8 +18,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     // UserItem을 통해 현재 사용자의 특정 아이템 구매여부 판별
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);
 
-    Optional<Item> findById(Long id);
-
     Optional<Item> findByName(String name);
 
     //사용자가 보유한 아이템만 조회(userId, category)

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -61,7 +61,7 @@ public class GroCommandServiceImpl implements GroCommandService{
                 .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
 
         //기본 핑크색 PLANT 조회
-        Item basicPlantItem = itemRepository.findById(1L)
+        Item basicPlantItem = itemRepository.findByName("핑크 머그컵")
                 .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
 
         // Gro 생성 및 저장

--- a/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
@@ -60,6 +60,10 @@ public class GroCommandServiceImpl implements GroCommandService{
         Item item = itemRepository.findByName(backgroundItem)
                 .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
 
+        //기본 핑크색 PLANT 조회
+        Item basicPlantItem = itemRepository.findById(1L)
+                .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
+
         // Gro 생성 및 저장
         Gro gro = GroConverter.toGro(user, nickname);
         Gro savedGro = groRepository.save(gro);
@@ -68,17 +72,16 @@ public class GroCommandServiceImpl implements GroCommandService{
         UserItem userItem = UserItemConverter.toUserItem(user, item);
         userItemRepository.save(userItem);
 
+        //PLANT 저장
+        userItem = UserItemConverter.toUserItem(user, basicPlantItem);
+        userItemRepository.save(userItem);
+
         return GroConverter.toGroResponseDTO(savedGro);
     }
 
 
     @Transactional(readOnly = true)
     public void checkNickname(String nickname){
-
-//        if (nickname.length() < 2 || nickname.length() > 10) {
-//
-//            throw new GroHandler(ErrorStatus.GRO_NICKNAME_LENGTH_INVALID);
-//        }
 
         Optional<Gro> gro = groRepository.findByName(nickname);
 


### PR DESCRIPTION
## 📝 작업 내용
> 
### 수정/추가된 부분
- src/main/java/umc/GrowIT/Server/service/GroService/GroCommandServiceImpl.java
 ```
//기본 핑크색 PLANT 조회
        Item basicPlantItem = itemRepository.findByName("핑크 머그컵")
                .orElseThrow(() -> new ItemHandler(ErrorStatus.ITEM_NOT_FOUND));
```
이 부분은 후에 DB가 초기화 된 후 Item테이블의 id가 변경될  수 있기때문에 아이템 이름으로 검색하도록 하드코딩으로 구현했습니다.

## 🔍 테스트 방법
- 토큰 입력후 테스트 진행(userId 42)
![image](https://github.com/user-attachments/assets/3e0bcc10-4b10-474e-84ff-ab83370012a7)
- gro테이블 레코드 생성
![image](https://github.com/user-attachments/assets/da66d220-00ca-4ea9-b9e9-2edfbc2a4122)
- userItem 테이블에 레코드 2개 생성
![image](https://github.com/user-attachments/assets/97bbad04-e7a2-4d66-96e8-def3a1104df1)
