### PR TITLE
[#219] Refactor: 챌린지 date 필드 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -94,11 +94,12 @@ public class ChallengeConverter {
     }
 
     // UserChallenge 생성
-    public static UserChallenge createUserChallenge(User user, Challenge challenge, UserChallengeType dtype) {
+    public static UserChallenge createUserChallenge(User user, Challenge challenge, UserChallengeType dtype, LocalDate date) {
         return UserChallenge.builder()
                 .user(user)
                 .challenge(challenge)
                 .dtype(dtype)
+                .date(date)
                 .completed(false)
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -6,6 +6,7 @@ import lombok.*;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -43,6 +44,9 @@ public class UserChallenge extends BaseEntity {
 
     @Column(name = "certification_date")
     private LocalDateTime certificationDate;
+
+    @Column(nullable = false)
+    private LocalDate date;
 
     // 인증 작성 (최초 등록 또는 전체 업데이트용)
     public void verifyUserChallenge(ChallengeRequestDTO.ProofRequestDTO proofRequest, String imageUrl){

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeCommandServiceImpl.java
@@ -14,6 +14,7 @@ import umc.GrowIT.Server.service.S3Service.S3Service;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
+import java.time.LocalDate;
 import java.util.*;
 
 @Service
@@ -42,7 +43,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         for (ChallengeRequestDTO.SelectChallengeRequestDTO selectRequest : selectRequestList) {
             List<Long> challengeIds = selectRequest.getChallengeIds();
             UserChallengeType dtype = selectRequest.getDtype();
-
+            LocalDate date = selectRequest.getDate();
 
             // 현재 dtype에 따라 저장 가능한 최대 개수 확인
             if (dtype == UserChallengeType.DAILY) {
@@ -69,7 +70,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
                                 .orElseThrow(() -> new ChallengeHandler(ErrorStatus.CHALLENGE_NOT_FOUND));
 
                         // UserChallenge 생성
-                        UserChallenge userChallenge = ChallengeConverter.createUserChallenge(user, challenge, dtype);
+                        UserChallenge userChallenge = ChallengeConverter.createUserChallenge(user, challenge, dtype, date);
                         return userChallengeRepository.save(userChallenge);
                     })
                     .toList();

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -1,10 +1,10 @@
 package umc.GrowIT.Server.web.dto.ChallengeDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class ChallengeRequestDTO {
@@ -27,5 +27,6 @@ public class ChallengeRequestDTO {
     public static class SelectChallengeRequestDTO {
         private List<Long> challengeIds;
         private UserChallengeType dtype;
+        private LocalDate date;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> bug로 하고 챌린지 홈 조회 부분 수정하려고 하였으나 dto 먼저 수정하여 pr 올립니다.
dto 변수명 createdAt로 하려다가 date로 설정하면서 UserChallenge에 date 필드 추가하게 되었습니다.
선택한 챌린지 저장 시 date값을 함께 넘겨줘야하며 챌린지 홈 조회 시 date 기준으로 조회할 예정입니다.
일기 삭제하면 관련 유저챌린지도 삭제하는 방식으로 변경되어 -> 일기 삭제 작업 끝나면 챌린지 홈 수정 작업 들어가겠습니다!

## 🔍 테스트 방법
> x