### PR TITLE
[#233] Feat: 챌린지 현황 페이징 기법 적용

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.converter;
 
+import org.springframework.data.domain.Page;
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.Keyword;
 import umc.GrowIT.Server.domain.User;
@@ -75,6 +76,18 @@ public class ChallengeConverter {
                 .build();
     }
 
+    public static ChallengeResponseDTO.ChallengeStatusPagedResponseDTO toChallengeStatusPagedDTO(Page<UserChallenge> userChallenges) {
+        Page<ChallengeResponseDTO.ChallengeStatusDTO> mappedPage = userChallenges.map(ChallengeConverter::toChallengeStatusDTO);
+
+        return ChallengeResponseDTO.ChallengeStatusPagedResponseDTO.builder()
+                .content(mappedPage.getContent())
+                .currentPage(mappedPage.getNumber() + 1)
+                .totalPages(mappedPage.getTotalPages())
+                .totalElements(mappedPage.getTotalElements())
+                .isFirst(mappedPage.isFirst())
+                .isLast(mappedPage.isLast())
+                .build();
+    }
 
     // 챌린지 인증 작성 결과 반환
     public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -65,17 +65,16 @@ public class ChallengeConverter {
     }
 
     // 챌린지 현황
-    public static List<ChallengeResponseDTO.ChallengeStatusDTO> toChallengeStatusListDTO(List<UserChallenge> userChallenges) {
-        return userChallenges.stream()
-                .map(userChallenge -> ChallengeResponseDTO.ChallengeStatusDTO.builder()
-                        .id(userChallenge.getId())
-                        .title(userChallenge.getChallenge().getTitle())
-                        .dtype(userChallenge.getDtype())
-                        .time(userChallenge.getChallenge().getTime())
-                        .completed(userChallenge.isCompleted())
-                        .build())
-                .collect(Collectors.toList());
+    public static ChallengeResponseDTO.ChallengeStatusDTO toChallengeStatusDTO(UserChallenge userChallenge) {
+        return ChallengeResponseDTO.ChallengeStatusDTO.builder()
+                .id(userChallenge.getId())
+                .title(userChallenge.getChallenge().getTitle())
+                .dtype(userChallenge.getDtype())
+                .time(userChallenge.getChallenge().getTime())
+                .completed(userChallenge.isCompleted())
+                .build();
     }
+
 
     // 챌린지 인증 작성 결과 반환
     public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(Challenge challenge, UserChallenge userChallenge) {

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -1,5 +1,7 @@
 package umc.GrowIT.Server.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -30,18 +32,20 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.completed = :completed")
-    List<UserChallenge> findChallengesByCompletionStatus(
+    Page<UserChallenge> findChallengesByCompletionStatus(
             @Param("userId") Long userId,
-            @Param("completed") Boolean completed);
+            @Param("completed") Boolean completed,
+            Pageable pageable);
 
     // 2. 특정 dtype에 대해 미완료 챌린지 조회 (completed가 true인 챌린지는 제외)
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.dtype = :dtype " +
             "AND uc.completed = false")  // 항상 미완료 챌린지만 조회
-    List<UserChallenge> findChallengesByDtypeAndCompletionStatus(
+    Page<UserChallenge> findChallengesByDtypeAndCompletionStatus(
             @Param("userId") Long userId,
-            @Param("dtype") UserChallengeType dtype);
+            @Param("dtype") UserChallengeType dtype,
+            Pageable pageable);
 
     //userId와 date로 UserChallenge 조회
     @Query("SELECT uc FROM UserChallenge uc " +

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.service.ChallengeService;
 
+import org.springframework.data.domain.Page;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
@@ -8,6 +9,6 @@ public interface ChallengeQueryService {
     int getTotalDiaries(Long userId);
     String getDiaryDate(Long userId);
     ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId);
-    ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed);
+    Page<ChallengeResponseDTO.ChallengeStatusDTO> getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page);
     ChallengeResponseDTO.ProofDetailsDTO getChallengeProofDetails(Long userId, Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryService.java
@@ -9,6 +9,6 @@ public interface ChallengeQueryService {
     int getTotalDiaries(Long userId);
     String getDiaryDate(Long userId);
     ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId);
-    Page<ChallengeResponseDTO.ChallengeStatusDTO> getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page);
+    ChallengeResponseDTO.ChallengeStatusPagedResponseDTO getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page);
     ChallengeResponseDTO.ProofDetailsDTO getChallengeProofDetails(Long userId, Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -99,7 +99,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
 
 
     @Override
-    public Page<ChallengeResponseDTO.ChallengeStatusDTO> getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page) {
+    public ChallengeResponseDTO.ChallengeStatusPagedResponseDTO getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page) {
         Page<UserChallenge> userChallenges;
 
         // dtype이 null이면 전체 챌린지 중 완료/미완료만 조회
@@ -115,7 +115,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
             userChallenges = Page.empty();
         }
 
