### PR TITLE
[#201] Fix: 일기 분석 API - 플라스크 연결

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -122,6 +122,9 @@ public enum ErrorStatus implements BaseErrorCode {
     GPT_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5001", "GPT 응답이 비어있습니다. 다시 시도해 주세요."),
     EMOTIONS_COUNT_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5002", "GPT 응답에서 감정의 개수는 3개여야 합니다."),
     EMOTIONS_DUPLICATE(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5003", "GPT 응답에서 중복된 감정이 존재합니다."),
+
+    // 플라스크 관련 에러
+    FLASK_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLASK5001", "Flask API 호출에 실패하였습니다.");
     ;
 
 

--- a/src/main/java/umc/GrowIT/Server/apiPayload/exception/FlaskHandler.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/exception/FlaskHandler.java
@@ -1,0 +1,10 @@
+package umc.GrowIT.Server.apiPayload.exception;
+
+import umc.GrowIT.Server.apiPayload.code.BaseErrorCode;
+
+public class FlaskHandler extends GeneralException {
+    public FlaskHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -243,11 +243,13 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
+
         //2. 예외 체크
         //일기 분석은 1번만 가능
         if(diary.getDiaryKeywords() != null && !diary.getDiaryKeywords().isEmpty()) {
             throw new DiaryHandler(ErrorStatus.ANALYZED_DIARY);
         }
+
 
         // 3. DB에서 감정들 조회
         List<String> emotions = keywordRepository.findAll()
@@ -338,14 +340,14 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         }
 
         // DB에 존재하는 감정인지 체크 & 없으면 유사도 검색
-        List<Keyword> emotionKeywords = checkEmotions(uniqueEmotions.stream().toList());
+//        List<Keyword> emotionKeywords = checkEmotions(uniqueEmotions.stream().toList());
 
 //         테스트용
-//        Set<String> testEmotions = new HashSet<>();
-//        testEmotions.add("흥미로운");
-//        testEmotions.add("설레는");
-//        testEmotions.add("빠져있는");
-//        List<Keyword> emotionKeywords = checkEmotions(testEmotions.stream().toList());
+        Set<String> testEmotions = new HashSet<>();
+        testEmotions.add("분노");
+        testEmotions.add("설레는");
+        testEmotions.add("울적한");
+        List<Keyword> emotionKeywords = checkEmotions(testEmotions.stream().toList());
 
         return emotionKeywords;
     }
@@ -370,7 +372,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         // 2) DB에 없는 감정이 있다면 Flask에 유사도 분석 요청
         if (!needAnalysis.isEmpty()) {
-            log.info("[DB 없는 감정 존재]");
+            log.info("[DB 없는 감정 존재 -> 플라스크 API 요청]");
 
             Map<String, Object> request = Map.of(
                     "emotions", needAnalysis,

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
@@ -342,15 +343,76 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
             throw new OpenAIHandler(ErrorStatus.EMOTIONS_DUPLICATE);
         }
 
-        // DB에 존재하는 감정인지 체크
-        List<Keyword> emotionKeywords = uniqueEmotions.stream()
-                .map(emotion -> keywordRepository.findByName(emotion)
-                        .orElseThrow(() -> new KeywordHandler(ErrorStatus.KEYWORD_NOT_FOUND)))
-                .toList()
-                ;
+        // DB에 존재하는 감정인지 체크 & 없으면 유사도 검색
+        List<Keyword> emotionKeywords = checkEmotions(uniqueEmotions.stream().toList());
+
+//         테스트용
+//        Set<String> testEmotions = new HashSet<>();
+//        testEmotions.add("흥미로운");
+//        testEmotions.add("설레는");
+//        testEmotions.add("빠져있는");
+//        List<Keyword> emotionKeywords = checkEmotions(testEmotions.stream().toList());
 
         return emotionKeywords;
     }
+
+
+    // DB 감정인지 체크 (없으면 유사도 분석)
+    private List<Keyword> checkEmotions(List<String> inputEmotions) {
+        List<Keyword> result = new ArrayList<>();
+        Set<String> dbEmotions = new HashSet<>();
+        List<String> needAnalysis = new ArrayList<>();
+
+        // 1) DB에 있는지 체크
+        for (String emotion : inputEmotions) {
+            keywordRepository.findByName(emotion).ifPresentOrElse(
+                    keyword -> {
+                        result.add(keyword);
+                        dbEmotions.add(emotion);
+                    },
+                    () -> needAnalysis.add(emotion)
+            );
+        }
+
+        // 2) DB에 없는 감정이 있다면 Flask에 유사도 분석 요청
+        if (!needAnalysis.isEmpty()) {
+            log.info("[DB 없는 감정 존재]");
+
+            Map<String, Object> request = Map.of(
+                    "emotions", needAnalysis,
+                    "existingEmotions", dbEmotions
+            );
+
+            ResponseEntity<Map> response = template.postForEntity(
+                    "http://localhost:5000/analyze_emotions",
+                    request,
+                    Map.class
+            );
+
+            List<Map<String, Object>> analyzedEmotions = (List<Map<String, Object>>) response.getBody().get("analyzedEmotions");
+
+            if (analyzedEmotions != null) {
+                for (Map<String, Object> analysisResult : analyzedEmotions) {
+                    String inputEmotion = (String) analysisResult.get("inputEmotion");
+                    String similarEmotion = (String) analysisResult.get("similarEmotion");
+                    Double similarityScore = (Double) analysisResult.get("similarityScore");
+
+                    // Flask에서 받은 정보 출력
+                    log.info("[Flask 분석 결과] - 입력 감정 : {}, 유사 감정 : {}, 유사도 점수 : {}", inputEmotion, similarEmotion, similarityScore);
+
+                    keywordRepository.findByName(similarEmotion)
+                            .ifPresentOrElse(result::add,
+                                    () -> { throw new KeywordHandler(ErrorStatus.KEYWORD_NOT_FOUND); });
+                }
+            }
+            else {
+                throw new FlaskHandler(ErrorStatus.FLASK_API_CALL_FAILED);
+            }
+        }
+
+        return result;
+    }
+
 
     // 일기와 감정키워드 연관관계 설정
     private void setDiaryKeyword(Diary diary, List<Keyword> analyzedEmotions) {

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -93,6 +93,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FLASK5001", description = "❌ Flask API 호출에 실패하였습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))


### PR DESCRIPTION
## 📝 작업 내용
> 일기 분석 API 과정에서 OpenAI가 DB에 없는 감정을 반환하는 경우, 플라스크로 전송하여 DB에 저장된 감정 중 가장 유사한 감정으로 매칭함으로써 오류를 방지하였습니다.
> 유사도 매칭 자체의 한계와 중복 방지를 위한 차선책으로 인해 완전히 만족스러운 결과가 나오지 않을 수도 있지만, DB에 없는 감정이 반환되는 경우가 드물고 오류 방지를 위한 조치이기 때문에 현재로서는 최선의 방법이라고 생각됩니다.
> 현재 테스트용 코드로 PR을 올렸는데, 이 상태로 Merge하여 Ec2 위에서 정상적으로 플라스크와 연결이 되는지 확인한 다음에 이상 없는 것이 확인되면 주석 처리해둔 코드로 다시 PR 올릴 예정입니다.


## 🔍 테스트 방법
> X