### PR TITLE
[#223] Feat: 일기 삭제 API에서 관련된 UserChallenger 삭제 기능 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -43,6 +43,15 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("userId") Long userId,
             @Param("dtype") UserChallengeType dtype);
 
+    //userId와 date로 UserChallenge 조회
+    @Query("SELECT uc FROM UserChallenge uc " +
+            "WHERE uc. user.id = :userId " +
+            "AND uc.date = :date ")
+    List<UserChallenge> findUserChallengesByDateAndUserId(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
 }
 
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -11,10 +11,7 @@ import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.*;
 import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.domain.*;
-import umc.GrowIT.Server.repository.ChallengeKeywordRepository;
-import umc.GrowIT.Server.repository.ChallengeRepository;
-import umc.GrowIT.Server.repository.KeywordRepository;
-import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.repository.*;
 import umc.GrowIT.Server.repository.diaryRepository.DiaryRepository;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -35,6 +32,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final ChallengeKeywordRepository challengeKeywordRepository;
     private final KeywordRepository keywordRepository;
     private final ChallengeRepository challengeRepository;
+    private final UserChallengeRepository userChallengeRepository;
     //일기 작성 시 추가되는 크레딧 개수
     private Integer diaryCredit = 2;
 
@@ -124,8 +122,17 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
+        LocalDate targetDate = diary.getDate();
 
+        //일기 삭제
         diaryRepository.delete(diary);
+
+        //UserChallenge 조회
+        List<UserChallenge> targetUserChallenge = userChallengeRepository.findUserChallengesByDateAndUserId(user.getId(), targetDate);
+
+        //UserChallenge 삭제
+        userChallengeRepository.deleteAll(targetUserChallenge);
+
 
         return DiaryConverter.toDeleteResultDTO(diary);
     }


### PR DESCRIPTION
## 📝 작업 내용
> - 일기 삭제 API에서 해당 일기를 작성하면서 선택한 UserChallenge도 같이 삭제되도록 구현하였습니다.
> 1. 삭제할 일기의 date를 사용해서 UserChallenge 리스트를 조회합니다.
> 2. 조회된 UserChallenge 들을 삭제합니다.


## 🔍 테스트 방법
> X