### PR TITLE
[#280] Feat : 약관 목록 조회 및 검증 로직 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -32,7 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //약관 관련 에러
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),
     MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 약관에 반드시 동의해야 합니다."),
-    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4003", "전체 약관 정보를 주세요."),
+    INVALID_TERM(HttpStatus.BAD_REQUEST, "TERM4004", "약관 정보가 유효하지 않습니다."),
 
     //인증 관련 에러
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH4001", "이메일 인증을 완료해주세요."),

--- a/src/main/java/umc/GrowIT/Server/domain/Term.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Term.java
@@ -1,12 +1,26 @@
 package umc.GrowIT.Server.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
-import umc.GrowIT.Server.domain.common.BaseEntity;
-import umc.GrowIT.Server.domain.enums.TermType;
-
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.GrowIT.Server.domain.common.BaseEntity;
+import umc.GrowIT.Server.domain.enums.TermStatus;
+import umc.GrowIT.Server.domain.enums.TermType;
 
 @Entity
 @Getter
@@ -31,6 +45,23 @@ public class Term extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private TermType type;
+
+    // 약관 적용 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TermStatus status;
+
+    // 약관 효력 발생일
+    @Column(nullable = false)
+    private LocalDateTime effectiveDate;
+
+    // 약관 종료일
+    @Column(nullable = true) 
+    private LocalDateTime expirationDate;
+
+    // 버전
+    @Column(nullable = false)
+    private int version;
 
     @OneToMany(mappedBy = "term", cascade = CascadeType.ALL)
     private List<UserTerm> userTerm = new ArrayList<>();

--- a/src/main/java/umc/GrowIT/Server/domain/Term.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Term.java
@@ -19,7 +19,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.GrowIT.Server.domain.common.BaseEntity;
-import umc.GrowIT.Server.domain.enums.TermStatus;
 import umc.GrowIT.Server.domain.enums.TermType;
 
 @Entity
@@ -45,11 +44,6 @@ public class Term extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private TermType type;
-
-    // 약관 적용 상태
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private TermStatus status;
 
     // 약관 효력 발생일
     @Column(nullable = false)

--- a/src/main/java/umc/GrowIT/Server/domain/enums/TermStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/TermStatus.java
@@ -1,0 +1,7 @@
+package umc.GrowIT.Server.domain.enums;
+
+public enum TermStatus {
+    PENDING, // 예정 약관
+    ACTIVE,  // 현행 약관
+    INACTIVE // 종료 약관
+}

--- a/src/main/java/umc/GrowIT/Server/domain/enums/TermStatus.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/TermStatus.java
@@ -1,7 +1,0 @@
-package umc.GrowIT.Server.domain.enums;
-
-public enum TermStatus {
-    PENDING, // 예정 약관
-    ACTIVE,  // 현행 약관
-    INACTIVE // 종료 약관
-}

--- a/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
@@ -1,7 +1,14 @@
 package umc.GrowIT.Server.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import umc.GrowIT.Server.domain.Term;
+import umc.GrowIT.Server.domain.enums.TermStatus;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
+    List<Term> findAllByStatus(TermStatus status);
+
+    int countByStatus(TermStatus status);
 }

--- a/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/TermRepository.java
@@ -1,14 +1,17 @@
 package umc.GrowIT.Server.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import umc.GrowIT.Server.domain.Term;
-import umc.GrowIT.Server.domain.enums.TermStatus;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
-    List<Term> findAllByStatus(TermStatus status);
+    @Query("SELECT COUNT(t) FROM Term t WHERE t.effectiveDate <= :today AND (t.expirationDate IS NULL OR t.expirationDate >= :today)")
+    int countByDate(LocalDateTime today);
 
-    int countByStatus(TermStatus status);
+    @Query("SELECT t FROM Term t WHERE t.effectiveDate <= :today AND (t.expirationDate IS NULL OR t.expirationDate >= :today)")
+    List<Term> findAllByDate(LocalDateTime today);
 }

--- a/src/main/java/umc/GrowIT/Server/service/termService/TermCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/termService/TermCommandServiceImpl.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import static umc.GrowIT.Server.apiPayload.code.status.ErrorStatus.TERM_NOT_FOUND;
 
-
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/src/main/java/umc/GrowIT/Server/service/termService/TermQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/termService/TermQueryServiceImpl.java
@@ -1,33 +1,34 @@
 package umc.GrowIT.Server.service.termService;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.TermHandler;
 import umc.GrowIT.Server.converter.TermConverter;
 import umc.GrowIT.Server.domain.Term;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserTerm;
+import umc.GrowIT.Server.domain.enums.TermStatus;
 import umc.GrowIT.Server.domain.enums.TermType;
+import umc.GrowIT.Server.repository.TermRepository;
 import umc.GrowIT.Server.web.dto.TermDTO.TermRequestDTO;
 import umc.GrowIT.Server.web.dto.TermDTO.TermResponseDTO;
