### PR TITLE
Feat/#245 로그아웃 api 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthService.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthService.java
@@ -4,9 +4,12 @@ import jakarta.validation.Valid;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+import umc.GrowIT.Server.web.dto.LogoutDTO.LogoutResponseDTO;
 
 public interface AuthService {
     AuthResponseDTO.SendAuthEmailResponseDTO sendAuthEmail(AuthType type, AuthRequestDTO.SendAuthEmailRequestDTO request);
 
     AuthResponseDTO.VerifyAuthCodeResponseDTO verifyAuthCode(AuthRequestDTO.VerifyAuthCodeRequestDTO request);
+
+    LogoutResponseDTO logout(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/authService/AuthServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
@@ -15,11 +16,13 @@ import umc.GrowIT.Server.apiPayload.exception.AuthHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
 import umc.GrowIT.Server.converter.AuthenticationCodeConverter;
 import umc.GrowIT.Server.domain.AuthenticationCode;
+import umc.GrowIT.Server.domain.RefreshToken;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.domain.enums.CodeStatus;
 import umc.GrowIT.Server.repository.AuthenticationCodeRepository;
 import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.service.refreshTokenService.RefreshTokenCommandService;
 import umc.GrowIT.Server.service.userService.UserCommandService;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
@@ -28,6 +31,7 @@ import java.time.LocalDateTime;
 
 
 import org.springframework.beans.factory.annotation.Value;
+import umc.GrowIT.Server.web.dto.LogoutDTO.LogoutResponseDTO;
 
 import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 
@@ -40,6 +44,7 @@ public class AuthServiceImpl implements AuthService {
     private final JavaMailSender javaMailSender;
     private final TemplateEngine templateEngine;
     private final AuthenticationCodeRepository authenticationCodeRepository;
+    private final RefreshTokenCommandService refreshTokenCommandService;
 
     @Value("${spring.mail.username}")
     private String fromEmail;
@@ -149,4 +154,35 @@ public class AuthServiceImpl implements AuthService {
         AuthenticationCode newAuthenticationCode = AuthenticationCodeConverter.toAuthenticationCode(email, authenticationCode);
         return authenticationCodeRepository.save(newAuthenticationCode);
     }
+
+    @Override
+    @Transactional
+    public LogoutResponseDTO logout(Long userId){
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 이미 탈퇴한 회원인지 확인
+        userCommandService.checkUserInactive(user);
+
+        // 3. RefreshToken이 있는 경우에만 삭제 처리
+        if (user.getRefreshToken() != null) {
+            // RefreshToken DB에서 삭제
+            RefreshToken refreshToken = user.getRefreshToken();
+            user.deleteRefreshToken(); // User 엔티티의 refreshToken 필드를 null로 설정
+            userRepository.save(user);
+
+            // RefreshToken 엔티티 삭제
+            refreshTokenCommandService.deleteRefreshToken(refreshToken);
+        }
+
+        // 4. 성공 응답 반환 (이미 로그아웃된 상태여도 성공으로 처리)
+        return LogoutResponseDTO.builder()
+                .message("로그아웃이 완료되었습니다.")
+                .build();
+
+
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandService.java
@@ -13,5 +13,5 @@ public interface RefreshTokenCommandService {
 
     TokenResponseDTO.AccessTokenDTO reissueToken(TokenRequestDTO.ReissueDTO reissueDTO);
 
-
+    void deleteRefreshToken(RefreshToken refreshToken);
 }

--- a/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/refreshTokenService/RefreshTokenCommandServiceImpl.java
@@ -66,4 +66,9 @@ public class RefreshTokenCommandServiceImpl implements RefreshTokenCommandServic
 
     }
 
+    @Override
+    @Transactional
+    public void deleteRefreshToken(RefreshToken refreshToken) {
+        refreshTokenRepository.delete(refreshToken);
+    }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.AuthType;
@@ -15,6 +17,7 @@ import umc.GrowIT.Server.service.refreshTokenService.RefreshTokenCommandService;
 import umc.GrowIT.Server.web.controller.specification.AuthSpecification;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+import umc.GrowIT.Server.web.dto.LogoutDTO.LogoutResponseDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthRequestDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
 import umc.GrowIT.Server.web.dto.TokenDTO.TokenRequestDTO;
@@ -92,4 +95,17 @@ public class AuthController implements AuthSpecification {
         TokenResponseDTO.TokenDTO tokenDTO = oAuthService.signupSocial(oAuthUserInfoAndUserTermsDTO);
         return ApiResponse.onSuccess(tokenDTO);
     }
+    @Override
+    @PostMapping("/logout")
+    public ApiResponse<LogoutResponseDTO> logout() {
+        // AccessToken에서 userId 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        // 로그아웃 처리
+        LogoutResponseDTO result = authService.logout(userId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -11,6 +11,7 @@ import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
+import umc.GrowIT.Server.web.dto.LogoutDTO.LogoutResponseDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthRequestDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
 import umc.GrowIT.Server.web.dto.TokenDTO.TokenRequestDTO;
@@ -100,4 +101,16 @@ public interface AuthSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM4003", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<TokenResponseDTO.TokenDTO> signupSocial(@RequestBody @Valid OAuthRequestDTO.OAuthUserInfoAndUserTermsDTO oAuthUserInfoAndUserTermsDTO);
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 처리하는 API입니다. AccessToken을 무효화하고 RefreshToken을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4011", description = "❌ 유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4012", description = "❌ 만료된 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4015", description = "❌ 토큰이 제공되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<LogoutResponseDTO> logout();
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/LogoutDTO/LogoutRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/LogoutDTO/LogoutRequestDTO.java
@@ -1,0 +1,4 @@
+package umc.GrowIT.Server.web.dto.LogoutDTO;
+
+public class LogoutRequestDTO {
+}

--- a/src/main/java/umc/GrowIT/Server/web/dto/LogoutDTO/LogoutResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/LogoutDTO/LogoutResponseDTO.java
@@ -1,0 +1,14 @@
+package umc.GrowIT.Server.web.dto.LogoutDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LogoutResponseDTO {
+    private String message; // "로그아웃이 완료되었습니다."
+}


### PR DESCRIPTION
## 📝 작업 내용
> <작업한 내용을 간략히 설명해주세요 (스크린샷 첨부 가능)>


## 🔍 테스트 방법
> 
### 1. 로그인 api 호출 - refreshToken 생성
```json
{
  "email": "ccc@example.com",
  "password": "password123"
}
```

- 로그인 성공 응답
```JSON
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjY2NAZXhhbXBsZS5jb20iLCJyb2xlcyI6IlVTRVIiLCJ1c2VySWQiOjUsImV4cCI6MTc1NTA2MzYzOH0.3987OFCxblwWBzPGryyOOt3RTo61OaG5WvWxIqhMOus",
    "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE3NjAyNDQwMzh9.mOw0W29TS1J_ayEGzAJxVY5jHAkJuBxsPymvHmhc_VM"
  }
}
```
- db에서 refreshToken 생성 확인
<img width="1225" height="263" alt="image" src="https://github.com/user-attachments/assets/3c77782b-c7eb-41fd-b3a4-bdedbdf3c2e0" />


### 2. Swagger Authorize에 `accessToken`입력
<img width="1000" height="800" alt="image" src="https://github.com/user-attachments/assets/c8d87dbc-c68f-426a-a381-a9e0fa0d0ed2" />

- 아이템 조회 api 호출 성
<img width="1000" height="800" alt="image" src="https://github.com/user-attachments/assets/aed82dad-9523-4eca-a141-df0cfdc27423" />


### 3. 로그아웃 API 호출
<img width="1520" height="1644" alt="image" src="https://github.com/user-attachments/assets/630ef87d-056d-4adb-a9d3-79624ccfe193" />


- db에서 refresh_token 삭제 확인
<img width="1576" height="766" alt="image" src="https://github.com/user-attachments/assets/5fb30390-0dda-411d-89ce-fa1934404073" />






##‼️ 현재 로그아웃 후에 refreshToken은 삭제되지만 accessToken으로 계속 api호출 가능한 문제 존재

✅ ios에서 호출한다면 문제 x
RefreshToken 정상 삭제됨 → 토큰 재발급 불가능
실제 클라이언트에서는 로그아웃 시 토큰 삭제하여 API 호출 불가
Swagger에서만 수동으로 입력한 토큰이 남아있어 테스트 가능한 상황

🔧 추후 개선 방향
AccessToken BlackList 구현 (Redis 활용)
토큰 만료시간 단축 (1시간 → 15분)
토큰 탈취 시나리오 대비 보안 강화
