### PR TITLE
[#288] Refactor: 챌린지 인증 작성 제한

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC4003", "이미 완료된 챌린지입니다."),
     USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC4004", "챌린지 인증이 완료되지 않았습니다."),
     USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC4005", "챌린지 인증 내역에 수정사항이 없습니다."),
+    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC4006", "하루에 인증 가능한 챌린지 개수는 10개입니다."),
 
     //약관 관련 에러
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -29,7 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC4003", "이미 완료된 챌린지입니다."),
     USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC4004", "챌린지 인증이 완료되지 않았습니다."),
     USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC4005", "챌린지 인증 내역에 수정사항이 없습니다."),
-    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC4006", "하루에 인증 가능한 챌린지 개수는 10개입니다."),
+    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC4006", "하루에 10번만 인증이 가능합니다."),
 
     //약관 관련 에러
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -57,7 +57,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 챌린지 관련 에러
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE4001", "챌린지를 찾을 수 없습니다."),
-    CHALLENGE_TOTAL_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4002", "챌린지는 하루에 9개까지 저장 가능합니다."),
     CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "챌린지는 3개까지 저장 가능합니다."),
     CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "최소 하나의 챌린지를 선택해야 합니다."),
     CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -61,7 +61,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             "WHERE uc.user.id = :userId " +
             "AND uc.completed = :completed " +
             "AND uc.createdAt BETWEEN :startOfDay AND :endOfDay")
-    long countByCompletion(@Param("userId") Long userId,
+    long countCompletedTodayByUserId(@Param("userId") Long userId,
                            @Param("completed") Boolean completed,
                            @Param("startOfDay") LocalDateTime startOfDay,
                            @Param("endOfDay") LocalDateTime endOfDay);
@@ -71,7 +71,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             "WHERE uc.user.id = :userId " +
             "AND uc.completed = :completed " +
             "AND uc.date = :date")
-    long countByDateAndCompletion(@Param("userId") Long userId,
+    long countCompletedOnDateByUserId(@Param("userId") Long userId,
                                   @Param("completed") Boolean completed,
                                   @Param("date") LocalDate date
     );

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -56,10 +56,6 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("date") LocalDate date
     );
 
-    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
-            "WHERE uc.user.id = :userId AND uc.date = :date")
-    long countByDateAndUserId(Long userId, LocalDate date);
-
     // 하루에 인증 완료한 챌린지 개수 조회
     @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -66,6 +66,16 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
                            @Param("startOfDay") LocalDateTime startOfDay,
                            @Param("endOfDay") LocalDateTime endOfDay);
 
+    // 동일한 date에 대해 인증 완료한 챌린지 개수 조회 (크레딧 지급 용도)
+    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId " +
+            "AND uc.completed = :completed " +
+            "AND uc.date = :date")
+    long countByDateAndCompletion(@Param("userId") Long userId,
+                                  @Param("completed") Boolean completed,
+                                  @Param("date") LocalDate date
+    );
+
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -55,10 +55,9 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("date") LocalDate date
     );
 
-    // 추후에 작업 필요
-//    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
-//            "WHERE uc.user.id = :userId AND uc.date = :date")
-//    long countByDateAndUserId(Long userId, LocalDate date);
+    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId AND uc.date = :date")
+    long countByDateAndUserId(Long userId, LocalDate date);
 
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -10,6 +10,7 @@ import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,6 +59,16 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId AND uc.date = :date")
     long countByDateAndUserId(Long userId, LocalDate date);
+
+    // 하루에 인증 완료한 챌린지 개수 조회
+    @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
+            "WHERE uc.user.id = :userId " +
+            "AND uc.completed = :completed " +
+            "AND uc.createdAt BETWEEN :startOfDay AND :endOfDay")
+    long countByCompletion(@Param("userId") Long userId,
+                           @Param("completed") Boolean completed,
+                           @Param("startOfDay") LocalDateTime startOfDay,
+                           @Param("endOfDay") LocalDateTime endOfDay);
 
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")

--- a/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/UserChallengeRepository.java
@@ -59,22 +59,18 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     // 하루에 인증 완료한 챌린지 개수 조회
     @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND uc.completed = :completed " +
+            "AND uc.completed = true " +
             "AND uc.createdAt BETWEEN :startOfDay AND :endOfDay")
     long countCompletedTodayByUserId(@Param("userId") Long userId,
-                           @Param("completed") Boolean completed,
                            @Param("startOfDay") LocalDateTime startOfDay,
                            @Param("endOfDay") LocalDateTime endOfDay);
 
     // 동일한 date에 대해 인증 완료한 챌린지 개수 조회 (크레딧 지급 용도)
     @Query("SELECT COUNT(uc) FROM UserChallenge uc " +
             "WHERE uc.user.id = :userId " +
-            "AND uc.completed = :completed " +
+            "AND uc.completed = true " +
             "AND uc.date = :date")
