### PR TITLE
[#249] Feat: 서브모듈 & Docker 도입

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
 
       # 2. JDK 17 설정 (Gradle 캐시 포함)
       - name: Set up JDK 17

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -31,8 +31,10 @@ jobs:
         run: chmod +x gradlew
 
       # 4. prod 프로필로 JAR 빌드
-      - name: Build JAR with prod profile
-        run: ./gradlew clean bootJar -Dspring.profiles.active=prod
+      - name: Build JAR with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: clean bootJar -x test --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
 
       # 5. 아티팩트 업로드
       - name: Upload build artifact
@@ -95,7 +97,7 @@ jobs:
           
           # 애플리케이션 실행
           ssh ec2 "
-            nohup java -jar -Xmx1024m ~/GrowItServer.jar > app.log 2>&1 &
+            nohup java -Dspring.profiles.active=prod -jar -Xmx1024m ~/GrowItServer.jar > app.log 2>&1 &
           
             # 실행 확인
             sleep 30

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # 2. JDK 17 설정 (Gradle 캐시 포함)
       - name: Set up JDK 17
@@ -24,25 +25,15 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
-      # 3. Gradle 캐시 최적화
-      - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
-
-      # 4. gradlew 실행 권한 부여
+      # 3. gradlew 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # 5. 테스트 실행
-      - name: Run tests
-        run: ./gradlew clean test --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
-
-      # 6. prod 프로필로 JAR 빌드
+      # 4. prod 프로필로 JAR 빌드
       - name: Build JAR with prod profile
-        run: ./gradlew bootJar -Dspring.profiles.active=prod --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
+        run: ./gradlew build -x test -Dspring.profiles.active=prod --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
 
-      # 7. 아티팩트 업로드
+      # 5. 아티팩트 업로드
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # 1. 코드 + 서브모듈 체크아웃
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: 'recursive'
 
+      # 2. JDK 17 설정 (Gradle 캐시 포함)
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -21,20 +24,25 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
-      - name: Make application.yml
-        run: |
-          mkdir -p ./src/main/resources
-          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
-        shell: bash
+      # 3. Gradle 캐시 최적화
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' }}
 
+      # 4. gradlew 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build -x test --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
+      # 5. 테스트 실행
+      - name: Run tests
+        run: ./gradlew clean test --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
 
+      # 6. prod 프로필로 JAR 빌드
+      - name: Build JAR with prod profile
+        run: ./gradlew bootJar -Dspring.profiles.active=prod --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
+
+      # 7. 아티팩트 업로드
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -11,7 +11,8 @@ jobs:
 
     steps:
       # 1. 코드 + 서브모듈 체크아웃
-      - uses: actions/checkout@v3
+      - name: Checkout With Submodules
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -19,7 +20,7 @@ jobs:
 
       # 2. JDK 17 설정 (Gradle 캐시 포함)
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -31,7 +32,7 @@ jobs:
 
       # 4. prod 프로필로 JAR 빌드
       - name: Build JAR with prod profile
-        run: ./gradlew build -x test -Dspring.profiles.active=prod --parallel --build-cache --no-daemon -Dorg.gradle.jvmargs="-Xmx2048m"
+        run: ./gradlew clean bootJar -Dspring.profiles.active=prod
 
       # 5. 아티팩트 업로드
       - name: Upload build artifact

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "config"]
+	path = config
+	url = https://github.com/7-umc-GrowIT/config.git

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,14 @@ dependencies {
 	implementation 'io.prometheus:prometheus-metrics-core:1.2.1'
 }
 
+task copyPrivateYml(type: Copy) {
+	copy {
+		from './config'
+		include "*.yml"
+		into 'src/main/resources'
+	}
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+name: growit
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: growit_mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root1234!
+      MYSQL_DATABASE: GrowIT
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:
+
+networks:
+  growit_network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 name: growit
 
 services:


### PR DESCRIPTION
## 📝 작업 내용
### yml 파일 관리를 위한 서브모듈 도입
개발&배포 환경의 DB 세팅이 다르며, 변경사항이 있을때마다 Notion을 변경하고 서로에게 알려주어야 하기 때문에
이를 개선하기 위해 서브모듈 도입했습니다. 서브모듈에서는 `dev(로컬 개발)` & `prod(배포)`용 yml을 각각 관리합니다.
이를 유의하시고, 특정 환경에만 필요한 설정인지/공통으로 필요한 설정인지를 구분하여 각각의 yml에 작성해주시면 됩니다.
<br>

### 서브모듈 도입으로 인한 DB 환경 통일을 위해 Docker 도입
서브모듈을 도입하였는데, 각자의 로컬 `MySQL` 세팅이 다르다보니 서브모듈을 도입했음에도 이를 매번 수정하여야 하는 번거로움이 존재합니다. 이를 위해 `Docker`를 도입하였습니다.
`Docker`는 높은 이식성이 특징이기 때문에 매번 수동으로 다운하고 설정해야하는 번거로움을 덜어줍니다.
처음 사용하신다면 간단하게 로컬에 `컨테이너`라는 별도의 환경을 구축하고 그곳에 `MySQL`을 실행시켜서 사용한다 라고 이해하시면 될 거 같습니다. 설치...는 어렵지는 않은데, 되도록 빠르게 Notion 페이지에 블로그 첨부하겠습니다. 😅
<br>

### 서브모듈 도입으로 인한 CI/CD 수정
기존에는 Github Secrets의 yml을 끌어다가 CI/CD의 빌드 과정에서 사용하는 구조였고,
서브모듈을 도입하게 되며 서브모듈의 yml을 사용하도록 CI/CD를 수정하였습니다.
<br>

서브모듈과 Docker와 관련한 자세한 내용은 Notion 확인 부탁드립니다!

## 🔍 테스트 방법
변경한 CI/CD 성공하는 거까지 확인하였습니다.
<img width="1058" height="469" alt="스크린샷 2025-08-16 오전 2 39 13" src="https://github.com/user-attachments/assets/b66bcd06-9a10-48a3-a48b-ab068f056ff7" />
https://github.com/7-umc-GrowIT/GrowIT-SpringBoot/actions/runs/16994665124