### PR TITLE
[#196] Feat: 스케줄러 - 오래된 인증번호 삭제

### DIFF
--- a/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
+++ b/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
@@ -3,9 +3,11 @@ package umc.GrowIT.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class GrowItServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/AuthenticationCodeRepository.java
@@ -1,8 +1,11 @@
 package umc.GrowIT.Server.repository;
 
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import umc.GrowIT.Server.domain.AuthenticationCode;
 import umc.GrowIT.Server.domain.enums.CodeStatus;
 
@@ -12,4 +15,9 @@ import java.util.Optional;
 public interface AuthenticationCodeRepository extends JpaRepository<AuthenticationCode, Integer> {
     // 특정 이메일의 expirationDate가 지금 이후 & status가 유효한 데이터 찾기
     Optional<AuthenticationCode> findByEmailAndExpirationDateAfterAndStatus(String email, LocalDateTime currentDateTime, CodeStatus codeStatus);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM AuthenticationCode ac WHERE ac.expirationDate < :threshold")
+    int deleteByExpirationDateBefore(LocalDateTime threshold);
 }

--- a/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
+++ b/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
@@ -26,7 +26,7 @@ public class Scheduler {
 
             LocalDateTime threshold = LocalDateTime.now().minusDays(expirationDays);
             int count = authenticationCodeRepository.deleteByExpirationDateBefore(threshold);
-            log.info("[스케줄러 : 만료시간이" + expirationDays + "일 지난 데이터 삭제");
+            log.info("[스케줄러 : 만료시간이 " + expirationDays + "일 지난 데이터 삭제");
             log.info("[스케줄러] : 삭제된 데이터 개수 : " + count);
         } catch (Exception e) {
             log.error("[스케줄러] : 인증번호 삭제 실패", e);

--- a/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
+++ b/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
@@ -1,0 +1,35 @@
+package umc.GrowIT.Server.scheduler;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import umc.GrowIT.Server.domain.AuthenticationCode;
+import umc.GrowIT.Server.repository.AuthenticationCodeRepository;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class Scheduler {
+    private final AuthenticationCodeRepository authenticationCodeRepository;
+
+    // 인증번호 삭제 스케줄러
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정 실행
+    @Transactional
+    public void deleteExpiredAuthenticationCodes() {
+        try {
+            // 기준일
+            int expirationDays = 14;
+
+            LocalDateTime threshold = LocalDateTime.now().minusDays(expirationDays);
+            int count = authenticationCodeRepository.deleteByExpirationDateBefore(threshold);
+            log.info("[스케줄러 : 만료시간이" + expirationDays + "일 지난 데이터 삭제");
+            log.info("[스케줄러] : 삭제된 데이터 개수 : " + count);
+        } catch (Exception e) {
+            log.error("[스케줄러] : 인증번호 삭제 실패", e);
+        }
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
+++ b/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
@@ -22,7 +22,7 @@ public class Scheduler {
     public void deleteExpiredAuthenticationCodes() {
         try {
             // 기준일
-            int expirationDays = 14;
+            int expirationDays = 15;
 
             LocalDateTime threshold = LocalDateTime.now().minusDays(expirationDays);
             int count = authenticationCodeRepository.deleteByExpirationDateBefore(threshold);


### PR DESCRIPTION
## 📝 작업 내용
> 인증 번호를 받기 위해 메일을 전송하는 경우의 데이터를 DB에서 관리 중입니다. 
> 이때, 오래 누적된 데이터들을 삭제하는 스케줄러를 구현하였습니다.
> 만료시간이 15일 지난 데이터를 매일 자정에 삭제합니다
> (테스트는 변경해서 진행하였습니다)
> 
> 현재 코드는, 인증 여부와는 별개로 만료시간만 오래되었다면 삭제하도록 하였는데 인증 완료한 데이터는 유지할 필요가 있을까요??


## 🔍 테스트 방법
> 1. 14일 기준으로 변경하였기 때문에, ID 6~9 데이터가 삭제되어야 함
> ![image](https://github.com/user-attachments/assets/0332a064-1149-421f-b317-1b34057d6e89)
>
> 2. 설정해둔 22시 18분이 되면 삭제되는 것을 확인할 수 있음
> ![image](https://github.com/user-attachments/assets/f04b22eb-d900-41b5-8486-caab0eb1fe78)
