### PR TITLE
[#225] Refactor: 챌린지 홈 조회 api 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -29,15 +29,12 @@ public class ChallengeConverter {
 
     // 추천 챌린지 리스트를 반환
     public static List<ChallengeResponseDTO.RecommendedChallengeDTO> toRecommendedChallengeListDTO(
-            List<UserChallenge> userChallenges, List<Long> todayDiaryKeywordChallengeIds) {
+            List<UserChallenge> userChallenges) {
 
         LocalDate today = LocalDate.now();
 
         return userChallenges.stream()
-                .filter(userChallenge ->
-                        userChallenge.getCreatedAt().toLocalDate().isEqual(today) && // 오늘 저장된 챌린지만 필터링
-                                todayDiaryKeywordChallengeIds.contains(userChallenge.getChallenge().getId()) // 오늘 작성한 일기 분석으로 추천된 챌린지만 포함
-                )
+                .filter(userChallenge -> userChallenge.getDate().isEqual(today))
                 .map(ChallengeConverter::toRecommendedChallengeDTO)
                 .collect(Collectors.toList());
     }
@@ -56,14 +53,13 @@ public class ChallengeConverter {
 
     // 전체 챌린지 홈 데이터를 ChallengeHomeDTO로 변환
     public static ChallengeResponseDTO.ChallengeHomeDTO toChallengeHomeDTO(List<UserChallenge> userChallenges,
-                                                                        List<Long> todayDiaryKeywordChallengeIds, // 오늘 작성한 일기의 키워드 기반 추천 챌린지
                                                                         int totalCredits,
                                                                         int totalDiaries,
                                                                         String diaryGoal, List<String> keywords) {
 
         return ChallengeResponseDTO.ChallengeHomeDTO.builder()
                 .challengeKeywords(keywords) // 변환된 DTO 적용
-                .recommendedChallenges(toRecommendedChallengeListDTO(userChallenges, todayDiaryKeywordChallengeIds))
+                .recommendedChallenges(toRecommendedChallengeListDTO(userChallenges))
                 .challengeReport(toChallengeReportDTO(totalCredits, totalDiaries, diaryGoal))
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
+++ b/src/main/java/umc/GrowIT/Server/domain/UserChallenge.java
@@ -45,7 +45,7 @@ public class UserChallenge extends BaseEntity {
     @Column(name = "certification_date")
     private LocalDateTime certificationDate;
 
-    @Column(nullable = false)
+    @Column(name = "date")
     private LocalDate date;
 
     // 인증 작성 (최초 등록 또는 전체 업데이트용)

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -20,7 +20,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     // 오늘 날짜 기준으로 저장된 챌린지만 필터링
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND DATE(uc.createdAt) = :today")
+            "AND uc.date = :today")
     List<UserChallenge> findTodayUserChallengesByUserId(
             @Param("userId") Long userId,
             @Param("today") LocalDate today);

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -86,14 +86,8 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
                 ? userChallengeRepository.findTodayUserChallengesByUserId(userId, today)
                 : Collections.emptyList();
 
-        // 오늘 작성한 일기의 키워드 기반 추천 챌린지 ID 목록 조회
-        List<Long> todayDiaryKeywordChallengeIds = todayDiary.isPresent()
-                ? challengeKeywordRepository.findChallengeIdsByTodayDiaryKeywords(userId, today)
-                : Collections.emptyList();
-
         return ChallengeConverter.toChallengeHomeDTO(
                 savedChallenges,
-                todayDiaryKeywordChallengeIds,
                 getTotalCredits(userId),
                 getTotalDiaries(userId),
                 getDiaryDate(userId),


### PR DESCRIPTION
## 📝 작업 내용
> 수정 내용
- 챌린지 홈에는 오늘 date로 작성한 일기 분석으로 저장한 챌린지들만 조회됨.
- 챌린지 현황 조회 시 사용자의 모든 유저챌린지 조회(날짜 상관없이) -> 프론트분께 여쭤보는 중입니다

UserChallenge 엔티티에서
```java
    @Column(nullable = false)
    private LocalDate date;
``` 
로 선언하였더니 전에 있던 유저챌린지 데이터의 date 필드가 0000-00-00 이런식으로 초기화돼서 챌린지 현황 조회 시 서버 에러가 뜨더라고요.. 그래서 nullable = false 삭제하고 이전 데이터 date 필드값 모두 <null>로 수정하였습니다! 유저챌린지 DB 초기화되면 그때는 nullable = false로 수정해도 될 것 같아요
## 🔍 테스트 방법
> x