### PR TITLE
[#217] Refactor: 인증 메일 템플릿 보완

### DIFF
--- a/src/main/resources/templates/email-authentication.html
+++ b/src/main/resources/templates/email-authentication.html
@@ -1,52 +1,114 @@
+<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>인증 페이지</title>
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
     <style>
-        /* 모바일 반응형 디자인 */
-        @media only screen and (max-width: 600px) {
-            body, table, td {
-                width: 100% !important;
-                padding: 0;
-            }
+        /* Reset styles for email clients */
+        body, table, td, div, p, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+        table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+        img { -ms-interpolation-mode: bicubic; }
 
+        /* Basic styles */
+        body {
+            margin: 0 !important;
+            padding: 0 !important;
+            height: 100% !important;
+            width: 100% !important;
+            background-color: #2ECC71 !important;
+        }
+
+        /* Fallback for dark mode */
+        @media (prefers-color-scheme: dark) {
+            body, table, td {
+                background-color: #2ECC71 !important;
+                color: white !important;
+            }
+        }
+
+        /* Mobile styles */
+        @media screen and (max-width: 600px) {
             .email-container {
+                width: 100% !important;
                 max-width: 100% !important;
             }
-
-            h1 {
-                font-size: 20px !important;
+            .email-container table {
+                width: 100% !important;
             }
-
+            .content-padding {
+                padding: 20px !important;
+            }
+            .logo-text {
+                font-size: 24px !important;
+            }
+            .character-img {
+                width: 150px !important;
+                height: auto !important;
+            }
+            .welcome-text {
+                font-size: 22px !important;
+            }
             .auth-code {
-                font-size: 18px !important;
+                font-size: 20px !important;
+                padding: 12px 24px !important;
             }
         }
     </style>
 </head>
-<body style="font-family: 'Arial', sans-serif; background-color: #2ECC71; color: white; text-align: center; margin: 0; padding: 0; height: 100%; width: 100%;">
-
-<table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" class="email-container" style="margin: auto; max-width: 700px; background-color: #A9DFBF; border-radius: 5px;">
+<body style="margin: 0; padding: 0; background-color: #2ECC71;">
+<!--[if mso]>
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #2ECC71;">
+<![endif]-->
+<table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px; margin: 0 auto; background-color: transparent;">
     <tr>
-        <td style="padding: 40px; text-align: center;">
+        <td align="center" style="padding: 20px 0;">
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" class="email-container" style="width: 90%; max-width: 600px; background: linear-gradient(145deg, #A9DFBF, #82E0AA); border-radius: 15px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+                <tr>
+                    <td class="content-padding" style="padding: 40px 30px; text-align: center;">
+                        <div style="margin-bottom: 20px;">
+                            <strong class="logo-text" style="font-size: 28px; color: #1D8348; letter-spacing: 1px; text-transform: uppercase; font-family: Arial, sans-serif;">GrowIT</strong>
+                        </div>
 
-            <div style="margin-bottom: 30px;">
-                <!-- 여기에 로고 이미지를 삽입하거나 로고 텍스트를 사용하세요 -->
-                <strong style="font-size: 24px; color: #1D8348;">GrowIT</strong>
-            </div>
+                        <!--[if mso]>
+                        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"><tr><td align="center">
+                        <![endif]-->
+                        <img src="https://growit-server-bucket.s3.ap-northeast-2.amazonaws.com/email/gro.png" alt="GrowIT Character" class="character-img" width="150" style="width: 150px; height: auto; margin: 20px auto; border-radius: 10px; display: block; box-shadow: 0 3px 6px rgba(0,0,0,0.1);">
+                        <!--[if mso]>
+                        </td></tr></table>
+                        <![endif]-->
 
-            <h1 style="color: white; font-size: 24px; margin: 0 0 10px 0;">안녕하세요!</h1>
-            <p style="margin: 0 0 20px 0; color: white; line-height: 1.5; font-size: 16px; ">인증 코드 보내드립니다.</p>
+                        <h1 class="welcome-text" style="color: white; font-size: 26px; margin: 20px 0; font-weight: 600; font-family: Arial, sans-serif;">안녕하세요!</h1>
 
-            <!-- 인증 코드 -->
-            <div class="auth-code" style="background-color: #F4F6F7; color: black; padding: 10px 20px; display: inline-block; border-radius: 4px; font-size: 20px; font-weight: bold;" th:text="${authenticationCode}">
-                [인증 코드]
-            </div>
+                        <p style="margin: 0 0 25px 0; color: #1A6D3E; line-height: 1.6; font-size: 16px; font-family: Arial, sans-serif;">
+                            아래의 인증 코드를 입력해주세요.
+                        </p>
 
+                        <div class="auth-code" style="background-color: white; color: #000000; padding: 15px 30px; display: inline-block; border-radius: 8px; font-size: 24px; font-weight: bold; margin: 10px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); letter-spacing: 0.5px; font-family: Arial, sans-serif; min-width: 180px; width: 180px; text-align: center;" th:text="${authenticationCode}">
+                            [인증 코드]
+                        </div>
+
+                        <p style="margin: 25px 0 0 0; color: #1D8348; font-size: 14px; font-family: Arial, sans-serif;">
+                            본 인증 코드는 5분간 유효합니다.
+                        </p>
+                    </td>
+                </tr>
+            </table>
         </td>
     </tr>
 </table>
-
+<!--[if mso]>
+</td></tr></table>
+<![endif]-->
 </body>
 </html>


### PR DESCRIPTION
## 📝 작업 내용
> 기존 템플릿에서는 인증번호에 따라 인증번호를 둘러싼 흰색 박스의 크기가 달라지고, 유효시간 안내가 없는 등이 부족하였습니다. 이를 개선하기 위해 타임리프 코드를 수정했습니다. HTML/CSS 영역이라 AI 사용하였습니다. 코드 리뷰는 안해주셔도 될 것 같습니다!


## 🔍 테스트 방법
> 기존 (좌-구글 / 우-네이버)
<p align="center">
  <img src="https://github.com/user-attachments/assets/aac2eb77-43ee-4b63-b423-05fcdff1c66c" width="45%">
  <img src="https://github.com/user-attachments/assets/34d38b95-1141-43f8-83cf-e658803328c1" width="45%">
</p>

> 변경 (웹)
<p align="center">
  <img src="https://github.com/user-attachments/assets/97233481-104a-49bc-8e2d-ed7f81ea16b8" width="45%">
  <img src="https://github.com/user-attachments/assets/17e036b9-ea61-48c7-aa87-9de0efe4f1bd" width="45%">
</p>

> 변경 (모바일)
<p align="center">
  <img src="https://github.com/user-attachments/assets/1cbb1174-1b8f-4cec-996f-605011e27b30" width="45%">
  <img src="https://github.com/user-attachments/assets/448733b5-af6a-4e1a-9ac2-0e3e2273419f" width="45%">
</p>
