### PR TITLE
[#276] Refactor: 챌린지 현황 조회 시 페이징 기법 적용

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -1,6 +1,6 @@
 package umc.GrowIT.Server.converter;
 
-import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Page;
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserChallenge;
@@ -67,14 +67,16 @@ public class ChallengeConverter {
                 .build();
     }
 
-    public static ChallengeResponseDTO.ChallengeStatusPagedResponseDTO toChallengeStatusPagedDTO(Slice<UserChallenge> userChallenges) {
-        Slice<ChallengeResponseDTO.ChallengeStatusDTO> mappedSlice = userChallenges.map(ChallengeConverter::toChallengeStatusDTO);
+    public static ChallengeResponseDTO.ChallengeStatusPagedResponseDTO toChallengeStatusPagedDTO(Page<UserChallenge> userChallenges) {
+        Page<ChallengeResponseDTO.ChallengeStatusDTO> mappedPage = userChallenges.map(ChallengeConverter::toChallengeStatusDTO);
 
         return ChallengeResponseDTO.ChallengeStatusPagedResponseDTO.builder()
-                .content(mappedSlice.getContent())
-                .currentPage(mappedSlice.getNumber() + 1)
-                .isFirst(mappedSlice.isFirst())
-                .isLast(!mappedSlice.hasNext())
+                .content(mappedPage.getContent())
+                .currentPage(mappedPage.getNumber() + 1)
+                .totalPages(mappedPage.getTotalPages())
+                .totalElements(mappedPage.getTotalElements())
+                .isFirst(mappedPage.isFirst())
+                .isLast(mappedPage.isLast())
                 .build();
     }
 

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -88,7 +88,7 @@ public class ChallengeConverter {
                 .build();
     }
 
-    // 챌린지 인증 작성 결과 반환
+    // 챌린지 인증 내역 조회
     public static ChallengeResponseDTO.ProofDetailsDTO toProofDetailsDTO(UserChallenge userChallenge, String certificationImageUrl) {
         return ChallengeResponseDTO.ProofDetailsDTO.builder()
                 .id(userChallenge.getId())

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -1,7 +1,7 @@
 package umc.GrowIT.Server.repository;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,7 +29,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.completed = :completed")
-    Slice<UserChallenge> findChallengesByCompletionStatus(
+    Page<UserChallenge> findChallengesByCompletionStatus(
             @Param("userId") Long userId,
             @Param("completed") Boolean completed,
             Pageable pageable);
@@ -39,7 +39,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             "WHERE uc.user.id = :userId " +
             "AND uc.challengeType = :challengeType " +
             "AND uc.completed = false")  // 항상 미완료 챌린지만 조회
-    Slice<UserChallenge> findChallengesByChallengeTypeAndCompletionStatus(
+    Page<UserChallenge> findChallengesByChallengeTypeAndCompletionStatus(
             @Param("userId") Long userId,
             @Param("challengeType") UserChallengeType challengeType,
             Pageable pageable);

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -25,14 +25,14 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("userId") Long userId,
             @Param("today") LocalDate today);
 
-    // 챌린지 미완료/완료 여부 필터
+    // 전체 챌린지 중 인증 완료 여부 필터
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId AND uc.completed = :completed")
     Page<UserChallenge> findChallengesByCompletionStatus(@Param("userId") Long userId,
                                                          @Param("completed") Boolean completed,
                                                          Pageable pageable);
 
-    // 챌린지 타입 + 완료 여부 필터
+    // 챌린지 타입 + 인증 완료 여부 필터
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.challengeType = :challengeType " +

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -25,28 +25,27 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("userId") Long userId,
             @Param("today") LocalDate today);
 
-    // 1. 유저의 완료 또는 미완료 챌린지 조회 (challengeType 무시)
+    // 챌린지 미완료/완료 여부 필터
     @Query("SELECT uc FROM UserChallenge uc " +
-            "WHERE uc.user.id = :userId " +
-            "AND uc.completed = :completed")
-    Page<UserChallenge> findChallengesByCompletionStatus(
-            @Param("userId") Long userId,
-            @Param("completed") Boolean completed,
-            Pageable pageable);
+            "WHERE uc.user.id = :userId AND uc.completed = :completed")
+    Page<UserChallenge> findChallengesByCompletionStatus(@Param("userId") Long userId,
+                                                         @Param("completed") Boolean completed,
+                                                         Pageable pageable);
 
-    // 2. 특정 challengeType에 대해 미완료 챌린지 조회 (completed가 true인 챌린지는 제외)
+    // 챌린지 타입 + 완료 여부 필터
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.challengeType = :challengeType " +
-            "AND uc.completed = false")  // 항상 미완료 챌린지만 조회
-    Page<UserChallenge> findChallengesByChallengeTypeAndCompletionStatus(
+            "AND uc.completed = :completed")
+    Page<UserChallenge> findByTypeAndCompletion(
             @Param("userId") Long userId,
-            @Param("challengeType") UserChallengeType challengeType,
+            @Param("challengeType") UserChallengeType userChallengeType,
+            @Param("completed") Boolean completed,
             Pageable pageable);
 
     //userId와 date로 UserChallenge 조회
     @Query("SELECT uc FROM UserChallenge uc " +
-            "WHERE uc. user.id = :userId " +
+            "WHERE uc.user.id = :userId " +
             "AND uc.date = :date ")
     List<UserChallenge> findUserChallengesByDateAndUserId(
             @Param("userId") Long userId,

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
@@ -3,7 +3,6 @@ package umc.GrowIT.Server.service.challengeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
@@ -90,7 +89,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     // 챌린지 현황 조회
     @Override
     public ChallengeResponseDTO.ChallengeStatusPagedResponseDTO getChallengeStatus(Long userId, UserChallengeType challengeType, Boolean completed, Integer page) {
-        Slice<UserChallenge> userChallenges;
+        Page<UserChallenge> userChallenges;
 
         // challengeType이 null이면 전체 챌린지 중 완료/미완료만 조회
         if (challengeType == null) {

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
@@ -89,21 +89,15 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     // 챌린지 현황 조회
     @Override
     public ChallengeResponseDTO.ChallengeStatusPagedResponseDTO getChallengeStatus(Long userId, UserChallengeType challengeType, Boolean completed, Integer page) {
+        PageRequest pr = PageRequest.of(page - 1, 5);
         Page<UserChallenge> userChallenges;
 
-        // challengeType이 null이면 전체 챌린지 중 완료/미완료만 조회
         if (challengeType == null) {
-            userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, completed, PageRequest.of(page-1, 5));
-        }
-        else {
-            if (!completed) {
-                // challengeType이 RANDOM 또는 DAILY인 경우 미완료 챌린지만 조회 (completed = false 고정)
-                userChallenges = userChallengeRepository.findChallengesByChallengeTypeAndCompletionStatus(userId, challengeType, PageRequest.of(page-1, 5));
-            }
-            else {
-                // 잘못된 요청 방지
-                userChallenges = Page.empty();
-            }
+            // 전체 챌린지 중 완료/미완료 챌린지 조회
+            userChallenges = userChallengeRepository.findChallengesByCompletionStatus(userId, completed, pr);
+        } else {
+            // 특정 챌린지 타입 + 완료/미완료 챌린지 조회
+            userChallenges = userChallengeRepository.findByTypeAndCompletion(userId, challengeType, completed, pr);
         }
 
         return ChallengeConverter.toChallengeStatusPagedDTO(userChallenges);

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -31,15 +31,13 @@ public interface ChallengeSpecification {
 
     @GetMapping("")
     @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다. <br> " +
-            "challengeType에 값을 주지 않으면 전체 완료/미완료 챌린지를 조회할 수 있습니다. <br> " +
-            "응답은 슬라이스 기반으로 페이징되며, 현재 페이지, 다음 페이지 존재 여부 등의 정보가 포함됩니다.")
+            "challengeType에 값을 주지 않으면 전체 완료/미완료 챌린지를 조회할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
             @Parameter(description = "챌린지 유형",
-                    schema = @Schema(allowableValues = {"DAILY", "RANDOM", "-"}),
                     example = "DAILY")
             @RequestParam(required = false) UserChallengeType challengeType,
             @Parameter(description = "챌린지 완료(인증) 여부",

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -41,8 +41,8 @@ public interface ChallengeSpecification {
                     example = "DAILY")
             @RequestParam(required = false) UserChallengeType challengeType,
             @Parameter(description = "챌린지 완료(인증) 여부",
-                    schema = @Schema(allowableValues = {"TRUE", "FALSE"}),
-                    example = "FALSE")
+                    schema = @Schema(allowableValues = {"true", "false"}),
+                    example = "false")
             @RequestParam(required = false) Boolean completed,
             @Parameter(description = "조회할 페이지",
                     example = "1")

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -88,6 +88,10 @@ public class ChallengeResponseDTO {
         private List<ChallengeStatusDTO> content;
         @Schema(description = "현재 페이지", example = "1")
         private int currentPage;
+        @Schema(description = "전체 페이지", example = "5")
+        private int totalPages;
+        @Schema(description = "전체 챌린지 수", example = "15")
+        private long totalElements;
         @Schema(description = "첫번째 페이지인지", example = "true")
         private boolean isFirst;
         @Schema(description = "마지막 페이지인지", example = "true")

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -88,9 +88,9 @@ public class ChallengeResponseDTO {
         private List<ChallengeStatusDTO> content;
         @Schema(description = "현재 페이지", example = "1")
         private int currentPage;
-        @Schema(description = "전체 페이지", example = "5")
+        @Schema(description = "전체 페이지", example = "1")
         private int totalPages;
-        @Schema(description = "전체 챌린지 수", example = "15")
+        @Schema(description = "전체 챌린지 수", example = "1")
         private long totalElements;
         @Schema(description = "첫번째 페이지인지", example = "true")
         private boolean isFirst;


### PR DESCRIPTION
## 📝 작업 내용
1차 출시 전까지는 슬라이스 기법 -> 페이징 기법으로 다시 변경하고 카테고리별 챌린지 개수까지 조회하도록 변경되었습니다.
출시 이후에 그로 아이템 조회 시 무한스크롤 방식이 적용되면 챌린지 현황 조회에서도 동일하게 적용될 것 같습니다.

그리고 예전에 작업한 코드를 다시 보니 `totalElements` 에서 **카테고리별 챌린지 개수**를 조회하고 있더라고요.. ㅎㅎ
response body 예시는 아래와 같은데 기존과 동일하게 currentPage는 현재 페이지, totalPages는 총 페이지, totalElements는 총 요소 개수(챌린지 개수), first는 첫번째 페이지인지, last는 마지막 페이지인지. 를 의미합니다.

```java
{
  "isSuccess": true,
  "code": "string",
  "message": "string",
  "result": {
    "content": [
      {
        "id": 1,
        "title": "좋아하는 책 독서하기",
        "challengeType": "DAILY",
        "time": 1,
        "completed": false
      }
    ],
    "currentPage": 1,
    "totalPages": 1,
    "totalElements": 1,
    "first": true,
    "last": true
  }
}
``` 

## 🔍 테스트 방법
**한 페이지에 5개의 챌린지가 조회됩니다!**
- 전체(미완료) 챌린지 조회
<img width="523" height="661" alt="image" src="https://github.com/user-attachments/assets/7c8da1b2-65d9-4efa-b710-d73b3d61d8d5" />


- 완료 챌린지 조회
<img width="523" height="662" alt="image" src="https://github.com/user-attachments/assets/e9dc8f19-5979-4c3b-ae95-a46206177831" />


- 미완료한 DAILY 챌린지 조회
<img width="656" height="653" alt="image" src="https://github.com/user-attachments/assets/8db3e9a6-0556-48ef-ae22-954f65b54739" />


- 완료한 DAILY 챌린지 조회
<img width="647" height="663" alt="image" src="https://github.com/user-attachments/assets/8d5e14e2-a1d2-4811-92b1-33888bb52044" />


- 미완료한 RANDOM 챌린지 조회
<img width="672" height="566" alt="image" src="https://github.com/user-attachments/assets/5e848859-372d-4c88-a296-057f9afc0451" />


- 완료한 RANDOM 챌린지 조회
<img width="640" height="563" alt="image" src="https://github.com/user-attachments/assets/d8f6a89a-8738-468a-87ae-08a2ee1d1067" />