### PR TITLE
[#274] Refactor: 일기 api 스키마 적용 및 서비스 로직 개선

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -26,6 +26,9 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final ChallengeRepository challengeRepository;
     private final S3Util s3Util;
 
+    //챌린지 인증 작성 시 추가되는 크레딧 개수
+    private static final int CHALLENGE_CREDIT = 1;
+
     @Override
     @Transactional
     public void selectChallenges(Long userId, List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList) {
@@ -112,9 +115,8 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         userChallenge.verifyUserChallenge(proofRequest);
 
-        Integer challengeCredit = 1;
-        user.updateCurrentCredit(user.getCurrentCredit() + challengeCredit);
-        user.updateTotalCredit(user.getTotalCredit() + challengeCredit);
+        user.updateCurrentCredit(user.getCurrentCredit() + CHALLENGE_CREDIT);
+        user.updateTotalCredit(user.getTotalCredit() + CHALLENGE_CREDIT);
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -25,7 +25,6 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final UserChallengeRepository userChallengeRepository;
     private final ChallengeRepository challengeRepository;
     private final S3Util s3Util;
-    private Integer challengeCredit = 1;
 
     @Override
     @Transactional
@@ -113,6 +112,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         userChallenge.verifyUserChallenge(proofRequest);
 
+        Integer challengeCredit = 1;
         user.updateCurrentCredit(user.getCurrentCredit() + challengeCredit);
         user.updateTotalCredit(user.getTotalCredit() + challengeCredit);
     }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -1,20 +1,19 @@
 package umc.GrowIT.Server.service.diaryService;
 
-import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryCommandService {
 
-    public DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId);
+    DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId);
 
-    public DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId);
+    DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId);
 
-    public DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId);
+    DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId);
 
-    public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
+    DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 
-    public DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId);
+    DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId);
 
     DiaryResponseDTO.AnalyzedDiaryResponseDTO analyze(Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -39,7 +39,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final UserChallengeRepository userChallengeRepository;
 
     //일기 작성 시 추가되는 크레딧 개수
-    private final Integer diaryCredit = 2;
+    private static final int DIARY_CREDIT = 2;
 
     @Value("${openai.model1}")
     private String chatModel;
@@ -100,8 +100,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         diary = diaryRepository.save(diary);
 
         //사용자의 크레딧수 증가
-        user.updateCurrentCredit(user.getCurrentCredit() + diaryCredit);
-        user.updateTotalCredit(user.getTotalCredit() + diaryCredit);
+        user.updateCurrentCredit(user.getCurrentCredit() + DIARY_CREDIT);
+        user.updateTotalCredit(user.getTotalCredit() + DIARY_CREDIT);
 
         return DiaryConverter.toCreateResultDTO(diary);
     }
@@ -253,8 +253,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         diary = diaryRepository.save(diary);
 
         //사용자의 크레딧 수 증가
-        user.updateCurrentCredit(user.getCurrentCredit() + diaryCredit);
-        user.updateTotalCredit(user.getTotalCredit() + diaryCredit);
+        user.updateCurrentCredit(user.getCurrentCredit() + DIARY_CREDIT);
+        user.updateTotalCredit(user.getTotalCredit() + DIARY_CREDIT);
 
         // 대화 기록 삭제
         conversationHistory.remove(userId);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -85,11 +85,6 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         //유저 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        //일기 내용이 100자 이상인지 검사
-        if(request.getContent().length()<100){
-            throw new DiaryHandler(ErrorStatus.DIARY_CHARACTER_LIMIT);
-        }
-
         //날짜 검사(오늘 이후의 날짜 x)
         if (request.getDate().isAfter(LocalDate.now())) {
             throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     public DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId) {
 
         //유저 조회
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
@@ -144,7 +144,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId) {
 
         //유저 조회
-        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         String userChat = request.getChat();
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -87,7 +87,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 일기 날짜 검사
-        validateDiaryDate(userId, request.getDate());
+        checkDiaryDate(userId, request.getDate());
 
         //일기 생성
         Diary diary = Diary.builder()
@@ -191,8 +191,9 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
 
         // 유저 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
         // 일기 날짜 검사
-        validateDiaryDate(userId, request.getDate());
+        checkDiaryDate(userId, request.getDate());
 
         // 기존 대화 목록 가져오기
 //        List<Message> messages = conversationHistory.get(userId);
@@ -261,7 +262,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         return DiaryConverter.toSummaryResultDTO(diary);
     }
 
