### PR TITLE
[#270] Bug : OAuth client 및 Security 설정 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() //인증 없이 접근 가능
                         .requestMatchers("/actuator/**").permitAll() //인증 없이 접근 가능
                         .requestMatchers("/auth/**", "/users/password", "/terms").permitAll() //인증 없이 접근 가능
+                        .requestMatchers("/apple/oauth/login").permitAll() // 테스트용
                         .anyRequest().authenticated() //나머지 요청은 인증 필요
                 );
 


### PR DESCRIPTION
## 📝 작업 내용
애플 로그인 OAuth 인증 테스트를 위한 설정입니다

Apple OAuth client 설정 값 오류로 수정했으며
웹에서 Apple 로그인 테스트를 위해 authorization code를 받기 위한 Redirect uri에 해당하는 경로가 인증이 필요해서 해당 경로 인증 제외했습니다


## 🔍 테스트 방법
> 1. <테스트 방법을 상세히 적어주세요 (스크린샷 첨부 가능)>