### PR TITLE
[#284] Refactor: 챌린지 현황 최신순 조회 및 엔드포인트 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -57,7 +57,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 챌린지 관련 에러
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE4001", "챌린지를 찾을 수 없습니다."),
-    CHALLENGE_ALREADY_SAVED(HttpStatus.BAD_REQUEST, "CHALLENGE4002", "오늘 이미 챌린지를 저장하였습니다. 추가 저장은 불가능합니다."),
+    CHALLENGE_TOTAL_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4002", "챌린지는 하루에 9개까지 저장 가능합니다."),
     CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "챌린지는 3개까지 저장 가능합니다."),
     CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "최소 하나의 챌린지를 선택해야 합니다."),
     CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),

--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -111,6 +111,23 @@ public class ChallengeConverter {
                 .build();
     }
 
+    // 선택한 챌린지 저장
+    public static ChallengeResponseDTO.SelectChallengeResponseDTO toSelectChallengeDTO(List<UserChallenge> userChallenges) {
+        List<ChallengeResponseDTO.SelectedChallengesInfo> selectedChallenges = userChallenges.stream()
+                .map(userChallenge -> ChallengeResponseDTO.SelectedChallengesInfo.builder()
+                        .id(userChallenge.getId())
+                        .challengeType(userChallenge.getChallengeType())
+                        .title(userChallenge.getChallenge().getTitle())
+                        .content(userChallenge.getChallenge().getContent())
+                        .time(userChallenge.getChallenge().getTime())
+                        .build())
+                .toList();
+
+        return ChallengeResponseDTO.SelectChallengeResponseDTO.builder()
+                .selectedChallenges(selectedChallenges) // 여러 개의 챌린지 리스트 반환
+                .build();
+    }
+
     // 챌린지 삭제
     public static ChallengeResponseDTO.DeleteChallengeResponseDTO toDeletedUserChallenge(UserChallenge userChallenge) {
         return ChallengeResponseDTO.DeleteChallengeResponseDTO.builder()

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -28,7 +28,8 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
 
     // 전체 챌린지 중 인증 완료 여부 필터
     @Query("SELECT uc FROM UserChallenge uc " +
-            "WHERE uc.user.id = :userId AND uc.completed = :completed")
+            "WHERE uc.user.id = :userId AND uc.completed = :completed " +
+            "ORDER BY uc.createdAt DESC")
     Page<UserChallenge> findChallengesByCompletionStatus(@Param("userId") Long userId,
                                                          @Param("completed") Boolean completed,
                                                          Pageable pageable);
@@ -37,7 +38,8 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     @Query("SELECT uc FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
             "AND uc.challengeType = :challengeType " +
-            "AND uc.completed = :completed")
+            "AND uc.completed = :completed " +
+            "ORDER BY uc.createdAt DESC")
     Page<UserChallenge> findByTypeAndCompletion(
             @Param("userId") Long userId,
             @Param("challengeType") UserChallengeType userChallengeType,

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -53,6 +53,9 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("date") LocalDate date
     );
 
+    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId AND uc.date = :date")
+    Integer countByDateAndUserId(Long userId, LocalDate date);
 
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -55,9 +55,10 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("date") LocalDate date
     );
 