-    private void validateDiaryDate(Long userId, LocalDate date) {
+    private void checkDiaryDate(Long userId, LocalDate date) {
         // 오늘 이후의 날짜를 선택한 경우
         if (date.isAfter(LocalDate.now())) {
             throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
@@ -3,9 +3,9 @@ package umc.GrowIT.Server.service.diaryService;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryQueryService {
-    public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId);
+    DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId);
 
-    public DiaryResponseDTO.DiaryListDTO getDiaryList(Integer year, Integer month, Long userId);
+    DiaryResponseDTO.DiaryListDTO getDiaryList(Integer year, Integer month, Long userId);
 
-    public DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId);
+    DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 public class DiaryQueryServiceImpl implements DiaryQueryService{
 
     private final DiaryRepository diaryRepository;
+
     @Override
     public DiaryResponseDTO.DiaryDateListDTO getDiaryDate(Integer year, Integer month, Long userId) {
         // Diary 리스트를 year와 month를 기준으로 필터링
@@ -38,9 +39,9 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     }
 
     @Override
+    @Transactional(readOnly = true)
     public DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId){
         Optional<Diary> diary = diaryRepository.findByUserIdAndId(userId, diaryId);
-
 
         return diary.map(DiaryConverter::toDiaryDTO)
                 .orElseThrow(() -> new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -39,7 +39,6 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     }
 
     @Override
-    @Transactional(readOnly = true)
     public DiaryResponseDTO.DiaryDTO getDiary(Long diaryId, Long userId){
         Optional<Diary> diary = diaryRepository.findByUserIdAndId(userId, diaryId);
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.web.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -50,7 +51,7 @@ public class DiaryController implements DiarySpecification {
     }
 
     @PatchMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
@@ -67,7 +68,7 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
     }
     @PostMapping("/text")
-    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.CreateDiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -82,9 +82,8 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4003", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Void> createChallengeProof(
-            @Parameter(description = "사용자 챌린지 아이디",
-            example = "1")@PathVariable Long userChallengeId,
+    @Parameter(name = "userChallengeId", description = "인증 작성할 사용자 챌린지의 ID", example = "1")
+    ApiResponse<Void> createChallengeProof(@PathVariable Long userChallengeId,
             @Valid @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest);
 
     @GetMapping("{userChallengeId}")
@@ -95,9 +94,8 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4004", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(
-            @Parameter(description = "사용자 챌린지 아이디",
-            example = "1")@PathVariable Long userChallengeId);
+    @Parameter(name = "userChallengeId", description = "인증 내역을 조회할 사용자 챌린지의 ID", example = "1")
+    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long userChallengeId);
 
 
     @PatchMapping("{userChallengeId}")
@@ -110,10 +108,8 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4004", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4005", description = "❌ 챌린지 인증 내역에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-
-    ApiResponse<Void> updateChallengeProof(
-            @Parameter(description = "사용자 챌린지 ID",
-            example = "1") @PathVariable Long userChallengeId,
+    @Parameter(name = "userChallengeId", description = "인증 내역을 수정할 사용자 챌린지의 ID", example = "1")
+    ApiResponse<Void> updateChallengeProof(@PathVariable Long userChallengeId,
             @Valid @RequestBody(required = false) ChallengeRequestDTO.ProofRequestDTO updateRequest);
 
     @DeleteMapping("{userChallengeId}")
@@ -131,6 +127,6 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
 
     })
-    @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", required = true)
+    @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", example = "1")
     ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -7,19 +7,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