-import umc.GrowIT.Server.repository.TermRepository;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TermQueryServiceImpl implements TermQueryService{
 
-    public static final int TERM_COUNT = 6;
     private final TermRepository termRepository;
 
     /**
-     * 약관 목록 조회
+     * 현행 약관 목록 조회
      */
     public List<TermResponseDTO.TermDTO> getTerms(){
-        List<Term> terms = termRepository.findAll();
+        List<Term> terms = termRepository.findAllByStatus(TermStatus.ACTIVE); // 현행 약관 조회
 
         return terms.stream()
                 .map(TermConverter::toTermDTO)
@@ -45,9 +46,15 @@ public class TermQueryServiceImpl implements TermQueryService{
      */
     @Override
     public List<UserTerm> checkUserTerms(List<TermRequestDTO.UserTermDTO> requestedUserTerms, User newUser) {
-        //전체 약관 정보가 주어지지 않았을 때 예외 처리
-        if (requestedUserTerms.size() < TERM_COUNT) {
-            throw new TermHandler(ErrorStatus.ALL_TERMS_REQUIRED);
+        // 현행 약관 조회
+        List<Term> terms = termRepository.findAllByStatus(TermStatus.ACTIVE); // 현행 약관 조회
+
+        // 현행 약관 개수 조회
+        int activeTermCount = terms.size();
+
+        // 요청된 약관 개수와 현행 약관 개수가 다르면 예외 처리
+        if (requestedUserTerms.size() != activeTermCount) {
+            throw new TermHandler(ErrorStatus.INVALID_TERM);
         }
 
         return requestedUserTerms.stream()
@@ -57,9 +64,14 @@ public class TermQueryServiceImpl implements TermQueryService{
                     // 존재하지 않는 약관을 요청하면 예외 처리
                     if (term == null) {
                         throw new TermHandler(ErrorStatus.TERM_NOT_FOUND);
-                        // 필수 약관에 동의하지 않으면 예외 처리
-                    } else if (term.getType() == TermType.MANDATORY && !userTerm.getAgreed()) {
+                    }
+                    // 필수 약관에 동의하지 않으면 예외 처리
+                    if (term.getType() == TermType.MANDATORY && !userTerm.getAgreed()) {
                         throw new TermHandler(ErrorStatus.MANDATORY_TERMS_REQUIRED);
+                    }
+                    // 약관 동의 상태 검증
+                    if (term.getStatus() != TermStatus.ACTIVE) {
+                        throw new TermHandler(ErrorStatus.INVALID_TERM);
                     }
                     // UserTerm 엔티티 생성
                     return TermConverter.toUserTerm(userTerm.getAgreed(), term, newUser);

--- a/src/main/java/umc/GrowIT/Server/service/termService/TermQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/termService/TermQueryServiceImpl.java
@@ -46,11 +46,8 @@ public class TermQueryServiceImpl implements TermQueryService{
      */
     @Override
     public List<UserTerm> checkUserTerms(List<TermRequestDTO.UserTermDTO> requestedUserTerms, User newUser) {
-        // 현행 약관 조회
-        List<Term> terms = termRepository.findAllByStatus(TermStatus.ACTIVE); // 현행 약관 조회
-
-        // 현행 약관 개수 조회
-        int activeTermCount = terms.size();
+        // 현행 약관 수 조회
+        int activeTermCount = termRepository.countByStatus(TermStatus.ACTIVE);
 
         // 요청된 약관 개수와 현행 약관 개수가 다르면 예외 처리
         if (requestedUserTerms.size() != activeTermCount) {
@@ -63,7 +60,7 @@ public class TermQueryServiceImpl implements TermQueryService{
                             .orElse(null);
                     // 존재하지 않는 약관을 요청하면 예외 처리
                     if (term == null) {
-                        throw new TermHandler(ErrorStatus.TERM_NOT_FOUND);
+                        throw new TermHandler(ErrorStatus.INVALID_TERM);
                     }
                     // 필수 약관에 동의하지 않으면 예외 처리
                     if (term.getType() == TermType.MANDATORY && !userTerm.getAgreed()) {

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -21,7 +21,7 @@ public interface AuthSpecification {
 
     @PostMapping("/signup")
     @SecurityRequirement(name = "")
-    @Operation(summary = "이메일 회원가입 API", description = "약관 목록 입력할 때 termId 1~6 입력해 주세요. (termId 1~4는 필수 동의 항목입니다.)", security = @SecurityRequirement(name = ""))
+    @Operation(summary = "이메일 회원가입 API", description = "GET /terms 약관 목록 조회 API 에서 조회된 약관에 대한 동의 정보를 함께 주세요.", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),


### PR DESCRIPTION
## 📝 작업 내용
약관 내용이 변경되거나, 추가될 때 현재 테이블로는
변경되기 전/변경된 후 사용자가 어떤 약관에 동의했는지 추적하기 어려운 문제가 있었습니다.

1. 테이블 수정
- 따라서 약관 효력 발생일(effectiveDate), 종료일 컬럼(expirationDate)을 추가해 구체적인 약관 시행 기간을 확인할 수 있게 하고
- 약관 적용 상태(status) 및 버전(version)은 쿼리 조회할 때나 어떤 약관인지 식별할 때 편리함이 있어 추가했습니다.

2. 약관 조회 및 검증 로직 수정
- 약관 조회 시 현행 약관(status=ACTIVE)만 조회
- 약관 검증 시 현행 약관(status=ACTIVE) 인지 확인

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->
애플 로그인 PR, 현재 PR로 인해 테이블 변경돼서 서브모듈에 해당 SQL 올려놓았습니다.
추후에 PR 승인 시 로컬 DB에만 반영해주시면 서버에 따로 적용하겠습니다.

## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
1. 