### PR TITLE
[#209] Refactor: 챌린지 홈 조회 시 recommendedChallenges 업데이트

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/ChallengeKeywordRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ChallengeKeywordRepository.java
@@ -5,12 +5,21 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.ChallengeKeyword;
 import umc.GrowIT.Server.domain.Keyword;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeKeywordRepository extends JpaRepository<ChallengeKeyword, Long> {
-    @Query("SELECT ck FROM ChallengeKeyword ck JOIN FETCH ck.keyword WHERE ck.challenge.id = :challengeId")
-    List<ChallengeKeyword> findByChallengeId(@Param("challengeId") Long challengeId);
     @Query("SELECT ck FROM ChallengeKeyword ck JOIN FETCH ck.challenge WHERE ck.keyword = :keyword")
     List<ChallengeKeyword> findByKeywordWithChallenge(@Param("keyword") Keyword keyword);
+
+    @Query("SELECT ck.challenge.id FROM ChallengeKeyword ck " +
+            "WHERE ck.keyword.id IN (" +
+            "    SELECT dk.keyword.id FROM DiaryKeyword dk " +
+            "    WHERE dk.diary.user.id = :userId " +
+            "    AND dk.diary.date = :today" +
+            ")")
+    List<Long> findChallengeIdsByTodayDiaryKeywords(@Param("userId") Long userId, @Param("today") LocalDate today);
+
 }

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -16,17 +17,16 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     // 특정 챌린지 ID와 매핑된 인증 내역 조회
     Optional<UserChallenge> findByIdAndUserId(@Param("challengeId") Long challengeId, @Param("userId") Long userId);
 
-    @Query("SELECT uc FROM UserChallenge uc JOIN FETCH uc.challenge WHERE uc.user.id = :userId AND uc.completed = false")
-    List<UserChallenge> findUserChallengesByUserId(@Param("userId") Long userId);
-
     // 오늘 날짜 기준으로 저장된 챌린지만 필터링
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND uc.createdAt BETWEEN :startOfDay AND :endOfDay")
+            "AND uc.createdAt >= :startOfDay " +
+            "AND uc.createdAt <= :endOfDay")
     List<UserChallenge> findTodayUserChallengesByUserId(
             @Param("userId") Long userId,
             @Param("startOfDay") LocalDateTime startOfDay,
             @Param("endOfDay") LocalDateTime endOfDay);
+
 
     // 1. 유저의 완료 또는 미완료 챌린지 조회 (dtype 무시)
     @Query("SELECT uc FROM UserChallenge uc " +

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -20,12 +20,10 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     // 오늘 날짜 기준으로 저장된 챌린지만 필터링
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND uc.createdAt >= :startOfDay " +
-            "AND uc.createdAt <= :endOfDay")
+            "AND DATE(uc.createdAt) = :today")
     List<UserChallenge> findTodayUserChallengesByUserId(
             @Param("userId") Long userId,
-            @Param("startOfDay") LocalDateTime startOfDay,
-            @Param("endOfDay") LocalDateTime endOfDay);
+            @Param("today") LocalDate today);
 
 
     // 1. 유저의 완료 또는 미완료 챌린지 조회 (dtype 무시)

--- a/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/diaryRepository/DiaryRepository.java
@@ -28,4 +28,5 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     // 오늘 작성한 일기 조회
     @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND d.date = :date")
     Optional<Diary> findTodayDiaryByUserId(@Param("userId") Long userId, @Param("date") LocalDate date);