-    long countCompletedOnDateByUserId(@Param("userId") Long userId,
-                                  @Param("completed") Boolean completed,
-                                  @Param("date") LocalDate date
-    );
+    long countCompletedOnDateByUserId(@Param("userId") Long userId, @Param("date") LocalDate date);
 
     @Modifying
     @Query("DELETE FROM UserChallenge uc WHERE uc.user.id = :userId")

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -121,7 +121,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         }
 
         // 오늘 날짜로 인증 완료한 챌린지 개수 가져오기
-        long todayCompletedCount = userChallengeRepository.countCompletedTodayByUserId(userId, true, startOfDay, endOfDay);
+        long todayCompletedCount = userChallengeRepository.countCompletedTodayByUserId(userId, startOfDay, endOfDay);
 
         // 인증 작성한 챌린지 개수가 10개인 경우
         if (todayCompletedCount == 10) {
@@ -136,7 +136,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         LocalDate targetDate = userChallenge.getDate();
 
         // 동일한 date로 저장한 챌린지 개수 가져오기
-        long completedCountOnDate = userChallengeRepository.countCompletedOnDateByUserId(userId, true, targetDate);
+        long completedCountOnDate = userChallengeRepository.countCompletedOnDateByUserId(userId, targetDate);
 
         // 챌린지 인증 3번까지 크레딧 지급
         if (completedCountOnDate <= 3) {

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -48,14 +48,6 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
             UserChallengeType challengeType = selectRequest.getChallengeType();
             LocalDate date = selectRequest.getDate();
 
-            // 날짜별로 이미 저장된 개수 가져오기
-            long existingCount = userChallengeRepository.countByDateAndUserId(userId, date);
-
-            // 이번에 추가하려는 개수까지 포함
-            if (existingCount + challengeIds.size() > 9) {
-                throw new ChallengeHandler(ErrorStatus.CHALLENGE_TOTAL_MAX);
-            }
-
             // 현재 challengeType에 따라 저장 가능한 최대 개수 확인
             if (challengeType == UserChallengeType.DAILY) {
                 dailyChallengeCount += challengeIds.size();

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -46,14 +46,13 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
             UserChallengeType challengeType = selectRequest.getChallengeType();
             LocalDate date = selectRequest.getDate();
 
-            // 추후에 작업 필요
-//            // 날짜별로 이미 저장된 개수 가져오기
-//            long existingCount = userChallengeRepository.countByDateAndUserId(userId, date);
-//
-//            // 이번에 추가하려는 개수까지 포함
-//            if (existingCount + challengeIds.size() > 9) {
-//                throw new ChallengeHandler(ErrorStatus.CHALLENGE_TOTAL_MAX);
-//            }
+            // 날짜별로 이미 저장된 개수 가져오기
+            long existingCount = userChallengeRepository.countByDateAndUserId(userId, date);
+
+            // 이번에 추가하려는 개수까지 포함
+            if (existingCount + challengeIds.size() > 9) {
+                throw new ChallengeHandler(ErrorStatus.CHALLENGE_TOTAL_MAX);
+            }
 
             // 현재 challengeType에 따라 저장 가능한 최대 개수 확인
             if (challengeType == UserChallengeType.DAILY) {

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -133,8 +133,14 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         userChallenge.verifyUserChallenge(proofRequest);
 
-        user.updateCurrentCredit(user.getCurrentCredit() + CHALLENGE_CREDIT);
-        user.updateTotalCredit(user.getTotalCredit() + CHALLENGE_CREDIT);
+        // 동일한 date로 저장한 챌린지 개수 가져오기
+        long creditCount = userChallengeRepository.countByDateAndCompletion(userId, true, userChallenge.getDate());
+
+        // 챌린지 인증 3번까지 크레딧 지급
+        if (creditCount <= 3) {
+            user.updateCurrentCredit(user.getCurrentCredit() + CHALLENGE_CREDIT);
+            user.updateTotalCredit(user.getTotalCredit() + CHALLENGE_CREDIT);
+        }
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -121,10 +121,10 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         }
 
         // 오늘 날짜로 인증 완료한 챌린지 개수 가져오기
-        long completedCount = userChallengeRepository.countByCompletion(userId, true, startOfDay, endOfDay);
+        long todayCompletedCount = userChallengeRepository.countCompletedTodayByUserId(userId, true, startOfDay, endOfDay);
 
         // 인증 작성한 챌린지 개수가 10개인 경우
-        if (completedCount == 10) {
+        if (todayCompletedCount == 10) {
             throw new ChallengeHandler(ErrorStatus.USER_CHALLENGE_PROVED_LIMIT);
         }
 
@@ -133,11 +133,13 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         userChallenge.verifyUserChallenge(proofRequest);
 
+        LocalDate targetDate = userChallenge.getDate();
+
         // 동일한 date로 저장한 챌린지 개수 가져오기
-        long creditCount = userChallengeRepository.countByDateAndCompletion(userId, true, userChallenge.getDate());
+        long completedCountOnDate = userChallengeRepository.countCompletedOnDateByUserId(userId, true, targetDate);
 
         // 챌린지 인증 3번까지 크레딧 지급
-        if (creditCount <= 3) {
+        if (completedCountOnDate <= 3) {
             user.updateCurrentCredit(user.getCurrentCredit() + CHALLENGE_CREDIT);
             user.updateTotalCredit(user.getTotalCredit() + CHALLENGE_CREDIT);
         }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -78,7 +78,8 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4003", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4003", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4006", description = "❌ 하루에 10번만 인증이 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 작성할 사용자 챌린지의 ID", example = "1")
     ApiResponse<Void> createChallengeProof(@PathVariable Long userChallengeId,


### PR DESCRIPTION
## 📝 작업 내용
1. 하루에 인증을 할 수 있는 챌린지 개수를 10개로 제한합니다.
2. 챌린지는 제한 없이 추가 저장 가능하되, 하루에 3개 인증까지 크레딧 지급하고 4개 인증부터는 크레딧을 지급하지 않습니다.

ex: 8월 31일 기준
8월 30일 날짜의 일기 작성과 재작성으로 챌린지를 6개 저장 후 모두 인증
-> 8월 31일 날짜의 일기 작성과 재작성으로 챌린지를 5개 저장 후 인증
-> 하루에 최대 10개까지 인증 가능하므로 나머지 1개는 인증 불가
=> 다음날(9월 1일)이 되면 해당 챌린지에 대하여 인증 가능

하루에 인증 완료한 챌린지 개수를 조회할 때 `uc.createdAt = :today` 로 비교가 불가능하여, 아래처럼 startOfDay와 endOfDay 선언하여
startOfDay와 endOfDay 범위 내에서 개수를 조회하고 11번째 인증을 시도하는 경우 `하루에 10번만 인증이 가능합니다.` 에러메시지가 뜨도록 처리하였습니다.
```java
LocalDate today = LocalDate.now();

LocalDateTime startOfDay = today.atStartOfDay();
LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
``` 

1. 하루에 인증을 할 수 있는 챌린지 개수를 10개로 제한합니다. `completedCount` 변수에 **오늘 날짜로 인증 완료한 챌린지 개수**를 담아, 챌린지 인증을 시도하려고 하는데 이미 인증 작성한 챌린지 개수가 10개인 경우 "하루에 10번만 인증이 가능합니다." 에러메시지를 반환합니다.
```java
// 오늘 날짜로 인증 완료한 챌린지 개수 가져오기
long todayCompletedCount= userChallengeRepository.countCompletedTodayByUserId(userId, true, startOfDay, endOfDay);

// 인증 작성한 챌린지 개수가 10개인 경우
if (todayCompletedCount== 10) {
throw new ChallengeHandler(ErrorStatus.USER_CHALLENGE_PROVED_LIMIT);
}
``` 

2. 챌린지 4개 인증부터 크레딧을 지급하지 않습니다. 이는 `creditCount` 변수에 **동일한 date로 저장한 챌린지 개수**를 담아, 챌린지 인증 4번째부터는 크레딧을 지급하지 않도록 조건으로 처리하였습니다.
```java
// 동일한 date로 저장한 챌린지 개수 가져오기
long completedCountOnDate= userChallengeRepository.countCompletedOnDateByUserId(userId, true, userChallenge.getDate());

// 챌린지 인증 3번까지 크레딧 지급
if (completedCountOnDate<= 3) {
    user.updateCurrentCredit(user.getCurrentCredit() + CHALLENGE_CREDIT);
    user.updateTotalCredit(user.getTotalCredit() + CHALLENGE_CREDIT);
}
``` 
## 👀 참고사항
1. 변수 이름을 대충 지은거같은데.... 더 나은 변수명이 있는지 고민해보겠습니다. -> 수정했는데... 더 좋은 아이디어 있을까여
2. ErrorStatus 컨벤션 정리되는대로 수정하겠습니다!


## 🔍 테스트 방법
1. 하루에 10번의 챌린지 인증을 완료하고 11번째 인증을 시도하는 경우
<img width="463" height="171" alt="image" src="https://github.com/user-attachments/assets/24a6869e-3ecf-4c78-8e9c-94be12d3cb1f" />


2. 하루에 챌린지 인증은 최대 10개까지 가능, 4번째 인증부터 크레딧 지급 x
    챌린지 인증 시 1개의 크레딧 지급 -> 챌린지 인증에 대해 동일한 날짜에 최대 3개의 크레딧 지급