-import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiarySpecification {
     @GetMapping("/dates")
     @Operation(summary = "일기 작성 날짜 조회 API",description = "특정 사용자의 일기 메인 화면에서 사용할 월별 일기 기록한 날짜를 보여주기 위한 API입니다. Query String으로 year와 month를 주세요." +
-            "ex)2024년 12월을 넘겨주면 해당 월에 기록한 일기들의 날짜 정보와 해당 일기의 id를 보내줍니다.")
+            "ex)2025년 9월을 넘겨주면 해당 월에 기록한 일기들의 날짜 정보와 해당 일기의 id를 보내줍니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(
+            @Parameter(description = "일기 작성 연도",
+                    example = "2025")@RequestParam Integer year,
+            @Parameter(description = "일기 작성 월",
+                    example = "9")@RequestParam Integer month);
 
     @GetMapping("/")
     @Operation(summary = "일기 모아보기 API",description = "특정 사용자가 작성한 일기를 모아보는 API입니다. query string으로 year와 month를 넘겨주면 해당 월에 작성한 일기들의 리스트, 작성한 일기 수를 보내줍니다.")
@@ -27,7 +30,11 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year, @RequestParam Integer month);
+    ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(
+            @Parameter(description = "일기 작성 연도",
+                    example = "2025")@RequestParam Integer year,
+            @Parameter(description = "일기 작성 월",
+                    example = "9")@RequestParam Integer month);
 
     @GetMapping("/{diaryId}")
     @Operation(summary = "특정 일기 조회 API",description = "특정 사용자가 작성한 특정 일기를 조회하는 API입니다. path variable로 일기의 id를 넘겨주면 해당 일기의 세부적인 내용을 보내줍니다.")
@@ -35,6 +42,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
+    @Parameter(name = "diaryId", description = "조회할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId);
 
     @PatchMapping("/{diaryId}")
@@ -44,8 +52,8 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004",description = "기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId,
-                                                                          @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
+    @Parameter(name = "diaryId", description = "수정할 일기의 ID", example = "1")
+    ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")
@@ -53,6 +61,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
+    @Parameter(name = "diaryId", description = "삭제할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
@@ -96,8 +105,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-
     })
