### PR TITLE
[#181] Feat: 일기 작성 시 유저 크레딧 개수 증가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -77,6 +77,9 @@ public class User extends BaseEntity {
     public void updateCurrentCredit(Integer currentCredit) {
         this.currentCredit = currentCredit;
     }
+    public void updateTotalCredit(Integer totalCredit){
+        this.totalCredit = totalCredit;
+    }
 
     public void deleteRefreshToken() {
         this.refreshToken = null;

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -34,6 +34,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final ChallengeKeywordRepository challengeKeywordRepository;
     private final KeywordRepository keywordRepository;
     private final ChallengeRepository challengeRepository;
+    //일기 작성 시 추가되는 크레딧 개수
+    private Integer diaryCredit = 2;
 
     @Value("${openai.model1}")
     private String chatModel;
@@ -102,6 +104,11 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         //일기 저장
         diary = diaryRepository.save(diary);
+
+        //사용자의 크레딧수 증가
+        user.updateCurrentCredit(user.getCurrentCredit() + diaryCredit);
+        user.updateTotalCredit(user.getTotalCredit() + diaryCredit);
+        userRepository.save(user);
 
         return DiaryConverter.toCreateResultDTO(diary);
     }
@@ -204,6 +211,11 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         //일기 저장
         diary = diaryRepository.save(diary);
+
+        //사용자의 크레딧수 증가
+        user.updateCurrentCredit(user.getCurrentCredit() + diaryCredit);
+        user.updateTotalCredit(user.getTotalCredit() + diaryCredit);
+        userRepository.save(user);
 
         // 대화 기록 삭제
         conversationHistory.remove(userId);


### PR DESCRIPTION
## 📝 작업 내용
> 1. 직접 일기 작성 시에 크레딧 개수 증가
> 2. 음성 일기 작성 시에 크레딧 개수 증가 
> -  User 엔티티에 updateCurrentCredit 메소드만 존재하여 updateTotalCredit 메소드도 추가하였습니다.
> -  일기 생성하는 두 가지 서비스 코드에 크레딧 개수 증가하는 부분을 추가하였습니다.

## 🔍 테스트 방법
> 1. 현재 크레딧과 누적 크레딧 수 확인 
> 현재 둘 다 6
<img width="708" alt="image" src="https://github.com/user-attachments/assets/634c0b36-1332-4621-9f5d-ab6ac5699c28" />
<img width="707" alt="image" src="https://github.com/user-attachments/assets/2a1dfacb-7bd1-403f-a9bd-dca84d150b11" />

> 2. 직접 일기 작성 시 크레딧 증가 확인
> 아무내용으로 100자 이상 일기를 작성합니다.
<img width="709" alt="image" src="https://github.com/user-attachments/assets/ed334b20-e89c-4c2c-b1dd-deddf407380c" />

> - 일기가 저장된 것 확인 
<img width="701" alt="image" src="https://github.com/user-attachments/assets/3f52706d-4f5e-4a88-9eef-df7055b979d9" />

> 3. 변경된 현재 크레딧과 누적 크레딧 수 확인
> 둘 다 8로 증가된 것을 확인할 수 있습니다.
<img width="711" alt="image" src="https://github.com/user-attachments/assets/3cc54959-7a22-455b-916c-018e20de8779" />
<img width="708" alt="image" src="https://github.com/user-attachments/assets/0c7563ea-c44c-4f07-ab49-e1a1f529c791" />

> 4. 음성 일기 작성 시 크레딧 증가 확인
> AI와 대화를 마구마구 한 후에 일기 생성 API 호출
<img width="638" alt="image" src="https://github.com/user-attachments/assets/5025c7ee-292a-4ea5-85e1-87af2acbf13a" />
<img width="631" alt="image" src="https://github.com/user-attachments/assets/9984b323-699f-412b-b61d-19f1570c6323" />

> - 일기가 저장된 것 확인
<img width="635" alt="image" src="https://github.com/user-attachments/assets/74fb9af8-3005-4984-9770-e2c9d480d5fb" />

> 5. 변경된 크레딧 수 확인
> 둘 다 10으로 증가된 것을 확인할 수 있습니다.
<img width="638" alt="image" src="https://github.com/user-attachments/assets/a14e1ece-0feb-48a2-a2e7-314eaf690742" />
<img width="638" alt="image" src="https://github.com/user-attachments/assets/c7313b05-f5a0-4883-b966-a76f5d3c6b41" />
