### PR TITLE
[Feat/#261] 마이페이지 조회 api 구현

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.converter;
 
+import umc.GrowIT.Server.domain.Gro;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthApiResponseDTO;
@@ -56,6 +57,13 @@ public class UserConverter {
 
         return AuthResponseDTO.LogoutResponseDTO.builder()
                 .message("로그아웃이 완료되었습니다.")
+                .build();
+    }
+
+    public static UserResponseDTO.MyPageDTO toMyPageDTO(User user, Gro gro){
+        return UserResponseDTO.MyPageDTO.builder()
+                .userId(user.getId())
+                .name(gro.getName())
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/UserConverter.java
@@ -60,10 +60,10 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.MyPageDTO toMyPageDTO(User user, Gro gro){
+    public static UserResponseDTO.MyPageDTO toMyPageDTO(User user){
         return UserResponseDTO.MyPageDTO.builder()
                 .userId(user.getId())
-                .name(gro.getName())
+                .name(user.getGro().getName())
                 .build();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/domain/Gro.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Gro.java
@@ -26,7 +26,7 @@ public class Gro extends BaseEntity {
     @ColumnDefault("1")
     private Integer level;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -55,6 +55,10 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Role role;
 
+    // 사용자의 그로
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private Gro gro;
+
 //    // 사용자 구독여부
 //    @Column(name = "is_subscribed", nullable = false)
 //    private Boolean isSubscribed = false;

--- a/src/main/java/umc/GrowIT/Server/domain/User.java
+++ b/src/main/java/umc/GrowIT/Server/domain/User.java
@@ -55,6 +55,10 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Role role;
 
+//    // 사용자 구독여부
+//    @Column(name = "is_subscribed", nullable = false)
+//    private Boolean isSubscribed = false;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserChallenge> userChallenges = new ArrayList<>();
 
@@ -70,10 +74,6 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "refresh_token_id", nullable = false)
     private RefreshToken refreshToken;
-
-//    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private RefreshToken refreshToken;
-
 
     public void encodePassword(String password) {
         this.password = password;

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
@@ -1,9 +1,5 @@
 package umc.GrowIT.Server.service.userService;
 
-import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
-
 public interface UserQueryService {
     boolean isUserInactive(Long userId);
-
-    UserResponseDTO.MyPageDTO getMyPage(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryService.java
@@ -1,5 +1,9 @@
 package umc.GrowIT.Server.service.userService;
 
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
+
 public interface UserQueryService {
     boolean isUserInactive(Long userId);
+
+    UserResponseDTO.MyPageDTO getMyPage(Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.converter.UserConverter;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 
@@ -20,5 +22,13 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return user.getStatus() == INACTIVE;
+    }
+
+    @Override
+    public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return UserConverter.toMyPageDTO(user);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
@@ -34,9 +34,6 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Gro gro = groRepository.findByUserId(userId)
-                .orElseThrow(() -> new GroHandler(ErrorStatus.GRO_NOT_FOUND));
-
-        return UserConverter.toMyPageDTO(user, gro);
+        return UserConverter.toMyPageDTO(user);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
@@ -3,14 +3,9 @@ package umc.GrowIT.Server.service.userService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
-import umc.GrowIT.Server.apiPayload.exception.GroHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
-import umc.GrowIT.Server.converter.UserConverter;
-import umc.GrowIT.Server.domain.Gro;
 import umc.GrowIT.Server.domain.User;
-import umc.GrowIT.Server.repository.GroRepository;
 import umc.GrowIT.Server.repository.UserRepository;
-import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 
@@ -19,21 +14,11 @@ import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
-    private final GroRepository groRepository;
 
-    @Override
     public boolean isUserInactive(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return user.getStatus() == INACTIVE;
-    }
-
-    @Override
-    public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-
-        return UserConverter.toMyPageDTO(user);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/userService/UserQueryServiceImpl.java
@@ -3,9 +3,14 @@ package umc.GrowIT.Server.service.userService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
+import umc.GrowIT.Server.apiPayload.exception.GroHandler;
 import umc.GrowIT.Server.apiPayload.exception.UserHandler;
+import umc.GrowIT.Server.converter.UserConverter;
+import umc.GrowIT.Server.domain.Gro;
 import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.repository.GroRepository;
 import umc.GrowIT.Server.repository.UserRepository;
+import umc.GrowIT.Server.web.dto.UserDTO.UserResponseDTO;
 
 import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 
@@ -14,11 +19,24 @@ import static umc.GrowIT.Server.domain.enums.UserStatus.INACTIVE;
 public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
+    private final GroRepository groRepository;
 
+    @Override
     public boolean isUserInactive(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return user.getStatus() == INACTIVE;
+    }
+
+    @Override
+    public UserResponseDTO.MyPageDTO getMyPage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Gro gro = groRepository.findByUserId(userId)
+                .orElseThrow(() -> new GroHandler(ErrorStatus.GRO_NOT_FOUND));
+
+        return UserConverter.toMyPageDTO(user, gro);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -11,6 +11,7 @@ import umc.GrowIT.Server.domain.enums.ItemCategory;
 import umc.GrowIT.Server.service.creditService.CreditQueryServiceImpl;
 import umc.GrowIT.Server.service.itemService.ItemQueryServiceImpl;
 import umc.GrowIT.Server.service.userService.UserCommandService;
+import umc.GrowIT.Server.service.userService.UserQueryService;
 import umc.GrowIT.Server.web.controller.specification.UserSpecification;
 import umc.GrowIT.Server.web.dto.CreditDTO.CreditResponseDTO;
 import umc.GrowIT.Server.web.dto.ItemDTO.ItemResponseDTO;
@@ -27,6 +28,7 @@ public class UserController implements UserSpecification {
 
     private final CreditQueryServiceImpl creditQueryService;
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
     private final ItemQueryServiceImpl itemQueryServiceImpl;
 
     @Override
@@ -75,5 +77,15 @@ public class UserController implements UserSpecification {
 
         UserResponseDTO.DeleteUserResponseDTO deleteUser = userCommandService.delete(userId);
         return ApiResponse.onSuccess(deleteUser);
+    }
+
+    @Override
+    @GetMapping("")
+    public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = (Long) authentication.getPrincipal();
+
+        UserResponseDTO.MyPageDTO result = userQueryService.getMyPage(userId);
+        return ApiResponse.onSuccess(result);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
@@ -28,7 +28,7 @@ public interface GroSpecification {
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "GRO4002",
+                    responseCode = "COMMON400",
                     description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.",
                     content = @Content(schema = @Schema(implementation = ApiResponse.class))
             ),
@@ -58,8 +58,7 @@ public interface GroSpecification {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4001", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4002", description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> updateNickname(@Valid @RequestBody GroRequestDTO.NicknameRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -77,4 +77,14 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
+
+    @GetMapping("")
+    @Operation(summary = "마이페이지 조회 API", description = "마이페이지에서 사용자의 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<UserResponseDTO.MyPageDTO> getMyPage();
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -77,14 +77,4 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<UserResponseDTO.DeleteUserResponseDTO> deleteUser();
-
-    @GetMapping("")
-    @Operation(summary = "마이페이지 조회 API", description = "마이페이지에서 사용자의 정보를 조회합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    ApiResponse<UserResponseDTO.MyPageDTO> getMyPage();
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.dto.UserDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 public class UserResponseDTO {
@@ -13,5 +14,17 @@ public class UserResponseDTO {
         // TODO 디테일하게 결정 필요
         private String name;
         private String message; // ex) 회원 탈퇴가 완료되었습니다
+    }
+
+    // 마이페이지 조회 DTO
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyPageDTO {
+        @Schema(description = "유저 ID", example="1")
+        private Long userId;
+        @Schema(description = "그로의 닉네임", example = "그로우")
+        private String name;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/UserDTO/UserResponseDTO.java
@@ -1,6 +1,5 @@
 package umc.GrowIT.Server.web.dto.UserDTO;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 public class UserResponseDTO {
@@ -14,17 +13,5 @@ public class UserResponseDTO {
         // TODO 디테일하게 결정 필요
         private String name;
         private String message; // ex) 회원 탈퇴가 완료되었습니다
-    }
-
-    // 마이페이지 조회 DTO
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class MyPageDTO {
-        @Schema(description = "유저 ID", example="1")
-        private Long userId;
-        @Schema(description = "그로의 닉네임", example = "그로우")
-        private String name;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
마이페이지 조회 api 구현하였습니다.

<img width="342" height="322" alt="image" src="https://github.com/user-attachments/assets/e9fd340c-babf-48e8-9c44-dbe64d7f93c7" />

해당 화면에서는 사용자의 그로의 닉네임과 구독여부를 조회하고, 구독여부에 따라 "구독 중" 라벨이 처리됩니다.
그러나 1차 출시에서 결제/구독 기능은 포함하지 않는다고 하여 User 엔티티에 isSubscribed 필드만 추가하고 주석 처리 해놨습니다.
-> 결제/구독 기능 구현되면 해당 필드까지 조회하여 반환할 예정입니다

그리고 엔티티에서는 사용자와 그로가 일대다 매핑으로 되어있는데 그로 생성 로직에서 그로 중복 처리를 진행하고 있는것으로 보아 일대일 매핑 같아서 수정하였습니다 관련 부분은 한번 확인해주세요!

```java
    // Gro.java
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "user_id", nullable = false)
    private User user;
``` 

## 🔍 테스트 방법
- 스웨거에서 마이페이지 조회 시 userId, 그로의 닉네임 반환
<img width="347" height="205" alt="image" src="https://github.com/user-attachments/assets/a39ec96a-7b6f-4868-adfd-3d3c10852b15" />

- 인증을 하지 않은 경우
<img width="428" height="167" alt="image" src="https://github.com/user-attachments/assets/3bb4e835-15ad-47eb-8095-c8da3cc04d72" />