-        return userChallenges.map(ChallengeConverter::toChallengeStatusDTO);
+        return ChallengeConverter.toChallengeStatusPagedDTO(userChallenges);
     }
 
     // 챌린지 인증 내역 조회

--- a/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/ChallengeService/ChallengeQueryServiceImpl.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
@@ -97,27 +99,23 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
 
 
     @Override
-    public ChallengeResponseDTO.ChallengeStatusListDTO getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed) {
-        List<UserChallenge> userChallenges;
+    public Page<ChallengeResponseDTO.ChallengeStatusDTO> getChallengeStatus(Long userId, UserChallengeType dtype, Boolean completed, Integer page) {
+        Page<UserChallenge> userChallenges;
 
         // dtype이 null이면 전체 챌린지 중 완료/미완료만 조회
         if (dtype == null) {
-            userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, completed);
+            userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, completed, PageRequest.of(page-1, 5));
         }
         // dtype이 RANDOM 또는 DAILY인 경우 미완료 챌린지만 조회 (completed = false 고정)
         else if (!completed) {
-            userChallenges = userChallengeRepository.findChallengesByDtypeAndCompletionStatus(userId, dtype);
+            userChallenges = userChallengeRepository.findChallengesByDtypeAndCompletionStatus(userId, dtype, PageRequest.of(page-1, 5));
         }
-        // dtype이 RANDOM 또는 DAILY인데 completed가 true이면 빈 리스트 반환 (잘못된 요청 방지)
+        // 잘못된 요청 방지
         else {
-            userChallenges = Collections.emptyList();
+            userChallenges = Page.empty();
         }
 
-        List<ChallengeResponseDTO.ChallengeStatusDTO> challenges = ChallengeConverter.toChallengeStatusListDTO(userChallenges);
-
-        return ChallengeResponseDTO.ChallengeStatusListDTO.builder()
-                .userChallenges(challenges)
-                .build();
+        return userChallenges.map(ChallengeConverter::toChallengeStatusDTO);
     }
 
     // 챌린지 인증 내역 조회

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -37,14 +37,14 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @GetMapping("/")
-    public ApiResponse<Page<ChallengeResponseDTO.ChallengeStatusDTO>> getChallengeStatus(
+    public ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
             @RequestParam(required = false) UserChallengeType dtype,
             @RequestParam Boolean completed,
             @RequestParam Integer page) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
         // 서비스 호출
-        Page<ChallengeResponseDTO.ChallengeStatusDTO> challengeStatusList = challengeQueryService.getChallengeStatus(userId, dtype, completed, page);
+        ChallengeResponseDTO.ChallengeStatusPagedResponseDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, dtype, completed, page);
 
         // 성공 응답 반환
         return ApiResponse.onSuccess(challengeStatusList);

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.web.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -36,13 +37,14 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @GetMapping("/")
-    public ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
+    public ApiResponse<Page<ChallengeResponseDTO.ChallengeStatusDTO>> getChallengeStatus(
             @RequestParam(required = false) UserChallengeType dtype,
-            @RequestParam Boolean completed) {
+            @RequestParam Boolean completed,
+            @RequestParam Integer page) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
         // 서비스 호출
