### PR TITLE
[#194] Refactor: 챌린지 인증 내역 조회 certificationDate 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -87,7 +87,7 @@ public class ChallengeConverter {
     }
 
     // 챌린지 인증 작성 결과 반환
-    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge, String imageurl) {
+    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {
         return ChallengeResponseDTO.ProofDetailsDTO.builder()
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -87,7 +87,7 @@ public class ChallengeConverter {
     }
 
     // 챌린지 인증 작성 결과 반환
-    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {
+    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge, String imageurl) {
         return ChallengeResponseDTO.ProofDetailsDTO.builder()
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -94,7 +94,7 @@ public class ChallengeConverter {
                 .time(challenge.getTime())
                 .certificationImage(imageUrl)
                 .thoughts(userChallenge.getThoughts())
-                .certificationDate(userChallenge.getCreatedAt())
+                .certificationDate(userChallenge.getCertificationDate())
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -92,7 +92,7 @@ public class ChallengeConverter {
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())
                 .time(challenge.getTime())
-                .certificationImage(imageUrl)
+                .certificationImage(userChallenge.getCertificationImage())
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCertificationDate())
                 .build();

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -87,7 +87,7 @@ public class ChallengeConverter {
     }
 
     // 챌린지 인증 작성 결과 반환
-    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge, String imageUrl) {
+    public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {
         return ChallengeResponseDTO.ProofDetailsDTO.builder()
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -40,8 +40,8 @@ public class UserChallenge extends BaseEntity {
     @Column(nullable = false)
     private boolean completed;
 
-    @Column(nullable = false)
-    private LocalDateTime certificationDate = LocalDateTime.now(); // null로 저장되는 문제 방지
+    @Column(name = "certification_date")
+    private LocalDateTime certificationDate;
 
     public void setChallenge(Challenge challenge) {
         this.challenge = challenge;

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -6,6 +6,8 @@ import lombok.*;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -38,6 +40,9 @@ public class UserChallenge extends BaseEntity {
     @Column(nullable = false)
     private boolean completed;
 
+    @Column(nullable = false)
+    private LocalDateTime certificationDate = LocalDateTime.now(); // null로 저장되는 문제 방지
+
     public void setChallenge(Challenge challenge) {
         this.challenge = challenge;
     }
@@ -47,9 +52,10 @@ public class UserChallenge extends BaseEntity {
     public void setCertificationImage(String certificationImage) { this.certificationImage = certificationImage; }
     // 인증 작성 (최초 등록 또는 전체 업데이트용)
     public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest, String imageUrl){
-        thoughts = proofRequest.getThoughts();
-        certificationImage = imageUrl;
-        completed = true;
+        this.thoughts = proofRequest.getThoughts();
+        this.certificationImage = imageUrl;
+        this.certificationDate = LocalDateTime.now(); // 인증한 날짜 저장
+        this.completed = true;
     }
 
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -96,17 +96,14 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 이미지 업로드
-        String imageUrl = proofRequest.getCertificationImageUrl();
-
-        userChallenge.verifyUserChallenge(proofRequest, imageUrl);
+        userChallenge.verifyUserChallenge(proofRequest, proofRequest.getCertificationImageUrl());
         userChallengeRepository.save(userChallenge);
 
         user.updateCurrentCredit(user.getCurrentCredit() + challengeCredit);
         user.updateTotalCredit(user.getTotalCredit() + challengeCredit);
         userRepository.save(user);
 
-        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge, imageUrl);
+        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge);
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -129,17 +129,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
             throw new ChallengeHandler(ErrorStatus.CHALLENGE_NOT_COMPLETED);
         }
 
-        // S3의 인증 이미지 경로 가져오기
-        String imageKey = userChallenge.getCertificationImage();
-
-        String folder = "challenges"; // 폴더 값 설정
-
-        // Presigned URL 생성 (이미지가 존재하는 경우에만)
-        String presignedUrl = (imageKey != null && !imageKey.isEmpty())
-                ? s3Service.generatePresignedUrlForDownload(folder, imageKey)
-                : null; // 이미지가 없으면 null 반환
-
-        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge, presignedUrl);
+        return ChallengeConverter.toProofDetailsDTO(userChallenge.getChallenge(), userChallenge);
     }
 
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.dto.ChallengeDTO;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -86,22 +87,6 @@ public class ChallengeResponseDTO {
         private boolean completed;
     }
 
-    // 챌린지 인증 응답 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AddProofResultDTO {
-        private Long id;
-        private String title;
-        private Integer time;
-        private String certificationImage;
-        private UserChallengeType dtype;
-        private String thoughts;
-        private boolean completed;
-        private LocalDateTime certificationDate;
-    }
-
     // 첼린지 인증 내역
     @Getter
     @Builder
@@ -113,6 +98,7 @@ public class ChallengeResponseDTO {
         private String certificationImage;
         private String thoughts;
         private Integer time;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime certificationDate;
     }
 


### PR DESCRIPTION
## 📝 작업 내용
> -converter에서 certificationDate를 createdAt로 불러오고 있어서 그 부분 수정하였습니다.
- UserChallenge에 certificationDate 필드 추가하였고,
```java
    @Column(nullable = false)
    private LocalDateTime certificationDate;
``` 
로 선언하면 00:00:00 00:00:00 null로 저장되어 에러가 떠서, 처음에는 createdAt 뜨게하고  챌린지 인증 작성을 하면 인증한 날짜와 시간이 나오게 수정하였습니다.
- 프론트에서 decodingError가 난다고 하여 LocalDateTime 값을 포맷하여 전송하는 식으로 수정하였습니다.

잘못된 부분 있으면 알려주세요!
## 🔍 테스트 방법
> x