### PR TITLE
[#229] Refactor: 일기 분석하기 API 로직 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/FlaskConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/FlaskConverter.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.converter;
+
+import umc.GrowIT.Server.web.dto.FlaskDTO.FlaskRequestDTO;
+
+import java.util.List;
+
+public class FlaskConverter {
+    // 챌린지 추천
+    public static FlaskRequestDTO.EmotionAnalysisRequestDTO toEmotionAnalysisRequestDTO(List<String> inputEmotions) {
+        return FlaskRequestDTO.EmotionAnalysisRequestDTO.builder()
+                .emotions(inputEmotions)  // 빌더로 emotions 필드를 설정
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/FlaskDTO/FlaskRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/FlaskDTO/FlaskRequestDTO.java
@@ -1,0 +1,20 @@
+package umc.GrowIT.Server.web.dto.FlaskDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class FlaskRequestDTO {
+
+    // Flask 요청 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmotionAnalysisRequestDTO {
+        private List<String> emotions;
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/FlaskDTO/FlaskResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/FlaskDTO/FlaskResponseDTO.java
@@ -1,0 +1,30 @@
+package umc.GrowIT.Server.web.dto.FlaskDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class FlaskResponseDTO {
+
+    // Flask 응답 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmotionAnalysisResponseDTO {
+        private List<SimilarityResultDTO> analyzedEmotions;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SimilarityResultDTO {
+        private String inputEmotion;
+        private String similarEmotion;
+        private Double similarityScore;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> #229
> 자세한 내용은 상단의 이슈 참고 부탁드립니다!
> 
> 수정된 일기 분석 API (SpringBoot)
> 1. 일기 내용을 OpenAI에게 전달하여 감정을 분석 (DB와 무관)
> 2. OpenAI의 결과를 그대로 Flask에 전달 (DB와 비교 X)
> 3. Flask의 결과인 문자열(감정)로 DB 조회하여 이후 작업 수행

## 🔍 테스트 방법
> 1. 데이터 세팅
> 감정과 챌린지 등 기본 데이터가 필요합니다.
> [노션 -> Back 개발 문서 -> DB 초기 데이터셋] 에 데모데이 때 사용한 데이터 sql문 있습니다.
> 2. 사용자 & 일기 데이터 각각 저장 필요
> 3. 로컬에서 Flask 서버까지 실행
> 4. 일기 분석 API Swagger에서 실행
> 5. 결과
> ![image](https://github.com/user-attachments/assets/2323df3d-6d2c-437a-880e-13af9ea5d7fc)
> ![image](https://github.com/user-attachments/assets/d5cd4f71-e376-4456-9b4d-9a78ab5cc499)