### PR TITLE
[#211] Refactor: 일기 분석 API - 플라스크 연결 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -340,14 +340,14 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         }
 
         // DB에 존재하는 감정인지 체크 & 없으면 유사도 검색
-//        List<Keyword> emotionKeywords = checkEmotions(uniqueEmotions.stream().toList());
+        List<Keyword> emotionKeywords = checkEmotions(uniqueEmotions.stream().toList());
 
 //         테스트용
-        Set<String> testEmotions = new HashSet<>();
-        testEmotions.add("분노");
-        testEmotions.add("설레는");
-        testEmotions.add("울적한");
-        List<Keyword> emotionKeywords = checkEmotions(testEmotions.stream().toList());
+//        Set<String> testEmotions = new HashSet<>();
+//        testEmotions.add("분노");
+//        testEmotions.add("설레는");
+//        testEmotions.add("울적한");
+//        List<Keyword> emotionKeywords = checkEmotions(testEmotions.stream().toList());
 
         return emotionKeywords;
     }


### PR DESCRIPTION
## 📝 작업 내용
> https://github.com/7-umc-GrowIT/GrowIT-SpringBoot/pull/210
> DB에 없는 감정이 반환되어야 플라스크를 호출하도록 되어있기 때문에 이전 PR에서 플라스크를 연결할 때 테스트 코드로 올렸습니다.
> 
> ![image](https://github.com/user-attachments/assets/c72ccb05-1bd9-478a-a280-9835ed7c5bf9)
> 방금 ec2의 스웨거로 테스트한 결과, 테스트 코드 정상 실행되는 것으로 확인되었습니다.
> 따라서, 테스트 코드는 주석 처리하고, 정상 코드로 변경해 두었습니다.


## 🔍 테스트 방법
> 1. X