### PR TITLE
[#293] Fix: Response DTO에 사용자 아이템 ID 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/GroConverter.java
@@ -3,6 +3,7 @@ package umc.GrowIT.Server.converter;
 import umc.GrowIT.Server.domain.Gro;
 import umc.GrowIT.Server.domain.Item;
 import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.UserItem;
 import umc.GrowIT.Server.web.dto.GroDTO.GroResponseDTO;
 
 import java.util.List;
@@ -30,7 +31,7 @@ public class GroConverter {
                 .build();
     }
 
-    public static GroResponseDTO.GroAndEquippedItemsDTO toGroAndEquippedItemsDTO(Gro gro, String groImageUrl, Map<Item, String> itemUrls) {
+    public static GroResponseDTO.GroAndEquippedItemsDTO toGroAndEquippedItemsDTO(Gro gro, String groImageUrl, Map<UserItem, String> itemUrls) {
         // 1. GroDTO 생성
         GroResponseDTO.GroDTO groDTO = GroResponseDTO.GroDTO.builder()
                 .level(gro.getLevel())
@@ -40,10 +41,11 @@ public class GroConverter {
 
         // 2. EquippedItemsDTO 리스트 생성
         List<GroResponseDTO.EquippedItemsDTO> equippedItems = itemUrls.entrySet().stream()
-                .map(item -> GroResponseDTO.EquippedItemsDTO.builder()
-                        .name(item.getKey().getName())
-                        .category(item.getKey().getCategory())
-                        .itemImageUrl(item.getValue())
+                .map(entry -> GroResponseDTO.EquippedItemsDTO.builder()
+                        .id(entry.getKey().getId())
+                        .name(entry.getKey().getItem().getName())
+                        .category(entry.getKey().getItem().getCategory())
+                        .itemImageUrl(entry.getValue())
                         .build())
                 .collect(Collectors.toList())
                 ;

--- a/src/main/java/umc/GrowIT/Server/service/groService/GroQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/groService/GroQueryServiceImpl.java
@@ -49,16 +49,11 @@ public class GroQueryServiceImpl implements GroQueryService {
             throw new ItemHandler(ErrorStatus.EQUIPPED_USER_ITEM_NOT_FOUND);
         }
 
-        // 4. 착용한 아이템을 이용하여 Item 접근
-        List<Item> equippedItems = equippedUserItems.stream()
-                .map(UserItem::getItem)
-                .toList();
-
-        // 5. 프리사인드 URL 생성
+        // 4. 프리사인드 URL 생성
         String groUrl = createGroPreSignedUrl(gro.getLevel());
-        Map<Item, String> itemUrls = createItemPreSignedUrl(equippedItems);
+        Map<UserItem, String> itemUrls = createItemPreSignedUrl(equippedUserItems);
 
-        // 6. converter 작업
+        // 5. converter 작업
         return GroConverter.toGroAndEquippedItemsDTO(gro, groUrl, itemUrls);
     }
 
@@ -81,11 +76,11 @@ public class GroQueryServiceImpl implements GroQueryService {
     }
 
     // 착용 중인 이미지에 대한 Pre-signed URL 생성
-    private Map<Item, String> createItemPreSignedUrl(List<Item> equippedItems) {
-        return equippedItems.stream()
+    private Map<UserItem, String> createItemPreSignedUrl(List<UserItem> equippedUserItems) {
+        return equippedUserItems.stream()
                 .collect(Collectors.toMap(
-                        item -> item,
-                        item -> s3Util.toGetPresignedUrl(item.getGroImageKey(), Duration.ofMinutes(15))
+                        userItem -> userItem,
+                        userItem -> s3Util.toGetPresignedUrl(userItem.getItem().getGroImageKey(), Duration.ofMinutes(15))
                 ));
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/GroDTO/GroResponseDTO.java
@@ -36,8 +36,12 @@ public class GroResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "그로와 착용 아이템 이미지 조회 Response")
     public static class GroAndEquippedItemsDTO {
+        @Schema(description = "그로 정보")
         private GroDTO gro;
+
+        @Schema(description = "착용 아이템 정보")
         private List<EquippedItemsDTO> equippedItems;
     }
 
@@ -45,18 +49,31 @@ public class GroResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "그로 정보")
     public static class GroDTO {
-        private Integer level; // 그로 레벨
-        private String groImageUrl; // 그로 이미지 URL
+        @Schema(description = "그로 레벨", example = "1")
+        private Integer level;
+
+        @Schema(description = "그로 이미지 URL", example = "https://example.com/gro.png")
+        private String groImageUrl;
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "착용 아이템 정보")
     public static class EquippedItemsDTO {
-        private String name; // 아이템 이름
-        private ItemCategory category; // 아이템 카테고리
-        private String itemImageUrl; // 아이템 이미지 URL
+        @Schema(description = "사용자 아이템 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "아이템 이름", example = "체리")
+        private String name;
+
+        @Schema(description = "아이템 카테고리")
+        private ItemCategory category;
+
+        @Schema(description = "아이템 이미지 URL", example = "https://example.com/item.png")
+        private String itemImageUrl;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/WithdrawalDTO/WithdrawalResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/WithdrawalDTO/WithdrawalResponseDTO.java
@@ -12,6 +12,7 @@ public class WithdrawalResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(title = "탈퇴이유 조회 Response")
     public static class WithdrawalReasonDTO {
 
         @Schema(description = "탈퇴이유 ID", example = "1")


### PR DESCRIPTION
## 📝 작업 내용
FE 요구사항으로 그로 & 착용 아이템 이미지 조회 API에서 UserItem의 ID가 필요하다고 하여
https://github.com/7-umc-GrowIT/GrowIT-SpringBoot/pull/287 최근 PR에서 삭제했던거 다시 복구하였습니다.

\+ DTO에 @Schema 작성하였습니다.

## 👀 참고사항
(복구하면서 삭제하기 전 코드 확인했는데 이전에는 `UserItem`의 `Id`가 아니라 `Item`의 `Id`를 반환하고 있었던 거 같긴합니다...🥲 저도 몰랐던 사실... 복구하지 않아도 괜찮을 거 같긴한데 혹시 모르니...)


## 🔍 테스트 방법
1. Swagger 실행
<img width="300" height="600" alt="스크린샷 2025-09-01 오후 9 56 31" src="https://github.com/user-attachments/assets/60773a59-e521-4dc4-9284-06125b9f20c7" />

2. `UserItem`의 Id인 점 확인했습니다!
<img width="442" height="267" alt="스크린샷 2025-09-01 오후 9 57 34" src="https://github.com/user-attachments/assets/3394c4b4-f246-4c32-a35b-7ea9fea87e01" />
