### PR TITLE
[#200] Refactor: 챌린지 관련 코드 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -92,7 +92,7 @@ public class ChallengeConverter {
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())
                 .time(challenge.getTime())
-                .certificationImageUrl(userChallenge.getCertificationImage())
+                .certificationImageUrl(userChallenge.getCertificationImageUrl())
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCertificationDate())
                 .build();
@@ -121,7 +121,7 @@ public class ChallengeConverter {
                 .toList();
 
         return ChallengeResponseDTO.SelectChallengeDTO.builder()
-                .selectedChallenges(selectedChallenges) // ✅ 여러 개의 챌린지 리스트 반환
+                .selectedChallenges(selectedChallenges) // 여러 개의 챌린지 리스트 반환
                 .build();
     }
 
@@ -129,7 +129,7 @@ public class ChallengeConverter {
     // 챌린지 수정
     public static ChallengeResponseDTO.ModifyProofDTO toChallengeModifyProofDTO(UserChallenge userChallenge) {
         return ChallengeResponseDTO.ModifyProofDTO.builder()
-                .certificationImageUrl(userChallenge.getCertificationImage())
+                .certificationImageUrl(userChallenge.getCertificationImageUrl())
                 .thoughts(userChallenge.getThoughts())
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -92,7 +92,7 @@ public class ChallengeConverter {
                 .id(userChallenge.getId())
                 .title(challenge.getTitle())
                 .time(challenge.getTime())
-                .certificationImage(userChallenge.getCertificationImage())
+                .certificationImageUrl(userChallenge.getCertificationImage())
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCertificationDate())
                 .build();
@@ -129,7 +129,7 @@ public class ChallengeConverter {
     // 챌린지 수정
     public static ChallengeResponseDTO.ModifyProofDTO toChallengeModifyProofDTO(UserChallenge userChallenge) {
         return ChallengeResponseDTO.ModifyProofDTO.builder()
-                .certificationImage(userChallenge.getCertificationImage())
+                .certificationImageUrl(userChallenge.getCertificationImage())
                 .thoughts(userChallenge.getThoughts())
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -30,8 +31,8 @@ public class UserChallenge extends BaseEntity {
     @Column(name = "thoughts", length = 100, nullable = false)
     private String thoughts;
 
-    @Column(name = "certification_image", columnDefinition = "TEXT")
-    private String certificationImage;
+    @Column(name = "certification_imageurl", columnDefinition = "TEXT")
+    private String certificationImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -43,17 +44,10 @@ public class UserChallenge extends BaseEntity {
     @Column(name = "certification_date")
     private LocalDateTime certificationDate;
 
-    public void setChallenge(Challenge challenge) {
-        this.challenge = challenge;
-    }
-
-    public void setThoughts(String thoughts) { this.thoughts = thoughts; }
-
-    public void setCertificationImage(String certificationImage) { this.certificationImage = certificationImage; }
     // 인증 작성 (최초 등록 또는 전체 업데이트용)
     public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest, String imageUrl){
         this.thoughts = proofRequest.getThoughts();
-        this.certificationImage = imageUrl;
+        this.certificationImageUrl = imageUrl;
         this.certificationDate = LocalDateTime.now(); // 인증한 날짜 저장
         this.completed = true;
     }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -120,7 +120,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         // 인증 이미지 업데이트
         if (updateRequest.getCertificationImageUrl() != null && !updateRequest.getCertificationImageUrl().isEmpty()) {
-            userChallenge.setCertificationImage(updateRequest.getCertificationImageUrl()); // 새 이미지 설정
+            userChallenge.setCertificationImageUrl(updateRequest.getCertificationImageUrl()); // 새 이미지 설정
         }
 
         // 소감 업데이트

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -68,7 +68,7 @@ public interface ChallengeSpecification {
 
     @PostMapping("{userChallengeId}/prove")
     @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다. <br>" +
-            "multipart/form-data 형식의 이미지를 input으로 받습니다. 이때 key 값은 file 입니다.")
+            "string 값으로 certificationImageUrl과 thoughts를 넘겨주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -68,7 +68,7 @@ public interface ChallengeSpecification {
 
     @PostMapping("{userChallengeId}/prove")
     @Operation(summary = "챌린지 인증 작성 API", description = "챌린지 인증을 작성하는 API입니다. <br>" +
-            "string 값으로 certificationImageUrl과 thoughts를 넘겨주세요.")
+            "s3에 업로드한 객체 URL을 certificationImageUrl로 넘겨주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -88,7 +88,8 @@ public interface ChallengeSpecification {
 
 
     @PatchMapping("{userChallengeId}")
-    @Operation(summary = "챌린지 인증 수정 API", description = "챌린지 인증을 수정하는 API입니다.")
+    @Operation(summary = "챌린지 인증 수정 API", description = "챌린지 인증을 수정하는 API입니다. <br>" +
+            "s3에 업로드한 객체 URL을 certificationImageUrl로 넘겨주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -87,7 +87,7 @@ public class ChallengeResponseDTO {
         private boolean completed;
     }
 
-    // 첼린지 인증 내역
+    // 챌린지 인증 내역
     @Getter
     @Builder
     @NoArgsConstructor
@@ -95,7 +95,7 @@ public class ChallengeResponseDTO {
     public static class ProofDetailsDTO {
         private Long id;
         private String title;
-        private String certificationImage;
+        private String certificationImageUrl;
         private String thoughts;
         private Integer time;
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
@@ -128,7 +128,7 @@ public class ChallengeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ModifyProofDTO {
-        private String certificationImage;
+        private String certificationImageUrl;
         private String thoughts;
     }
 


### PR DESCRIPTION
## 📝 작업 내용
> 

- [x] 인증이미지 변수명 수정 (certificationImage -> certificationImageUrl)
- [x] 챌린지 명세서 - 인증 작성 summary 수정 (기존에 있던 multipartFile 관련 설명 삭제)
- [x] UserChallenge에 @Setter 추가하여 코드 개선

변수명을 수정하여, 기존에 있던 UserChallenge 데이터에서 certificationImageUrl을 조회하면 null로 뜨고
일기 작성 - 분석 - 챌린지 저장 - 인증 작성 절차를 새로 거치면 작성한 certificationImageUrl이 잘 조회됩니다. (당일에 챌린지 인증 작성을 마쳐서 테스트를 못한다면, "챌린지 인증 내역 수정" 에서 url 수정하면 문제없이 잘 조회되는거 확인할 수 있습니다.)
-> 프론트분께 수정사항 말씀드렸습니다.
-> UserChallenge 엔티티에서 certificationImageUrl로 수정하였더니 DB에 certification_imageurl 필드가 새로 추가되었습니다. (certification_image 필드는 그대로)    UserChallenge 데이터 초기화할 때 참고해주세요.

❗ 자정이 지나도 챌린지 홈 조회 부분이 초기화되지 않는다고 하셔서 ec2 터미널에서 timezone Etc/UTC -> Asia/Seoul 변경하였습니다. UTC 기준 한국시간은 9시간 차이난다고 하니 테스트하시게 되면 참고해주세요. (자정이 지났는데도 초기화되지 않으면 timezone 적용이 안된거일수도 있으니 문제 생기면 말씀해주세요!)
## 🔍 테스트 방법
> x