### PR TITLE
[#173] Refactor: 챌린지 추천 API 수정 (->일기 분석 API)

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -99,6 +99,8 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY4002", "100자 이내로 작성된 일기입니다."),
     DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY4003", "해당날짜에 이미 일기가 존재합니다."),
     DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY4004", "기존 일기와 동일한 내용입니다."),
+    ANALYZED_DIARY(HttpStatus.BAD_REQUEST, "DIARY4005", "이미 분석된 일기입니다."),
+    DIARY_NOT_TODAY(HttpStatus.BAD_REQUEST, "DIARY4006", "오늘의 일기만 분석이 가능합니다."),
 
     // S3 관련 에러
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S3_4001", "파일 확장자가 잘못되었습니다."),

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -154,11 +154,7 @@ public class ChallengeConverter {
                 .build();
     }
 
-    // 챌린지 추천
-    public static ChallengeResponseDTO.RecommendChallengesResponseDTO toRecommendedChallengeDTO(List<Keyword> analyzedEmotions, List<Challenge> dailyChallenges, Challenge randomChallenge) {
-       // 감정키워드 변환
-        List<KeywordResponseDTO.KeywordDTO> emotionKeywordsDTOs = KeywordConverter.toKeywordsDTO(analyzedEmotions);
-
+    public static List<ChallengeResponseDTO.ChallengeDTO> toRecommendedChallenges(List<Challenge> dailyChallenges, Challenge randomChallenge) {
         // daily 챌린지 변환
         List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges = dailyChallenges.stream()
                 .map(challenge -> ChallengeResponseDTO.ChallengeDTO.builder()
@@ -181,10 +177,6 @@ public class ChallengeConverter {
                         .build()
         );
 
-        // 최종 response
-        return ChallengeResponseDTO.RecommendChallengesResponseDTO.builder()
-                .emotionKeywords(emotionKeywordsDTOs)
-                .recommendedChallenges(recommendedChallenges)
-                .build();
+        return recommendedChallenges;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -1,7 +1,12 @@
 package umc.GrowIT.Server.converter;
 
+import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.domain.Keyword;
+import umc.GrowIT.Server.domain.enums.UserChallengeType;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
+import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -82,6 +87,21 @@ public class DiaryConverter {
                 .diaryId(diary.getId())
                 .content(diary.getContent())
                 .date(diary.getDate())
+                .build();
+    }
+
+    // 챌린지 추천
+    public static DiaryResponseDTO.AnalyzedDiaryResponseDTO toAnalyzedDiaryDTO(List<Keyword> analyzedEmotions, List<Challenge> dailyChallenges, Challenge randomChallenge) {
+        // 감정키워드 변환
+        List<KeywordResponseDTO.KeywordDTO> emotionKeywordsDTOs = KeywordConverter.toKeywordsDTO(analyzedEmotions);
+
+        // 챌린지 변환
+        List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges = ChallengeConverter.toRecommendedChallenges(dailyChallenges, randomChallenge);
+
+        // 최종 response
+        return DiaryResponseDTO.AnalyzedDiaryResponseDTO.builder()
+                .emotionKeywords(emotionKeywordsDTOs)
+                .recommendedChallenges(recommendedChallenges)
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
+++ b/src/main/java/umc/GrowIT/Server/domain/DiaryKeyword.java
@@ -2,13 +2,14 @@ package umc.GrowIT.Server.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import umc.GrowIT.Server.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class DiaryKeyword {
+public class DiaryKeyword extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandService.java
@@ -12,5 +12,4 @@ public interface ChallengeCommandService {
     ChallengeResponseDTO.ProofDetailsDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
     ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
     ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
-    ChallengeResponseDTO.RecommendChallengesResponseDTO recommend(ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -8,14 +8,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
-import umc.GrowIT.Server.apiPayload.exception.ChallengeHandler;
-import umc.GrowIT.Server.apiPayload.exception.KeywordHandler;
-import umc.GrowIT.Server.apiPayload.exception.OpenAIHandler;
-import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.apiPayload.exception.*;
 import umc.GrowIT.Server.converter.ChallengeConverter;
 import umc.GrowIT.Server.domain.*;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.repository.*;
+import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.service.ImageService.ImageService;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
@@ -33,18 +31,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final UserRepository userRepository;
     private final UserChallengeRepository userChallengeRepository;
     private final ChallengeRepository challengeRepository;
-    private final ChallengeKeywordRepository challengeKeywordRepository;
-    private final KeywordRepository keywordRepository;
     private final ImageService imageService;
-
-    @Value("${openai.model2}")
-    private String model;
-
-    @Value("${openai.api.url}")
-    private String apiURL;
-
-    @Autowired
-    private RestTemplate template;
 
     @Override
     @Transactional
@@ -179,142 +166,5 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         // 5. converter 작업
         return ChallengeConverter.toDeletedUserChallenge(userChallenge);
-    }
-
-    // 추천
-    @Override
-    public ChallengeResponseDTO.RecommendChallengesResponseDTO recommend(ChallengeRequestDTO.RecommendChallengesRequestDTO recommendRequest) {
-        // 1. DB에서 감정들 조회
-//        List<String> emotions = keywordRepository.findAll()
-//                .stream()
-//                .map(emotion -> emotion.getName())
-//                .toList();
-//        log.info(emotions.toString());
-
-        // DB 설정이 제대로 안되었기 때문에 테스트용으로 DB ID 1~5까지의 감정 사용
-        // TODO 이후 위의 코드로 수정 필요
-        List<String> emotions = new ArrayList<>();
-        emotions.add("행복한");
-        emotions.add("슬픈");
-        emotions.add("외로운");
-        emotions.add("불안한");
-        emotions.add("기쁜");
-
-        // 2. OpenAI API 호출하여 감정 반환 & 반환받은 감정 체크 (3개인지, DB에 있는 것과 동일한지에 따라 오류)
-        List<Keyword> analyzedEmotions = analyzeDiary(recommendRequest.getDiaryContent(), emotions.toString());
-        log.info("[최종 분석된 감정] : " + analyzedEmotions.stream().map(Keyword::getName).toList().toString());
-
-        // 3. 감정 키워드 2개 랜덤 선택
-        List<Keyword> selectedKeyword = selectRandomKeyword(analyzedEmotions);
-        log.info("[선택된 감정] : " + selectedKeyword.stream().map(Keyword::getName).toList().toString());
-
-        // 4. 연관관계 맺고 있는 챌린지 중에서 각 랜덤으로 1개씩 선택
-        List<Challenge> dailyChallenges = selectDailyChallenge(selectedKeyword);
-        log.info("[데일리 챌린지] : " + dailyChallenges.stream().map(Challenge::getTitle).toList().toString());
-
-        // 5. 3)에서 선택되지 않은 챌린지들 중에서 랜덤으로 1개 선택
-        Challenge randomChallenge = challengeRepository.findRandomRemainingChallenge(dailyChallenges);
-        log.info("[랜덤 챌린지] : " + randomChallenge.getTitle());
-
-        // 6. converter작업
-        return ChallengeConverter.toRecommendedChallengeDTO(analyzedEmotions, dailyChallenges, randomChallenge);
-    }
-
-
-    // 일기 분석 (일기 -> 감정)
-    private List<Keyword> analyzeDiary(String diaryContent, String emotions) {
-
-        // 프롬프트
-        String prompt = String.format("""
-            다음 일기를 분석하여 %s 감정들 중 가장 해당되는 감정을 3개 선택해주세요.
-            
-            일기 내용: %s
-            
-            반환 결과는 다른 말 없이 감정들만을 []로 둘러싸서 반환해 주세요.
-            ex) [감정1, 감정2, 감정3]
-            """, emotions, diaryContent);
-
-
-        // API 요청 생성
-        ChatGPTRequest gptRequest = new ChatGPTRequest(model, prompt);
-
-        // API 요청 및 응답 처리
-        ChatGPTResponse chatGPTResponse = template.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
-        if (chatGPTResponse == null || chatGPTResponse.getChoices().isEmpty()) {
-            throw new OpenAIHandler(ErrorStatus.GPT_RESPONSE_EMPTY);
-        }
-        String result = chatGPTResponse.getChoices().get(0).getMessage().getContent();
-        log.info("[GPT 결과] : " + result);
-
-
-        // 응답 결과 정리 ([]를 제거하고 각 감정을 분리)
-        result = result.replace("[", "").replace("]", "").trim(); // 괄호 제거 후 양 옆 공백 제거
-        log.info("[결과정리1] : " + result);
-
-        List<String> emotionsList = Arrays.asList(result.split("\\s*,\\s*")); // , 앞뒤 공백 제거하고 감정들을 나누기
-        log.info("[결과정리2] : " + emotionsList.toString());
-
-
-        // 결과 체크
-        // 3개인지 체크
-        if (emotionsList.size() != 3) {
-            throw new OpenAIHandler(ErrorStatus.EMOTIONS_COUNT_INVALID);
-        }
-
-        // 중복 체크
-        Set<String> uniqueEmotions = new HashSet<>(emotionsList);
-        if (uniqueEmotions.size() != emotionsList.size()) {
-            throw new OpenAIHandler(ErrorStatus.EMOTIONS_DUPLICATE);
-        }
-
-        // DB에 존재하는 감정인지 체크
-        List<Keyword> emotionKeywords = uniqueEmotions.stream()
-                .map(emotion -> keywordRepository.findByName(emotion)
-                        .orElseThrow(() -> new KeywordHandler(ErrorStatus.KEYWORD_NOT_FOUND)))
-                .toList()
-                ;
-
-        return emotionKeywords;
-    }
-
-    // 감정키워드 랜덤 2개 선택
-    private List<Keyword> selectRandomKeyword(List<Keyword> analyzedEmotions) {
-        Random random = new Random();
-
-        List<Keyword> editableList = new ArrayList<>(analyzedEmotions);
-        Collections.shuffle(editableList, random);
-
-        return editableList.subList(0, 2);
-    }
-
-
-    // 데일리챌린지 랜덤 2개 선택
-    private List<Challenge> selectDailyChallenge(List<Keyword> selectedKeyword) {
-        Random random = new Random();
-        List<Challenge> selectedChallenges = new ArrayList<>();  // 중복 방지를 위해 리스트를 사용
-
-        // 전달받은 selectedKeyword를 통해 연관된 챌린지들 조회
-        for (Keyword keyword : selectedKeyword) {
-            // 매핑 테이블을 통해 해당 키워드와 연관된 챌린지들을 가져오기
-            List<ChallengeKeyword> challengeKeywords = challengeKeywordRepository.findByKeywordWithChallenge(keyword);
-
-            // 연관된 챌린지들
-            List<Challenge> relatedChallenges = challengeKeywords.stream()
-                    .map(ChallengeKeyword::getChallenge)
-                    .filter(challenge -> !selectedChallenges.contains(challenge))  // 이미 선택된 챌린지 제외
-                    .collect(Collectors.toList());
-
-            if (relatedChallenges.isEmpty()) {
-                throw new ChallengeHandler(ErrorStatus.RELATED_CHALLENGE_NOT_FOUND);
-            }
-
-            Collections.shuffle(relatedChallenges, random);
-            Challenge selectedChallenge = relatedChallenges.get(0);
-            selectedChallenges.add(selectedChallenge);
-
-            log.info(keyword.getName() + "과 연관된 " + selectedChallenge.getTitle() + "을 데일리 챌린지로 선택");
-        }
-
-        return selectedChallenges;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.service.diaryService;
 
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
@@ -14,4 +15,6 @@ public interface DiaryCommandService {
     public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 
     public DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId);
+
+    DiaryResponseDTO.AnalyzedDiaryResponseDTO analyze(Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -279,9 +279,12 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     // 일기 분석 (일기 -> 감정)
     private List<Keyword> openAIAnalyzeDiary(String diaryContent, String emotions) {
 
+        log.info("[프롬프트의 감정들] : " + emotions);
+
         // 프롬프트
         String prompt = String.format("""
-            다음 일기를 분석하여 %s 감정들 중 가장 해당되는 감정을 3개 선택해주세요.
+            다음 일기를 분석하여 %s 감정들 중에서 가장 해당되는 감정을 3개 선택해주세요.
+            목록에 없는 감정을 사용하면 안 됩니다.
             
             일기 내용: %s
             

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -98,10 +98,4 @@ public class ChallengeController implements ChallengeSpecification {
         ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
         return ApiResponse.onSuccess(deleteChallenge);
     }
-
-    @Override
-    public ApiResponse<ChallengeResponseDTO.RecommendChallengesResponseDTO> recommendChallenges(ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent) {
-        ChallengeResponseDTO.RecommendChallengesResponseDTO result = challengeCommandService.recommend(diaryContent);
-        return ApiResponse.onSuccess(result);
-    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -9,6 +9,7 @@ import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.service.diaryService.DiaryCommandService;
 import umc.GrowIT.Server.service.diaryService.DiaryQueryService;
 import umc.GrowIT.Server.web.controller.specification.DiarySpecification;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
@@ -91,5 +92,10 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryCommandService.createDiaryByVoice(request, userId));
     }
 
-
+    @Override
+    @PostMapping("/analyze/{diaryId}")
+    public ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary (@PathVariable("diaryId") Long diaryId) {
+        DiaryResponseDTO.AnalyzedDiaryResponseDTO result = diaryCommandService.analyze(diaryId);
+        return ApiResponse.onSuccess(result);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -109,22 +109,4 @@ public interface ChallengeSpecification {
     })
     @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", required = true)
     ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
-
-
-    @PostMapping("/recommend")
-    @Operation(
-            summary = "챌린지 추천 API",
-            description = "일기 내용을 분석하여, 데일리/랜덤 챌린지를 추천하는 API입니다.<br>"
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-
-    })
-    ApiResponse<ChallengeResponseDTO.RecommendChallengesResponseDTO> recommendChallenges(@RequestBody ChallengeRequestDTO.RecommendChallengesRequestDTO diaryContent);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -1,11 +1,13 @@
 package umc.GrowIT.Server.web.controller.specification;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
@@ -75,4 +77,27 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
     ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request);
+
+    @PostMapping("/analyze/{diaryId}")
+    @Operation(
+            summary = "일기 분석 API",
+            description = "일기 내용을 분석하여, 적절한 감정과 데일리/랜덤 챌린지를 반환하는 API입니다.<br>" +
+                    "일기 ID를 path variable로 전달받아 해당 일기를 분석합니다.<br>" +
+                    "❗Request Header에 JWT Access Token 값을 넣어야 합니다.❗"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "❌ 존재하지 않는 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4005", description = "❌ 이미 분석된 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4006", description = "❌ 오늘의 일기만 분석이 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+
+    })
+    @Parameter(name = "diaryId", description = "분석할 일기의 ID", required = true)
+    ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary (@PathVariable("diaryId") Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -31,14 +31,4 @@ public class ChallengeRequestDTO {
         private List<Long> challengeIds;
         private UserChallengeType dtype;
     }
-
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RecommendChallengesRequestDTO {
-        @NotNull
-        String diaryContent; //일기 내용
-    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -157,16 +157,6 @@ public class ChallengeResponseDTO {
         private String message; // ex) 챌린지 삭제가 완료되었습니다
     }
 
-    // 챌린지 추천 응답 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RecommendChallengesResponseDTO {
-        private List<KeywordResponseDTO.KeywordDTO> emotionKeywords; //감정키워드
-        private List<ChallengeDTO> recommendedChallenges; //추천챌린지
-    }
-
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.GrowIT.Server.domain.enums.UserChallengeType;
+import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -85,5 +88,15 @@ public class DiaryResponseDTO {
         Long diaryId;
         String content;
         LocalDate date;
+    }
+
+    // 챌린지 추천 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnalyzedDiaryResponseDTO {
+        private List<KeywordResponseDTO.KeywordDTO> emotionKeywords; //감정키워드
+        private List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges; //추천챌린지
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 서비스 흐름 [일기 저장 -> 일기 분석 -> 감정 -> 챌린지] 중에서 `일기 분석 ~ 챌린지`를 구현한 API입니다.
> 일기 저장 API와 합치는 식으로 진행하려 했으나, #173 해당 이슈를 읽어보시면 별도의 API를 유지하기로 정리되었습니다.
> 그리고 Request로 일기 ID를 전달받기 때문에, 챌린지 추천 API보다는 도메인 자체가 일기에 해당한다고 판단되어 `일기 분석 API`로 구분하며 이에 알맞게 코드 수정하였습니다.
> 주석을 최대한 달아두었기 때문에 이해에 어려움은 없으리라 생각됩니다! 옮기면서 보완된 내용이 있어, 코드도 확인 부탁드립니다.

## 🔍 테스트 방법
> 1. 작성된 일기 ID를 전달받으면 해당 일기의 내용에 대해 분석하여 감정과 연관된 챌린지를 반환합니다.
> <img width="532" alt="image" src="https://github.com/user-attachments/assets/efebcc66-0cf6-483f-bc50-36dae872d125" />
