### PR TITLE
[#300] Fix: 챌린지 인증 내역 수정 이미지 관련 문제

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -95,6 +95,7 @@ public class ChallengeConverter {
                 .title(userChallenge.getChallenge().getTitle())
                 .time(userChallenge.getChallenge().getTime())
                 .certificationImageUrl(certificationImageUrl)
+                .certificationImageName(userChallenge.getCertificationImageName())
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCertificationDate())
                 .build();

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -77,6 +77,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         }
 
         diary.updateContent(request.getContent());
+
+        diaryRepository.save(diary);
         return DiaryConverter.toModifyResultDTO(diary);
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -150,6 +150,8 @@ public class ChallengeResponseDTO {
         private String title;
         @Schema(description = "챌린지 인증 이미지 url", example = "https://growit-server-bucket.s3.ap-northeast-2.amazonaws.com/challenges/1842f2aa-40d0-4ae3~")
         private String certificationImageUrl;
+        @Schema(description = "챌린지 인증 이미지 파일명", example = "3c99605a8e01.png")
+        private String certificationImageName;
         @Schema(description = "챌린지 인증 소감", example = "오늘은 우주공강에 학교 도서관에 가서~")
         private String thoughts;
         @Schema(description = "챌린지 소요 시간", example = "1")


### PR DESCRIPTION
## 📝 작업 내용
(이전 문제)
- 챌린지 인증 내역 작성 시: 인증샷과 한줄소감 둘 다 필수
- 챌린지 인증 내역 수정 시: 인증샷과 한줄소감은 선택입력

챌린지 인증 내역 조회에서 따로 certificationImageName을 반환하고 있지 않기 때문에, 챌린지 인증 내역 수정에서 한줄소감만 수정할 경우 기존에 저장되어 있던 certificationImageName 값을 가져오는 것이 불가능하여
-> 챌린지 인증 내역 조회 시 해당 값을 반환하도록 수정하였습니다.

+) 일기 수정 시 수정사항 반영이 되지 않는다고 하여 코드를 살펴보니.. 제가 서비스 로직 개선하면서 save 코드를 삭제했었는데 그게 원인이었네요.. 다시 추가했습니다 (더티체킹 어렵네요... 😅 )

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
1. 챌린지 인증 내역 조회 시 파일명까지 반환
<img width="682" height="317" alt="image" src="https://github.com/user-attachments/assets/3722639b-3589-448c-a0e4-76d755ad1880" />


2. 일기 수정 시 다시 조회했을 때 수정사항이 잘 반영되어야 합니다.
<img width="340" height="243" alt="image" src="https://github.com/user-attachments/assets/e9bce054-97dc-4126-b54e-76f0d23172af" />
