### PR TITLE
[#164] Feat: 챌린지 추천 API 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "최소 하나의 챌린지를 선택해야 합니다."),
     CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "데일리 챌린지는 최대 2개까지만 저장 가능합니다."),
     CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4008", "랜덤 챌린지는 1개만 저장 가능합니다."),
+    RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE5001", "연관된 챌린지가 없습니다."),
 
     //기타 에러
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD4001", "비밀번호 확인이 일치하지 않습니다."),
@@ -109,8 +110,15 @@ public enum ErrorStatus implements BaseErrorCode {
     // OAuth 관련 에러
     ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH_4001", "이미 가입한 계정입니다."),
     ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH_4002", "존재하지 않는 계정입니다."),
-    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH_4003", "요청한 이메일로 가입할 수 없습니다.")
+    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH_4003", "요청한 이메일로 가입할 수 없습니다."),
 
+    // 감정 관련 에러
+    KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD5001", "감정키워드가 존재하지 않습니다."),
+
+    // GPT 관련 에러
+    GPT_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5001", "GPT 응답이 비어있습니다. 다시 시도해 주세요."),
+    EMOTIONS_COUNT_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5002", "GPT 응답에서 감정의 개수는 3개여야 합니다."),
+    EMOTIONS_DUPLICATE(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5003", "GPT 응답에서 중복된 감정이 존재합니다."),
     ;
 
 

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/KeywordHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/KeywordHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class KeywordHandler extends GeneralException {
+    public KeywordHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/OpenAIHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/OpenAIHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class OpenAIHandler extends GeneralException {
+    public OpenAIHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -1,12 +1,15 @@
 package umc.GrowIT.Server.converter;
 
 import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.Keyword;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -124,10 +127,45 @@ public class ChallengeConverter {
                 .build();
     }
 
+    // 챌린지 삭제
     public static ChallengeResponseDTO.DeleteChallengeResponseDTO toDeletedUserChallenge(UserChallenge userChallenge) {
         return ChallengeResponseDTO.DeleteChallengeResponseDTO.builder()
                 .id(userChallenge.getId())
                 .message("챌린지를 삭제했어요")
+                .build();
+    }
+
+    // 챌린지 추천
+    public static ChallengeResponseDTO.RecommendChallengesResponseDTO toRecommendedChallengeDTO(List<Keyword> analyzedEmotions, List<Challenge> dailyChallenges, Challenge randomChallenge) {
+       // 감정키워드 변환
+        List<KeywordResponseDTO.KeywordDTO> emotionKeywordsDTOs = KeywordConverter.toKeywordsDTO(analyzedEmotions);
+
+        // daily 챌린지 변환
+        List<ChallengeResponseDTO.ChallengeDTO> dailyChallengesDTOs = dailyChallenges.stream()
+                .map(challenge ->
+                        ChallengeResponseDTO.ChallengeDTO.builder()
+                        .id(challenge.getId())
+                        .title(challenge.getTitle())
+                        .content(challenge.getContent())
+                        .time(challenge.getTime())
+                        .type(UserChallengeType.DAILY)
+                        .build())
+                .toList();
+
+        // random 챌린지 변환
+        ChallengeResponseDTO.ChallengeDTO randomChallengeDTO = ChallengeResponseDTO.ChallengeDTO.builder()
+                .id(randomChallenge.getId())
+                .title(randomChallenge.getTitle())
+                .content(randomChallenge.getContent())
+                .time(randomChallenge.getTime())
+                .type(UserChallengeType.RANDOM) // RANDOM 타입 설정
+                .build();
+
+        // 최종 response
+        return ChallengeResponseDTO.RecommendChallengesResponseDTO.builder()
+                .emotionKeywords(emotionKeywordsDTOs)
+                .dailyChallenges(dailyChallengesDTOs)
+                .randomChallenge(randomChallengeDTO)
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -141,31 +141,31 @@ public class ChallengeConverter {
         List<KeywordResponseDTO.KeywordDTO> emotionKeywordsDTOs = KeywordConverter.toKeywordsDTO(analyzedEmotions);
 
         // daily 챌린지 변환
-        List<ChallengeResponseDTO.ChallengeDTO> dailyChallengesDTOs = dailyChallenges.stream()
-                .map(challenge ->
-                        ChallengeResponseDTO.ChallengeDTO.builder()
+        List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges = dailyChallenges.stream()
+                .map(challenge -> ChallengeResponseDTO.ChallengeDTO.builder()
                         .id(challenge.getId())
                         .title(challenge.getTitle())
                         .content(challenge.getContent())
                         .time(challenge.getTime())
                         .type(UserChallengeType.DAILY)
                         .build())
-                .toList();
+                .collect(Collectors.toList());
 
-        // random 챌린지 변환
-        ChallengeResponseDTO.ChallengeDTO randomChallengeDTO = ChallengeResponseDTO.ChallengeDTO.builder()
-                .id(randomChallenge.getId())
-                .title(randomChallenge.getTitle())
-                .content(randomChallenge.getContent())
-                .time(randomChallenge.getTime())
-                .type(UserChallengeType.RANDOM) // RANDOM 타입 설정
-                .build();
+        // random 챌린지 변환 후 리스트에 추가
+        recommendedChallenges.add(
+                ChallengeResponseDTO.ChallengeDTO.builder()
+                        .id(randomChallenge.getId())
+                        .title(randomChallenge.getTitle())
+                        .content(randomChallenge.getContent())
+                        .time(randomChallenge.getTime())
+                        .type(UserChallengeType.RANDOM)
+                        .build()
+        );
 
         // 최종 response
         return ChallengeResponseDTO.RecommendChallengesResponseDTO.builder()
                 .emotionKeywords(emotionKeywordsDTOs)
-                .dailyChallenges(dailyChallengesDTOs)
-                .randomChallenge(randomChallengeDTO)
+                .recommendedChallenges(recommendedChallenges)
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/KeywordConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/KeywordConverter.java
@@ -1,0 +1,25 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.domain.Challenge;
+import umc.GrowIT.Server.domain.Keyword;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserChallenge;
+import umc.GrowIT.Server.domain.enums.UserChallengeType;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class KeywordConverter {
+
+    // 챌린지 추천
+    public static List<KeywordResponseDTO.KeywordDTO> toKeywordsDTO(List<Keyword> analyzedEmotions) {
+        return analyzedEmotions.stream()
+                .map(keyword -> KeywordResponseDTO.KeywordDTO.builder()
+                        .id(keyword.getId())
+                        .keyword(keyword.getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -28,7 +28,7 @@ public class UserChallenge extends BaseEntity {
     @Column(name = "thoughts", length = 100)
     private String thoughts;
 
-    @Column(name = "certification_image", length = 255)
+    @Column(name = "certification_image", columnDefinition = "TEXT")
     private String certificationImage;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/GrowIT/Server/repository/ChallengeKeywordRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ChallengeKeywordRepository.java
@@ -1,0 +1,15 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc.GrowIT.Server.domain.ChallengeKeyword;
+import umc.GrowIT.Server.domain.Keyword;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChallengeKeywordRepository extends JpaRepository<ChallengeKeyword, Long> {
+    @Query("SELECT ck FROM ChallengeKeyword ck JOIN FETCH ck.challenge WHERE ck.keyword = :keyword")
+    List<ChallengeKeyword> findByKeywordWithChallenge(@Param("keyword") Keyword keyword);
+}

--- a/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ChallengeRepository.java
@@ -36,4 +36,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     @Query("SELECT uc FROM UserChallenge uc WHERE uc.challenge.id = :challengeId")
     Optional<UserChallenge> findByChallengeId(@Param("challengeId") Long challengeId);
 
+
+    @Query("SELECT c FROM Challenge c WHERE c NOT IN :dailyChallenges ORDER BY FUNCTION('RAND') LIMIT 1")
+    Challenge findRandomRemainingChallenge(@Param("dailyChallenges") List<Challenge> dailyChallenges);
 }

--- a/src/main/java/umc/GrowIT/Server/repository/KeywordRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/KeywordRepository.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.GrowIT.Server.domain.Keyword;
+
+import java.util.Optional;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    Optional<Keyword> findByName(String name);
+}

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -12,4 +12,5 @@ public interface ChallengeCommandService {
     ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
     ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
     ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
+    ChallengeResponseDTO.RecommendChallengesResponseDTO recommend(ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -37,7 +37,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final KeywordRepository keywordRepository;
     private final ImageService imageService;
 
-    @Value("${openai.model}")
+    @Value("${openai.model2}")
     private String model;
 
     @Value("${openai.api.url}")

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -1,34 +1,50 @@
 package umc.GrowIT.Server.service.ChallengeService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.ChallengeHandler;
+import umc.GrowIT.Server.apiPayload.exception.KeywordHandler;
+import umc.GrowIT.Server.apiPayload.exception.OpenAIHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.ChallengeConverter;
-import umc.GrowIT.Server.domain.Challenge;
-import umc.GrowIT.Server.domain.User;
-import umc.GrowIT.Server.domain.UserChallenge;
+import umc.GrowIT.Server.domain.*;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
-import umc.GrowIT.Server.repository.ChallengeRepository;
-import umc.GrowIT.Server.repository.UserChallengeRepository;
-import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.repository.*;
 import umc.GrowIT.Server.service.ImageService.ImageService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.OpenAIDTO.ChatGPTRequest;
+import umc.GrowIT.Server.web.dto.OpenAIDTO.ChatGPTResponse;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
     private final UserRepository userRepository;
     private final UserChallengeRepository userChallengeRepository;
     private final ChallengeRepository challengeRepository;
+    private final ChallengeKeywordRepository challengeKeywordRepository;
+    private final KeywordRepository keywordRepository;
     private final ImageService imageService;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
+    @Autowired
+    private RestTemplate template;
 
     @Override
     @Transactional
@@ -136,6 +152,8 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         return ChallengeConverter.toChallengeModifyProofDTO(userChallenge);
     }
 
+    // 삭제
+    @Override
     public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId) {
         // 1. userId를 조회하고 없으면 오류
         userRepository.findById(userId)
@@ -155,5 +173,142 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         // 5. converter 작업
         return ChallengeConverter.toDeletedUserChallenge(userChallenge);
+    }
+
+    // 추천
+    @Override
+    public ChallengeResponseDTO.RecommendChallengesResponseDTO recommend(ChallengeRequestDTO.RecommendChallengesRequestDTO recommendRequest) {
+        // 1. DB에서 감정들 조회
+//        List<String> emotions = keywordRepository.findAll()
+//                .stream()
+//                .map(emotion -> emotion.getName())
+//                .toList();
+//        log.info(emotions.toString());
+
+        // DB 설정이 제대로 안되었기 때문에 테스트용으로 DB ID 1~5까지의 감정 사용
+        // TODO 이후 위의 코드로 수정 필요
+        List<String> emotions = new ArrayList<>();
+        emotions.add("행복한");
+        emotions.add("슬픈");
+        emotions.add("외로운");
+        emotions.add("불안한");
+        emotions.add("기쁜");
+
+        // 2. OpenAI API 호출하여 감정 반환 & 반환받은 감정 체크 (3개인지, DB에 있는 것과 동일한지에 따라 오류)
+        List<Keyword> analyzedEmotions = analyzeDiary(recommendRequest.getDiaryContent(), emotions.toString());
+        log.info("[최종 분석된 감정] : " + analyzedEmotions.stream().map(Keyword::getName).toList().toString());
+
+        // 3. 감정 키워드 2개 랜덤 선택
+        List<Keyword> selectedKeyword = selectRandomKeyword(analyzedEmotions);
+        log.info("[선택된 감정] : " + selectedKeyword.stream().map(Keyword::getName).toList().toString());
+
+        // 4. 연관관계 맺고 있는 챌린지 중에서 각 랜덤으로 1개씩 선택
+        List<Challenge> dailyChallenges = selectDailyChallenge(selectedKeyword);
+        log.info("[데일리 챌린지] : " + dailyChallenges.stream().map(Challenge::getTitle).toList().toString());
+
+        // 5. 3)에서 선택되지 않은 챌린지들 중에서 랜덤으로 1개 선택
+        Challenge randomChallenge = challengeRepository.findRandomRemainingChallenge(dailyChallenges);
+        log.info("[랜덤 챌린지] : " + randomChallenge.getTitle());
+
+        // 6. converter작업
+        return ChallengeConverter.toRecommendedChallengeDTO(analyzedEmotions, dailyChallenges, randomChallenge);
+    }
+
+
+    // 일기 분석 (일기 -> 감정)
+    private List<Keyword> analyzeDiary(String diaryContent, String emotions) {
+
+        // 프롬프트
+        String prompt = String.format("""
+            다음 일기를 분석하여 %s 감정들 중 가장 해당되는 감정을 3개 선택해주세요.
+            
+            일기 내용: %s
+            
+            반환 결과는 다른 말 없이 감정들만을 []로 둘러싸서 반환해 주세요.
+            ex) [감정1, 감정2, 감정3]
+            """, emotions, diaryContent);
+
+
+        // API 요청 생성
+        ChatGPTRequest gptRequest = new ChatGPTRequest(model, prompt);
+
+        // API 요청 및 응답 처리
+        ChatGPTResponse chatGPTResponse = template.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
+        if (chatGPTResponse == null || chatGPTResponse.getChoices().isEmpty()) {
+            throw new OpenAIHandler(ErrorStatus.GPT_RESPONSE_EMPTY);
+        }
+        String result = chatGPTResponse.getChoices().get(0).getMessage().getContent();
+        log.info("[GPT 결과] : " + result);
+
+
+        // 응답 결과 정리 ([]를 제거하고 각 감정을 분리)
+        result = result.replace("[", "").replace("]", "").trim(); // 괄호 제거 후 양 옆 공백 제거
+        log.info("[결과정리1] : " + result);
+
+        List<String> emotionsList = Arrays.asList(result.split("\\s*,\\s*")); // , 앞뒤 공백 제거하고 감정들을 나누기
+        log.info("[결과정리2] : " + emotionsList.toString());
+
+
+        // 결과 체크
+        // 3개인지 체크
+        if (emotionsList.size() != 3) {
+            throw new OpenAIHandler(ErrorStatus.EMOTIONS_COUNT_INVALID);
+        }
+
+        // 중복 체크
+        Set<String> uniqueEmotions = new HashSet<>(emotionsList);
+        if (uniqueEmotions.size() != emotionsList.size()) {
+            throw new OpenAIHandler(ErrorStatus.EMOTIONS_DUPLICATE);
+        }
+
+        // DB에 존재하는 감정인지 체크
+        List<Keyword> emotionKeywords = uniqueEmotions.stream()
+                .map(emotion -> keywordRepository.findByName(emotion)
+                        .orElseThrow(() -> new KeywordHandler(ErrorStatus.KEYWORD_NOT_FOUND)))
+                .toList()
+                ;
+
+        return emotionKeywords;
+    }
+
+    // 감정키워드 랜덤 2개 선택
+    private List<Keyword> selectRandomKeyword(List<Keyword> analyzedEmotions) {
+        Random random = new Random();
+
+        List<Keyword> editableList = new ArrayList<>(analyzedEmotions);
+        Collections.shuffle(editableList, random);
+
+        return editableList.subList(0, 2);
+    }
+
+
+    // 데일리챌린지 랜덤 2개 선택
+    private List<Challenge> selectDailyChallenge(List<Keyword> selectedKeyword) {
+        Random random = new Random();
+        List<Challenge> selectedChallenges = new ArrayList<>();  // 중복 방지를 위해 리스트를 사용
+
+        // 전달받은 selectedKeyword를 통해 연관된 챌린지들 조회
+        for (Keyword keyword : selectedKeyword) {
+            // 매핑 테이블을 통해 해당 키워드와 연관된 챌린지들을 가져오기
+            List<ChallengeKeyword> challengeKeywords = challengeKeywordRepository.findByKeywordWithChallenge(keyword);
+
+            // 연관된 챌린지들
+            List<Challenge> relatedChallenges = challengeKeywords.stream()
+                    .map(ChallengeKeyword::getChallenge)
+                    .filter(challenge -> !selectedChallenges.contains(challenge))  // 이미 선택된 챌린지 제외
+                    .collect(Collectors.toList());
+
+            if (relatedChallenges.isEmpty()) {
+                throw new ChallengeHandler(ErrorStatus.RELATED_CHALLENGE_NOT_FOUND);
+            }
+
+            Collections.shuffle(relatedChallenges, random);
+            Challenge selectedChallenge = relatedChallenges.get(0);
+            selectedChallenges.add(selectedChallenge);
+
+            log.info(keyword.getName() + "과 연관된 " + selectedChallenge.getTitle() + "을 데일리 챌린지로 선택");
+        }
+
+        return selectedChallenges;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -28,7 +28,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
 
-    @Value("${openai.model}")
+    @Value("${openai.model1}")
     private String model;
 
     @Value("${openai.api.url}")

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -98,4 +98,10 @@ public class ChallengeController implements ChallengeSpecification {
         ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
         return ApiResponse.onSuccess(deleteChallenge);
     }
+
+    @Override
+    public ApiResponse<ChallengeResponseDTO.RecommendChallengesResponseDTO> recommendChallenges(ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent) {
+        ChallengeResponseDTO.RecommendChallengesResponseDTO result = challengeCommandService.recommend(diaryContent);
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
@@ -108,4 +109,22 @@ public interface ChallengeSpecification {
     })
     @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", required = true)
     ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
+
+
+    @PostMapping("/recommend")
+    @Operation(
+            summary = "챌린지 추천 API",
+            description = "일기 내용을 분석하여, 데일리/랜덤 챌린지를 추천하는 API입니다.<br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+
+    })
+    ApiResponse<ChallengeResponseDTO.RecommendChallengesResponseDTO> recommendChallenges(@RequestBody ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -1,14 +1,13 @@
 package umc.GrowIT.Server.web.dto.ChallengeDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class ChallengeRequestDTO {
@@ -33,4 +32,13 @@ public class ChallengeRequestDTO {
         private UserChallengeType dtype;
     }
 
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecommendChallengesRequestDTO {
+        @NotNull
+        String diaryContent; //일기 내용
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.GrowIT.Server.domain.ChallengeKeyword;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
+import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -147,5 +148,28 @@ public class ChallengeResponseDTO {
         // TODO 디테일하게 결정 필요
         private Long id;
         private String message; // ex) 챌린지 삭제가 완료되었습니다
+    }
+
+    // 챌린지 추천 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecommendChallengesResponseDTO {
+        private List<KeywordResponseDTO.KeywordDTO> emotionKeywords; //감정키워드
+        private List<ChallengeDTO> dailyChallenges; //데일리
+        private ChallengeDTO randomChallenge; //랜덤
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChallengeDTO {
+        private Long id; // 챌린지 ID
+        private String title; //챌린지 제목
+        private String content; //챌린지 내용
+        private Integer time; //챌린지 소요시간
+        private UserChallengeType type; //추천 타입 (Daily or Random)
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -157,8 +157,7 @@ public class ChallengeResponseDTO {
     @AllArgsConstructor
     public static class RecommendChallengesResponseDTO {
         private List<KeywordResponseDTO.KeywordDTO> emotionKeywords; //감정키워드
-        private List<ChallengeDTO> dailyChallenges; //데일리
-        private ChallengeDTO randomChallenge; //랜덤
+        private List<ChallengeDTO> recommendedChallenges; //추천챌린지
     }
 
     @Getter

--- a/src/main/java/umc/GrowIT/Server/web/dto/KeywordDTO/KeywordResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/KeywordDTO/KeywordResponseDTO.java
@@ -1,0 +1,17 @@
+package umc.GrowIT.Server.web.dto.KeywordDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class KeywordResponseDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KeywordDTO {
+        private Long id; // id
+        private String keyword; // 감정
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> ❗ 먼저, 노션에서 yml파일 수정 필요합니다 ❗
> [OpenAI API 호출 -> 감정 -> 챌린지] 를 모두 구현한 API라서 작업 내용이 많습니다...!
> 최대한 신경썼지만 OpenAI API, DB 데이터, 중복 방지, 랜덤 등을 동시에 고려하다보니, 예외 체크가 더 필요한 부분이 없을 지를 중점적으로 확인해주시면 감사하겠습니다.  ex) GPT 호출 결과가 감정 '3개'가 맞는지
> (제가 테트스하는 동안에는 별다른 이상이 없었고, 되도록 빠르게 PR 올리고 피드백 통해서 리팩토링하는게 낫다고 생각되어 올립니다.)
> 
> 주요 흐름 간단하게 설명드리겠습니다.
> 1) 사용자로부터 `일기 내용` 전달 받음
> 2) OpenAI API를 호출하여 `일기 내용`과 가장 적합한 3개의 `DB 감정`들을 매칭
> 3) 매칭된 `감정` 3개 중 2개를 랜덤 선택
> 4) 2개의 `감정`과 연관관계를 맺고 있는 `챌린지`들 중에서 중복되지 않도록 랜덤하게 각 1개씩 선택 (=데일리 챌린지)
> 5) 데일리 챌린지로 선택되지 않은 `챌린지` 중에서 랜덤하게 1개 선택 (=랜덤 챌린지)
> 6) 감정들과 데일리/랜덤 챌린지 반환


## 🔍 테스트 방법
> DB가 아직 정리되어 있지 않기 때문에, 현재 PR에서는 ID 1~5의 감정만 사용하며 각 감정에는 제가 임의로 챌린지를 매칭하여 놓았습니다. 이후에 DB 전체 감정들을 사용하도록 리팩토링하겠습니다.
> 1. 일기 내용을 전달 (로그인하여 JWT 토큰 세팅이 완료된 상태여야 합니다.)
> ![image](https://github.com/user-attachments/assets/224d8a94-1fd1-49d2-9623-4ef6ca69445c)
> 
> 중간 과정은 인텔리제이의 로그로 확인하시면 됩니다. (이후에 지우거나 깔끔하게 변경하겠습니다)
> 
> 2. OpenAI API호출 결과
> ![image](https://github.com/user-attachments/assets/fde9bb84-52b9-4da1-a198-b203ec2257f3)
> 3. 랜덤 선택한 2개의 감정
> ![image](https://github.com/user-attachments/assets/76f608d8-bc91-4075-8ffc-3362b7e91556)
> ![image](https://github.com/user-attachments/assets/df412a26-c33f-434e-8482-6158cce65948)
> 4. 데일리 챌린지 선택
> ![image](https://github.com/user-attachments/assets/79b8e2ea-1701-44e8-a294-0060825b205f)
> ![image](https://github.com/user-attachments/assets/c1750925-63ec-49db-bfce-a26d9316ef61)
> ![image](https://github.com/user-attachments/assets/0bd56079-44b3-48c8-8544-5a7554ab4d76)
> ![image](https://github.com/user-attachments/assets/1e638e64-7c4c-4f06-8426-58fb836a081a)
> ![image](https://github.com/user-attachments/assets/5a7d5c93-ef20-4df6-8de1-ae4442181e7f)
> 5. 랜덤 챌린지 선택
> ![image](https://github.com/user-attachments/assets/72e16834-bfea-4223-8ba1-7603f9be2515)
> 6. 결과
> ![image](https://github.com/user-attachments/assets/70082fb9-240d-4db4-825e-f320ce66e587)
> ![image](https://github.com/user-attachments/assets/b7ab0205-895b-45a3-a0b8-de036ae159ec)

## ❗❗ 특이사항 ❗❗
> 해당 기능을 일기 저장 API에 이어서 작성하는 것을 고려하였으나, 우진님께 저장 API와 구분되는 것이 나을 거 같다는 답변을 받았습니다.
> 개발이 급하다고 판단되어 우선 별도의 API로 개발하였는데 혹시 어떤 것이 나을지? 맞는지? 의견이 궁금합니다.
> (이렇게 API를 구분하면 먼저 일기-감정 키워드 간의 연관관계 설정이 불가해지는데 또 일기 조회에는 감정키워드를 띄우지 않아 상관없을 거 같기도 하고.. 현재 제 머리가 녹아버린 관계로 판단력이 흐려져서 부탁드립니다...)


\+ 방금 승현님 PR 리뷰하면서, 일기가 저장된 다음에 해당 로직까지 한꺼번에 실행되어야 챌린지 홈 조회에서 감정키워드 출력이 가능하다는 사실을 깨달았습니다.... 갈아엎다가 망할까봐 승인받은 다음에 리팩토링으로 진행하겠습니다...
<img width="687" alt="image" src="https://github.com/user-attachments/assets/90615121-28f8-4c36-a1c7-ebd91d02fa52" />