-    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
-            "WHERE uc.user.id = :userId AND uc.date = :date")
-    Integer countByDateAndUserId(Long userId, LocalDate date);
+    // 추후에 작업 필요
+//    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
+//            "WHERE uc.user.id = :userId AND uc.date = :date")
+//    long countByDateAndUserId(Long userId, LocalDate date);
 
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandService.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public interface ChallengeCommandService {
 
-    void selectChallenges(Long userId, List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
+    ChallengeResponseDTO.SelectChallengeResponseDTO selectChallenges(Long userId, List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
     ChallengeResponseDTO.ProofPresignedUrlResponseDTO createChallengePresignedUrl(Long userId, ChallengeRequestDTO.ProofRequestPresignedUrlDTO request);
     void createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
     void updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -44,6 +44,14 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
             UserChallengeType challengeType = selectRequest.getChallengeType();
             LocalDate date = selectRequest.getDate();
 
+            // 날짜별로 이미 저장된 개수 가져오기
+            Integer existingCount = userChallengeRepository.countByDateAndUserId(userId, date);
+
+            // 이번에 추가하려는 개수까지 포함
+            if (existingCount + challengeIds.size() > 9) {
+                throw new ChallengeHandler(ErrorStatus.CHALLENGE_TOTAL_MAX);
+            }
+
             // 현재 challengeType에 따라 저장 가능한 최대 개수 확인
             if (challengeType == UserChallengeType.DAILY) {
                 dailyChallengeCount += challengeIds.size();

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -52,12 +52,12 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @PostMapping("select")
-    public ApiResponse<Void> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList) {
+    public ApiResponse<ChallengeResponseDTO.SelectChallengeResponseDTO> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        challengeCommandService.selectChallenges(userId, selectRequestList);
-        return ApiResponse.onSuccess();
+        ChallengeResponseDTO.SelectChallengeResponseDTO response = challengeCommandService.selectChallenges(userId, selectRequestList);
+        return ApiResponse.onSuccess(response);
     }
 
     @PostMapping("presigned-url")

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -30,14 +30,14 @@ public class ChallengeController implements ChallengeSpecification {
     private final ChallengeQueryService challengeQueryService;
     private final ChallengeCommandService challengeCommandService;
 
-    @GetMapping("summary")
+    @GetMapping("")
     public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
         return ApiResponse.onSuccess(challengeQueryService.getChallengeHome(userId));
     }
 
-    @GetMapping("")
+    @GetMapping("status")
     public ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
             @RequestParam(required = false) UserChallengeType challengeType,
             @RequestParam Boolean completed,

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public interface ChallengeSpecification {
 
-    @GetMapping("summary")
+    @GetMapping("")
     @Operation(summary = "챌린지 홈 조회 API", description = "사용자의 챌린지 홈 화면에 보여질 챌린지 요약 정보를 조회하는 API입니다. <br> " +
             "오늘의 챌린지 추천과 그로의 챌린지 리포트를 조회할 수 있습니다.")
     @ApiResponses({
@@ -29,7 +29,7 @@ public interface ChallengeSpecification {
     })
     ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome();
 
-    @GetMapping("")
+    @GetMapping("status")
     @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다. <br> " +
             "challengeType에 값을 주지 않으면 전체 완료/미완료 챌린지를 조회할 수 있습니다.")
     @ApiResponses({

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -60,7 +60,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4005", description = "❌ 데일리 챌린지는 최대 2개까지 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4006", description = "❌ 랜덤 챌린지는 최대 1개만 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Void> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
+    ApiResponse<ChallengeResponseDTO.SelectChallengeResponseDTO> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
 
     @PostMapping("presigned-url")
     @Operation(summary = "사용자 챌린지 인증 이미지 업로드용 presigned url 생성 API", description = "사용자 챌린지 인증 이미지를 S3에 직접 업로드할 수 있는 presigned url을 생성합니다.")

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -43,11 +43,11 @@ public class ChallengeRequestDTO {
     @AllArgsConstructor
     @Schema(title = "챌린지 선택 후 저장 request")
     public static class SelectChallengeRequestDTO {
-        @Schema(description = "저장할 챌린지 아이디(리스트)", example = "[1, 2]")
+        @Schema(description = "저장할 챌린지 아이디(리스트)", example = "[60, 63]")
         private List<Long> challengeIds;
         @Schema(description = "저장할 챌린지의 타입", example = "DAILY")
         private UserChallengeType challengeType;
-        @Schema(description = "챌린지를 저장하는 날짜(오늘 날짜가 기본값)", example = "2025-08-26")
+        @Schema(description = "챌린지를 저장하는 날짜(오늘 날짜가 기본값)")
         private LocalDate date;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -30,6 +30,34 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "챌린지 선택 후 저장 리스트 response")
+    public static class SelectChallengeResponseDTO {
+        @Schema(description = "저장한 챌린지 리스트")
+        private List<SelectedChallengesInfo> selectedChallenges;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(title = "챌린지 선택 후 저장 response")
+    public static class SelectedChallengesInfo {
+        @Schema(description = "저장한 챌린지 id", example = "1")
+        private Long id;
+        @Schema(description = "저장한 챌린지 타입", example = "DAILY")
+        private UserChallengeType challengeType;
+        @Schema(description = "저장한 챌린지 제목", example = "좋아하는 책 독서하기")
+        private String title;
+        @Schema(description = "저장한 챌린지 내용", example = "좋아하는 책을 골라서 한 번 읽어 보세요!")
+        private String content;
+        @Schema(description = "챌린지 소요 시간", example = "1")
+        private Integer time;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(title = "챌린치 추천 response")
     public static class RecommendedChallengeDTO {
         @Schema(description = "추천 챌린지 id", example = "1")


### PR DESCRIPTION
## 📝 작업 내용
1. 기존에는 챌린지 현황이 최신순으로 조회되고 있지 않았기 때문에, 생성일자 기준으로 내림차순 정렬하도록 처리하였습니다.
2. 챌린지 홈 조회는 challenges, 챌린지 현황 조회는 challenges/status 로 엔드포인트 변경하였습니다.
3. 챌린지 선택저장 후 챌린지 홈을 조회하면 저장하지 않은 챌린지 아이디가 조회되는 문제가 있다고 하여, 선택저장 후 정상적으로 저장되었는지 확인을 위해 응답결과를 반환하도록 수정하였습니다.

## 👀 참고사항
위의 수정사항들은 머지되면 프론트측에 전달할 예정입니다.


## 🔍 테스트 방법
- 엔드포인트 변경
<img width="455" height="152" alt="image" src="https://github.com/user-attachments/assets/9548eab7-50c9-412c-99de-b1d30c63604c" />


- 챌린지 선택 후 저장하면 응답결과 반환
<img width="428" height="892" alt="image" src="https://github.com/user-attachments/assets/a8b0a4c0-8570-4f28-a3c5-985242982f7c" />

<img width="597" height="665" alt="image" src="https://github.com/user-attachments/assets/3bb55d48-0632-4ea0-aef9-ead0e70753b5" />