-        ChallengeResponseDTO.ChallengeStatusListDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, dtype, completed);
+        Page<ChallengeResponseDTO.ChallengeStatusDTO> challengeStatusList = challengeQueryService.getChallengeStatus(userId, dtype, completed, page);
 
         // 성공 응답 반환
         return ApiResponse.onSuccess(challengeStatusList);

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
@@ -33,9 +34,10 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ChallengeStatusListDTO> getChallengeStatus(
+    ApiResponse<Page<ChallengeResponseDTO.ChallengeStatusDTO>> getChallengeStatus(
             @RequestParam(required = false) UserChallengeType dtype,
-            @RequestParam(required = false) Boolean completed);
+            @RequestParam(required = false) Boolean completed,
+            @RequestParam Integer page);
 
     @PostMapping("{challengeId}/select")
     @Operation(summary = "선택된 챌린지 저장 API", description = "사용자가 선택한 챌린지를 저장하는 API입니다. <br> " +

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -34,7 +34,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Page<ChallengeResponseDTO.ChallengeStatusDTO>> getChallengeStatus(
+    ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
             @RequestParam(required = false) UserChallengeType dtype,
             @RequestParam(required = false) Boolean completed,
             @RequestParam Integer page);

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -79,6 +79,20 @@ public class ChallengeResponseDTO {
         private boolean completed;
     }
 
+    // 페이징 적용
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChallengeStatusPagedResponseDTO  {
+        private List<ChallengeStatusDTO> content;
+        private int currentPage;
+        private int totalPages;
+        private long totalElements;
+        private boolean isFirst;
+        private boolean isLast;
+    }
+
     // 챌린지 인증 내역
     @Getter
     @Builder

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -71,14 +71,6 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ChallengeStatusListDTO {
-        private List<ChallengeResponseDTO.ChallengeStatusDTO> userChallenges;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class ChallengeStatusDTO {
         private Long id;
         private String title;


### PR DESCRIPTION
## 📝 작업 내용
> 챌린지 현황 조회 시 페이지값 입력하면 특정 페이지에서 최대 5개까지 챌린지 조회 가능
[기존] 페이징 기법을 적용하면 아래처럼 응답 결과가 길게 나옴
`json "pageable": {
            "pageNumber": 1,
            "pageSize": 15,
            "sort": {
                "empty": true,
                "sorted": false,
                "unsorted": true
            },
            "offset": 15,
            "unpaged": false,
            "paged": true
        },
        "last": true,
        "totalElements": 0,
        "totalPages": 0,
        "size": 15,
        "number": 1,
        "sort": {
            "empty": true,
            "sorted": false,
            "unsorted": true
        },
        "first": false,
        "numberOfElements": 0,
        "empty": true,`
[변경] 응답 결과가 짧게 나오게 나오도록 dto 수정
`json     "currentPage": 1,
    "totalPages": 1,
    "totalElements": 1,
    "first": true,
    "last": true`

currentPage: 현재페이지
totalElements: 전체 개수(ex. 완료한 챌린지를 조회했을때 완료한 챌린지가 1개라면 totalElements는 1, 미완료한 랜덤챌린지를 조회했을때 미완료한 랜덤챌린지가 3개라면 totalElements는 3)
first: 첫번째 페이지인지
last: 마지막 페이지인지

dto에서 `private List<ChallengeStatusDTO> content;` 에는 조회한 유저챌린지 내용이 담겨있습니다.
로컬db에 챌린지 관련 데이터가 없어서 테스트를 제대로 하지 못했는데 오류 있으면 말씀해주세요!

## 🔍 테스트 방법
> 1. 조회한 챌린지 데이터가 1개일때 (ex. 완료한 챌린지가 1개)
![image](https://github.com/user-attachments/assets/c73d25af-c8c4-4c1c-9fe2-fd9c9a6e11f7)
![image](https://github.com/user-attachments/assets/eddecb7e-a1b9-4806-bd25-cf7599172aae)
> 2. 조회한 챌린지 데이터가 5개보다 많을때 (ex. 미완료한 데일리챌린지가 6개)
![image](https://github.com/user-attachments/assets/4aa8c79f-cdf8-4fd3-b8dd-1e447b85714c)
첫번째 페이지에는 챌린지 5개가 조회되고, 두번째 페이지(마지막 페이지)에는 남은 챌린지 1개가 조회됨.
![image](https://github.com/user-attachments/assets/40940f64-9618-4581-a03e-25f5abc29e56)