+
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -72,8 +72,6 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     @Transactional
     public ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId) {
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
         // 오늘 날짜의 일기 존재 여부 확인
         Optional<Diary> todayDiary = diaryRepository.findTodayDiaryByUserId(userId, today);
@@ -85,7 +83,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
 
         // 사용자가 직접 저장한 챌린지만 가져옴
         List<UserChallenge> savedChallenges = todayDiary.isPresent()
-                ? userChallengeRepository.findTodayUserChallengesByUserId(userId, startOfDay, endOfDay)
+                ? userChallengeRepository.findTodayUserChallengesByUserId(userId, today)
                 : Collections.emptyList();
 
         // 오늘 작성한 일기의 키워드 기반 추천 챌린지 ID 목록 조회

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.ChallengeHandler;
 import umc.GrowIT.Server.converter.ChallengeConverter;
+import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.repository.ChallengeKeywordRepository;
@@ -26,9 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -40,6 +39,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     private final S3Service s3Service;
     private final DiaryRepository diaryRepository;
     private final KeywordService keywordService;
+    private final ChallengeKeywordRepository challengeKeywordRepository;
 
 
     @Override
@@ -71,26 +71,37 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     @Override
     @Transactional
     public ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
-        // 오늘의 시작 시간과 끝 시간 계산
-        LocalDateTime startOfDay = LocalDate.now().atStartOfDay(); // 오늘 자정 00:00:00
-        LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX); // 오늘 끝 23:59:59
+        // 오늘 날짜의 일기 존재 여부 확인
+        Optional<Diary> todayDiary = diaryRepository.findTodayDiaryByUserId(userId, today);
 
-        // 오늘 저장된 챌린지 조회
-        List<UserChallenge> todayChallenges = userChallengeRepository.findTodayUserChallengesByUserId(userId, startOfDay, endOfDay);
+        // 감정 키워드 조회
+        List<String> keywordNames = todayDiary.isPresent()
+                ? keywordService.getTodayDiaryKeywords(userId)
+                : Collections.emptyList();
 
-        // 감정 키워드 조회 (사용자가 오늘 작성한 일기 기반)
-        List<String> keywordNames = keywordService.getTodayDiaryKeywords(userId);
+        // 사용자가 직접 저장한 챌린지만 가져옴
+        List<UserChallenge> savedChallenges = todayDiary.isPresent()
+                ? userChallengeRepository.findTodayUserChallengesByUserId(userId, startOfDay, endOfDay)
+                : Collections.emptyList();
+
+        // 오늘 작성한 일기의 키워드 기반 추천 챌린지 ID 목록 조회
+        List<Long> todayDiaryKeywordChallengeIds = todayDiary.isPresent()
+                ? challengeKeywordRepository.findChallengeIdsByTodayDiaryKeywords(userId, today)
+                : Collections.emptyList();
 
         return ChallengeConverter.toChallengeHomeDTO(
-                todayChallenges,
+                savedChallenges,
+                todayDiaryKeywordChallengeIds,
                 getTotalCredits(userId),
                 getTotalDiaries(userId),
                 getDiaryDate(userId),
                 keywordNames
         );
     }
-
 
 
     @Override


### PR DESCRIPTION
## 📝 작업 내용
> 챌린지 홈 조회 시 recommendedChallenges 업데이트

(수정 사항)
- 일기를 삭제하면 챌린지 홈에서 recommendedChallenges 가 빈 리스트로 반환
- 삭제하기 전 일기 분석으로 저장한 챌린지들은 UserChallenge에 유지
- 챌린지 현황 조회 시 해당 챌린지들 조회 가능, 인증 작성 가능

일기를 삭제해도, 분석하여 추천받은 챌린지들 중 사용자가 n개의 챌린지를 선택하여 UserChallenge 에 저장하였다면 데이터는 유지됩니다. (즉, 일기를 삭제해도 저장한 UserChallenge 데이터는 삭제되지 않는다는 의미)

## 🔍 테스트 방법
1. 오늘 날짜로 일기 작성
2. 일기 분석 후 챌린지 홈 조회하였을 때 추출된 3가지 키워드가 조회되는지 확인(recommendedChallenges 는 빈 리스트)
3. "선택된 챌린지 저장 API"에서 추천받은 챌린지 3개 중 1~3개 선택하고 저장하기
4. 챌린지 홈 조회하였을 때 recommendedChallenges 에 저장한 챌린지 목록이 조회되어야함. (만약 챌린지를 2개 저장하였다면 2개만 조회되어야함.)
5. **해당 일기를 삭제하고 챌린지 홈 조회를 하였을 때 키워드와 추천챌린지 둘 다 빈 리스트로 반환되는지 확인**