### PR TITLE
[#237] Refactor : 일기 AI 대화 개선

### DIFF
--- a/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
@@ -10,8 +10,8 @@ public class OpenAiConfig {
     @Value("${openai.api.key}")
     private String openAiKey;
 
-    @Value("${openai.api.key-100}")
-    private String openAiKey100;
+    @Value("${openai.api.key-sub}")
+    private String subOpenAiKey;
 
     @Bean
     public RestTemplate template(){
@@ -27,10 +27,10 @@ public class OpenAiConfig {
      * 일기-감정키워드 추출하는 모델 API 호출 템플릿
      */
     @Bean
-    public RestTemplate keywordModelTemplate(){
+    public RestTemplate subTemplate(){
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getInterceptors().add((request, body, execution) -> {
-            request.getHeaders().add("Authorization", "Bearer " + openAiKey100);
+            request.getHeaders().add("Authorization", "Bearer " + subOpenAiKey);
             return execution.execute(request, body);
         });
         return restTemplate;

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -152,15 +152,31 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         //처음 대화라면 시스템 프롬프트 추가
         if(messages.isEmpty()){
-            messages.add(new Message("system", "너는 사용자와 대화하며 일기를 작성하는 챗봇이야." +
-                    " role: user인 경우 사용자의 말이고, role: assistant인 경우 너가 사용자의 말에 대답하는 말이야." +
-                    " 사용자와의 대화 내용을 기억하고 사용자의 마지막말에 대해 상황에 맞게 대답해줘." +
-                    " 그리고 사용자의 말에 공감하며 가끔씩 감정을 이끌어내는 질문을 해야해." +
-                    " 반드시 존댓말을 사용하고 맞춤법은 제대로 맞춰줘."));
+            messages.add(new Message("system",
+                    "당신은 사용자의 하루 이야기를 공감으로 받아주는 AI입니다.\n\n" +
+                            "다음 규칙을 반드시 따르세요:\n" +
+                            "1. 절대 질문하지 마세요. 물음표(?)를 포함한 문장도 금지입니다.\n" +
+                            "2. '~했나요?', '~무엇인가요?', '~어떠셨나요?' 같은 의문형 표현도 사용하지 마세요.\n" +
+                            "3. 감정이나 생각을 유도하는 문장도 금지입니다. 예: '어떤 기분이셨나요?', '무슨 생각이 드셨나요?'\n" +
+                            "4. 공감과 긍정적인 피드백만 해주세요. 사용자에게 아무것도 묻지 마세요.\n" +
+                            "5. 대화를 이어가려 하지 말고, 사용자의 메시지에 대해 짧고 따뜻한 반응만 하세요.\n" +
+                            "6. 당신은 경청하는 역할이며, 대화 흐름을 주도하지 않습니다.\n" +
+                            "사용자 메시지에는 항상 'cnt' 값이 포함되어 있습니다. 반드시 cnt == 3 일 때만, 규칙이 적용되지 않습니다."
+            ));
+
         }
 
+        long userTurn = messages.stream()
+                .filter(m -> m.getRole().equals("user"))
+                .count() % 3;  // 지금까지 몇 번 user가 말했는지 셈
+
+        String numberedUserChat = "cnt == " + (userTurn + 1) + "\n\n" +
+                                  "사용자 메세지 : " + userChat;
+
+        log.info(numberedUserChat);
+
         // 사용자의 입력을 대화 목록에 추가
-        messages.add(new Message("user", userChat));
+        messages.add(new Message("user", numberedUserChat));
 
         // ChatGPT 요청 생성
         ChatGPTRequest gptRequest = new ChatGPTRequest(chatModel, messages);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -52,7 +52,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private RestTemplate template;
 
     @Autowired
-    private RestTemplate keywordModelTemplate;
+    private RestTemplate subTemplate;
 
     //userId-대화내용 저장용 HashMap
     private final Map<Long, List<Message>> conversationHistory = new HashMap<>();
@@ -151,7 +151,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         List<Message> messages = conversationHistory.get(userId);
 
         //처음 대화라면 시스템 프롬프트 추가
-        if(messages.isEmpty()){
+        if (messages.isEmpty()){
             messages.add(new Message("system",
                     "당신은 사용자의 하루 이야기를 공감으로 받아주는 AI입니다.\n\n" +
                             "다음 규칙을 반드시 따르세요:\n" +
@@ -163,7 +163,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
                             "6. 당신은 경청하는 역할이며, 대화 흐름을 주도하지 않습니다.\n" +
                             "사용자 메시지에는 항상 'cnt' 값이 포함되어 있습니다. 반드시 cnt == 3 일 때만, 규칙이 적용되지 않습니다."
             ));
-
         }
 
         long userTurn = messages.stream()
@@ -335,7 +334,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         ChatGPTRequest gptRequest = new ChatGPTRequest(keywordModel, prompt, temperature);
 
         // API 요청 및 응답 처리
-        ChatGPTResponse chatGPTResponse = keywordModelTemplate.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
+        ChatGPTResponse chatGPTResponse = subTemplate.postForObject(apiURL, gptRequest, ChatGPTResponse.class);
         if (chatGPTResponse == null || chatGPTResponse.getChoices().isEmpty()) {
             throw new OpenAIHandler(ErrorStatus.GPT_RESPONSE_EMPTY);
         }


### PR DESCRIPTION
## 📝 작업 내용

### 1. 문제점
기존 AI 대화에서 질문이 너무 많다는 피드백이 있어 **질문보다는 공감 위주의 응답을 하도록** 조정했습니다.

### 2. 개선 사항
시스템 프롬프트
- 질문을 하지 않도록 명시했습니다.
- 단 cnt == 3일 때만 질문 1개를 허용하는 조건 추가

사용자 프롬프트
- 매 요청마다 cnt 값을 포함하여, AI가 질문 여부를 판단할 수 있도록 수정

### 3. 한계점
프롬프트만으로 제어한 방식이라, 확률 기반으로 응답을 생성하는 GPT 특성상 예외적으로 질문이 발생할 수 있습니다.
GPT가 if-else 처럼 동작하지 않기 때문입니다.
(이전 감정 키워드 추출 문제와 같은 문제가 발생합니다. 🥹 하지만 예외가 발생해도 시스템에 큰 영향을 주지 않는다는 차이점이 있습니다.)

## 🔍 테스트 방법
> 1. <테스트 방법을 상세히 적어주세요 (스크린샷 첨부 가능)>