### PR TITLE
[#198] Bug: 일기-키워드 추출 시, 잘못된  분석 및 DB 없는 감정 응답 개선

### DIFF
--- a/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
@@ -9,11 +9,28 @@ import org.springframework.web.client.RestTemplate;
 public class OpenAiConfig {
     @Value("${openai.api.key}")
     private String openAiKey;
+
+    @Value("${openai.api.key-100}")
+    private String openAiKey100;
+
     @Bean
     public RestTemplate template(){
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add((request, body, execution) -> {
             request.getHeaders().add("Authorization", "Bearer " + openAiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+
+    /**
+     * 일기-감정키워드 추출하는 모델 API 호출 템플릿
+     */
+    @Bean
+    public RestTemplate keywordModelTemplate(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + openAiKey100);
             return execution.execute(request, body);
         });
         return restTemplate;

--- a/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTRequest.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/ChatGPTRequest.java
@@ -19,4 +19,10 @@ public class ChatGPTRequest {
         this.messages =  new ArrayList<>();
         this.messages.add(new Message("user", prompt));
     }
+
+    public ChatGPTRequest(String model, String prompt, Float temperature) {
+        this.model = model;
+        this.messages = new ArrayList<>();
+        this.messages.add(new Message("user", prompt));
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
### 🤯 문제 상황
1. 모델이 일기를 잘못 분석
2. DB에 없는 감정을 포함하여 응답

### 😃 해결 방법
1. 일기를 잘못 분석하는 일은 4o-mini 로 변경 및 temperature 값 조절로 크게 개선됐습니다.
여기서 추가로 파인튜닝을 통해 특정 문장 패턴에 대한 학습을 시켜서 좀 더 일기의 전체 맥락에 맞는 3개의 감정을 추출하도록 했습니다.

- ex) 요즘 중요한 시험을 앞두고 준비하느라 걱정이 많이 됐다. 하지만 오늘 결국 긴장하지 않고 시험을 잘 치뤘다고 느꼈고, 준비한 만큼 결과가 잘 나올 거라고 기대한다.

  - <img width="195" alt="Screenshot 2025-02-15 at 3 13 57 PM" src="https://github.com/user-attachments/assets/c4b196e1-aa3f-41dd-b045-ace56b84f332" /> : **gpt-4o-mini** 

  - <img width="220" alt="Screenshot 2025-02-15 at 3 14 36 PM" src="https://github.com/user-attachments/assets/fc2697cd-b5d7-4790-8266-d8e6a20d1c62" /> : **파인튜닝v3.3(200개 데이터 학습)**

  - <img width="216" alt="Screenshot 2025-02-15 at 3 14 48 PM" src="https://github.com/user-attachments/assets/f9ab8465-3135-4f88-9a30-69d51d958fb0" /> : **파인튜닝v3.4(600개 데이터 학습)**


2. temperature 값을 최소한으로 낮춰서 다양하고 창의적인 답변을 제한했습니다. 하지만 DB에 없는 감정을 포함하는 경우가 더러 있습니다. 일기에 "흥미" 라는 단어가 들어갔지만, DB에는 존재하지 않는 경우
- temperature 값을 낮춤에 따라 답변이 변하지 않고 고정되는데, 이럴 경우에 API 재요청하는 것은 무리가 있습니다. 따라서 현재 생각한 방법은 진성님이 그 감정에 대해 DB에 있는 감정과 유사도 분석을 거쳐 다시 감정 키워드를 뽑아내기로 했습니다. "흥미로운" 과 유사한 "설레는"

*추가로 프롬프트도 수정했습니다.

###  ✍️코드 변경사항
- 일기-키워드 추출용 파인튜닝 모델 추가
- temperature 값 0.0으로 설정 후 API 요청에 추가
- 프롬프트 수정

## 🔍 테스트 방법
### 1. 일기 작성
예시 일기 : 오늘은 정말 지치는 하루였다. 해야 할 일이 많았는데도 시작이 너무 어려웠고, 계속 미루다 보니 시간이 부족해져서 더 초조해졌다. 집중하려 해도 자꾸만 흐트러지고, 생각대로 되지 않으니 답답함이 쌓였다. 그래도 마냥 손 놓고 있을 수는 없어서 조금씩이라도 해보려 했고, 하나하나 해결해 나가면서 점점 기분이 나아졌다. 막막했던 일이 정리되니 마음도 가벼워졌고, 결국 생각보다 더 많은 걸 해낼 수 있었다. 처음엔 너무 힘들었지만, 끝까지 해낸 덕분에 보람차고 만족스러운 하루가 되었다.

<img width="1148" alt="Screenshot 2025-02-15 at 2 49 59 PM" src="https://github.com/user-attachments/assets/8eede4f2-232c-40a1-aeda-a583dd63c6e5" />

### 2-1. 일기 분석 (키워드 추출)
만족스러운, 지친, 뿌듯한

<img width="183" alt="Screenshot 2025-02-15 at 2 51 01 PM" src="https://github.com/user-attachments/assets/db81e98f-6ab6-4945-987d-ca0028137e11" />

### 2-2. 모델 비교

일기의 감정이 복합적인데, 부정적인 감정 1 : 긍정적인 감정 2 정도가 된다고 생각합니다.
파인튜닝v3.4가 대체로 더 논리적인 감정 분석을 할 수 있게 학습시켰고, 다음과 같이 나옵니다.
(복합적인 감정 일기가 아닌 감정이 일관되게 이어지는 일기는 모든 모델이 대체로 잘 응답해서 학습을 많이 시키지 않았습니다.)

<img width="192" alt="Screenshot 2025-02-15 at 2 53 58 PM" src="https://github.com/user-attachments/assets/c31be1a6-b92f-437b-ac83-9c6ef305ebb7" />

- gpt-4o-mini
- 파인튜닝v3.3(200개 데이터 학습)
- 파인튜닝v3.4(600개 데이터 학습)