-    @Parameter(name = "diaryId", description = "분석할 일기의 ID", required = true)
-    ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary (@PathVariable("diaryId") Long diaryId);
+    @Parameter(name = "diaryId", description = "분석할 일기의 ID", example = "1")
+    ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary(@PathVariable("diaryId") Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
@@ -49,11 +50,12 @@ public interface DiarySpecification {
     @Operation(summary = "일기 수정하기 API",description = "특정 사용자가 작성한 일기를 수정하는 API입니다. path variable로 일기의 id, RequestBody로 수정한 내용과 수정 시간을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004",description = "기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "수정할 일기의 ID", example = "1")
-    ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")
@@ -68,10 +70,10 @@ public interface DiarySpecification {
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002",description = "100자 이내로 작성된 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4002",description = "날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@RequestBody DiaryRequestDTO.CreateDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
     @PostMapping("/voice")
     @Operation(summary = "음성 대화하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용(STT)을 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -20,7 +20,7 @@ public class ChallengeResponseDTO {
     public static class ChallengeHomeDTO {
         @Schema(description = "챌린지 키워드(리스트)", example = "즐거운, 차분한, 새로운")
         private List<String> challengeKeywords;
-        @Schema(description = "오늘의 추천 챌린지(리스트)", example = "좋아하는 책 독서하기")
+        @Schema(description = "오늘의 추천 챌린지(리스트)")
         private List<RecommendedChallengeDTO> recommendedChallenges;
         @Schema(description = "챌린지 리포트")
         private ChallengeReportDTO challengeReport;

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -64,7 +64,7 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "챌린지 조회 response")
+    @Schema(title = "챌린지 리스트 조회 response")
     public static class ChallengeStatusDTO {
         @Schema(description = "챌린지 id", example = "1")
         private Long id;
@@ -127,26 +127,33 @@ public class ChallengeResponseDTO {
         private LocalDateTime certificationDate;
     }
 
-    // 챌린지 삭제 응답 DTO
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "챌린지 삭제 response")
     public static class DeleteChallengeResponseDTO {
-        // TODO 디테일하게 결정 필요
+        @Schema(description = "사용자 챌린지 id", example = "1")
         private Long id;
-        private String message; // ex) 챌린지 삭제가 완료되었습니다
+        @Schema(description = "챌린지 삭제 성공 메시지", example = "챌린지를 삭제했어요.")
+        private String message;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "챌린지 추천 response")
     public static class ChallengeDTO {
-        private Long id; // 챌린지 ID
-        private String title; //챌린지 제목
-        private String content; //챌린지 내용
-        private Integer time; //챌린지 소요시간
-        private UserChallengeType challengeType; //추천 타입 (Daily or Random)
+        @Schema(description = "추천 챌린지 id", example = "1")
+        private Long id;
+        @Schema(description = "추천 챌린지 제목", example = "좋아하는 책 독서하기")
+        private String title;
+        @Schema(description = "추천 챌린지 내용", example = "좋아하는 책을 골라서 한 번 읽어 보세요!")
+        private String content;
+        @Schema(description = "챌린지 소요 시간", example = "1")
+        private Integer time;
+        @Schema(description = "챌린지 추천 타입(DAILY or RANDOM)", example = "DAILY")
+        private UserChallengeType challengeType;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.web.dto.DiaryDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -15,6 +16,7 @@ public class DiaryRequestDTO {
     public static class CreateDiaryDTO {
         @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         @NotNull
+        @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
         String content;
         @Schema(description = "일기 작성 날짜")
         @NotNull
@@ -29,6 +31,7 @@ public class DiaryRequestDTO {
     public static class ModifyDiaryDTO {
         @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         @NotNull
+        @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
         String content;
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -1,38 +1,55 @@
 package umc.GrowIT.Server.web.dto.DiaryDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
 public class DiaryRequestDTO {
     @Getter
-    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "일기 작성 request")
     public static class CreateDiaryDTO {
+        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         @NotNull
-        String content; //작성 내용
+        String content;
+        @Schema(description = "일기 작성 날짜")
         @NotNull
-        LocalDate date; //작성 날짜
+        LocalDate date;
     }
 
     @Getter
-    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "일기 수정 request")
     public static class ModifyDiaryDTO {
+        @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         @NotNull
-        String content; //수정 내용
+        String content;
     }
 
     @Getter
-    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "음성 대화 request")
     public static class VoiceChatDTO {
+        @Schema(description = "사용자의 음성내용", example = "오늘 정말 힘든 하루였어.")
         @NotNull
-        String chat; //사용자의 음성내용
+        String chat;
     }
 
     @Getter
-    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "일기 요약 request")
     public static class SummaryDTO {
+        @Schema(description = "일기 작성 날짜")
         @NotNull
         LocalDate date;
     }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -1,10 +1,10 @@
 package umc.GrowIT.Server.web.dto.DiaryDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
@@ -16,42 +16,59 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "작성된 일기 조회 response")
     public static class DiaryDateDTO{
+        @Schema(description = "일기 id", example = "1")
         Long diaryId;
-        LocalDate date;    //일기 최종 수정 날짜
+        @Schema(description = "일기 최종 수정 날짜")
+        LocalDate date;
     }
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 작성 날짜 조회 response")
     public static class DiaryDateListDTO{
-        List<DiaryDateDTO> diaryDateList;  //일기 작성 날짜들의 리스트
+        @Schema(description = "일기 작성 날짜들의 리스트")
+        List<DiaryDateDTO> diaryDateList;
+        @Schema(description = "리스트 사이즈")
         Integer listSize;
     }
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "작성된 일기 내용 조회 response")
     public static class DiaryDTO{
+        @Schema(description = "일기 id", example = "1")
         Long diaryId;
+        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         String content;
-        LocalDate date;    //일기 최종 수정 날짜
+        @Schema(description = "일기 최종 수정 날짜")
+        LocalDate date;
     }
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 모아보기 response")
     public static class DiaryListDTO {
+        @Schema(description = "일기 리스트")
         List<DiaryDTO> diaryList;
+        @Schema(description = "리스트 사이즈")
         Integer listSize;
     }
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 작성 response")
     public static class CreateDiaryResultDTO {
+        @Schema(description = "일기 id", example = "1")
         Long diaryId;
+        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         String content;
+        @Schema(description = "일기 작성 날짜")
         LocalDate date;
     }
 
@@ -59,8 +76,11 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 수정 response")
     public static class ModifyDiaryResultDTO {
+        @Schema(description = "일기 id", example = "1")
         Long diaryId;
+        @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         String content;
     }
 
@@ -68,7 +88,9 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 삭제 response")
     public static class DeleteDiaryResultDTO {
+        @Schema(description = "일기 삭제 성공 메시지", example = "일기를 삭제했어요.")
         String message;
     }
 
@@ -76,27 +98,35 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "음성 대화 response")
     public static class VoiceChatResultDTO {
-        String chat;    //AI의 답변내용
+        @Schema(description = "AI의 답변 내용", example = "힘든 하루셨군요. 어떤 일이 있으셨나요?")
+        String chat;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "일기 요약 response")
     public static class SummaryResultDTO {
+        @Schema(description = "일기 id", example = "1")
         Long diaryId;
+        @Schema(description = "일기 요약 내용", example = "오늘은 평소보다 더 차분한 하루를 보냈다. 아침에 일어나 창밖을 보니..")
         String content;
+        @Schema(description = "일기 작성 날짜")
         LocalDate date;
     }
 
-    // 챌린지 추천 응답 DTO
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "챌린지 추천 response")
     public static class AnalyzedDiaryResponseDTO {
-        private List<KeywordResponseDTO.KeywordDTO> emotionKeywords; //감정키워드
-        private List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges; //추천챌린지
+        @Schema(description = "감정키워드")
+        private List<KeywordResponseDTO.KeywordDTO> emotionKeywords;
+        @Schema(description = "추천챌린지")
+        private List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -31,7 +31,7 @@ public class DiaryResponseDTO {
     public static class DiaryDateListDTO{
         @Schema(description = "일기 작성 날짜들의 리스트")
         List<DiaryDateDTO> diaryDateList;
-        @Schema(description = "리스트 사이즈")
+        @Schema(description = "리스트 사이즈", example = "1")
         Integer listSize;
     }
     @Builder
@@ -55,7 +55,7 @@ public class DiaryResponseDTO {
     public static class DiaryListDTO {
         @Schema(description = "일기 리스트")
         List<DiaryDTO> diaryList;
-        @Schema(description = "리스트 사이즈")
+        @Schema(description = "리스트 사이즈", example = "1")
         Integer listSize;
     }
     @Builder

--- a/src/main/java/umc/GrowIT/Server/web/dto/KeywordDTO/KeywordResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/KeywordDTO/KeywordResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.dto.KeywordDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,9 @@ public class KeywordResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class KeywordDTO {
-        private Long id; // id
-        private String keyword; // 감정
+        @Schema(description = "감정 키워드 id", example = "1")
+        private Long id;
+        @Schema(description = "감정 키워드 내용", example = "행복한")
+        private String keyword;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

1. 기존 코드에서 선언은 되지만 사용되지 않는 자잘한 코드들 삭제하였습니다.
ex1) `User user = userRepository.findById`~ 에서 user 변수가 해당 메소드 내에서 사용되지 않는 부분
ex2) 인터페이스 파일에서 `public` 코드는 불필요하다고 생각하여 해당 부분 삭제

2. 일기 글자 수 제한은 서비스에서 조건문으로 처리하는 대신 @Valid로 처리하였습니다. (Size와 message 옵션 사용)

3. 중복 코드는 메소드 분리하여 관리하였습니다.
(1) `createDiary` 와 `createDiaryByVoice` 에서 일기 날짜 유효성 검사를 동일하게 진행하고 있어 duplicate 발생
-> `checkDiaryDate `메소드로 따로 분리하여 일기 날짜 유효성 검사를 진행하는 식으로 수정하였습니다.
```java
    private void checkDiaryDate(Long userId, LocalDate date) {
        // 오늘 이후의 날짜를 선택한 경우
        if (date.isAfter(LocalDate.now())) {
            throw new DiaryHandler(ErrorStatus.DATE_IS_AFTER);
        }
        // 이미 해당 날짜에 작성된 일기가 존재하는 경우
        if (diaryRepository.existsByUserIdAndDate(userId, date)) {
            throw new DiaryHandler(ErrorStatus.DIARY_ALREADY_EXISTS);
        }
    }
``` 
(2) `chatByVoice`와 `createDiaryByVoice`에서 gpt 요청을 생성하고 응답 처리하는 로직을 동일하게 처리하고 있어 duplicate 발생
-> requestGptChat 메소드로 따로 분리하여 관리하도록 수정하였습니다.
🚨 gpt 요청 생성, 응답 처리 부분은 정상적으로 테스트되는지 확인이 필요하여 기존의 코드는 주석처리해놨습니다.
```java
    private String requestGptChat(String model, List<Message> messages) {
        // ChatGPT 요청 생성
        ChatGPTRequest gptRequest = new ChatGPTRequest(model, messages);

        // API 요청 및 응답 처리
        ChatGPTResponse res = template.postForObject(apiURL, gptRequest, ChatGPTResponse.class);

        if (res.getChoices() == null || res.getChoices().isEmpty() || res.getChoices().get(0) == null || res.getChoices().get(0).getMessage() == null) {
            throw new OpenAIHandler(ErrorStatus.GPT_RESPONSE_EMPTY);
        }

        return res.getChoices().get(0).getMessage().getContent();
    }
``` 

4. `openAIAnalyzeDiary`의 아래의 코드에서 redundant가 발생하여 `return computeSimilarity(emotionsList);` 으로 수정하였습니다. (`computeSimilarity`에서 리스트 형태로 처리되고 있기 때문에 문제 없을거라고 판단)
```java
        // 유사도 분석을 통해 DB의 감정으로 변환
        List<Keyword> emotionKeywords = computeSimilarity(emotionsList);

        return emotionKeywords;
``` 

5. 그 외 일기 dto와 일기 명세서에 Schema와 Parameter 적용하였고, 
일기 api 응답 관련해서는 프론트에서 응답값을 활용하고 있기 때문에 기존 응답 그대로 유지하기로 하였습니다.

+1) 서비스 로직에서 @Autowired 관련하여 Field injection is not recommended 경고 문구가 뜨는데 추후에 따로 해결하는게 좋을 것 같습니다.
```java
    @Autowired
    private RestTemplate template;

    @Autowired
    private RestTemplate subTemplate;
``` 
+2 ) createDiaryByVoice 에서 주석 처리한 부분(더미데이터 등)은 추후에 사용되는 코드인가요 ?_?

+3) 프롬포트 관련 코드는 나중에 파일 분리하는게 좋을 것 같다는 생각..

+4) 트랜잭션, 더티체킹 관련해서는 100% 확인하고 수정하지는 x

+5) 그 외.. ChallengeService 파일에서는 `createChallengeProof` 에서만 `challengeCredit`(크레딧 변수)가 사용되고 있어 메소드 내에서 선언 후 처리하는 식으로 수정..
DiaryService 조건문에서 항상 false로 처리되던 부분 삭제..(`chatGptResponse == null` 등) -> 테스트했는데 문제 있으면 말씀해주세요ㅠ


## 🔍 테스트 방법
> 1. <테스트 방법을 상세히 적어주세요 (스크린샷 첨부 가능)>