### PR TITLE
[#298] Refactor: ErrorStatus 정리

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -17,26 +17,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    //멤버 관련 에러
+    // 멤버 관련 에러
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER40001", "비밀번호 확인이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER40102", "이메일 또는 패스워드가 일치하지 않습니다."),
     USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER40304", "탈퇴한 회원입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER40903", "이미 존재하는 이메일입니다."),
 
-    //사용자 챌린지 관련 에러
-    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC40001", "완료된 챌린지는 삭제가 불가합니다"),
-    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC40002", "이미 완료된 챌린지입니다."),
-    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC40003", "챌린지 인증이 완료되지 않았습니다."),
-    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC40004", "챌린지 인증 내역에 수정사항이 없습니다."),
-    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC40005", "하루에 10번만 인증이 가능합니다."),
-    USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC40401", "사용자 챌린지가 존재하지 않습니다"),
-
-    //약관 관련 에러
-    MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40001", "필수 약관에 반드시 동의해야 합니다."),
-    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40002", "전체 약관 정보를 주세요."),
-    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM40401", "존재하지 않는 약관을 요청했습니다."),
-
-    //인증 관련 에러
+    // 인증 관련 에러
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH40001", "이메일 인증을 완료해주세요."),
     INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "AUTH40002", "이메일 인증 타입이 잘못되었습니다."),
     AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH40003", "유효한 인증번호가 없습니다."),
@@ -55,16 +42,35 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50001", "이메일 전송에 실패했습니다."),
     EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50002", "이메일 내용 인코딩에 실패했습니다."),
 
-    // 챌린지 관련 에러
-    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE40001", "챌린지는 3개까지 저장 가능합니다."),
-    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE40002", "최소 하나의 챌린지를 선택해야 합니다."),
-    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40003", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),
-    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40004", "랜덤 챌린지는 최대 1개만 저장 가능합니다."),
-    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40401", "챌린지를 찾을 수 없습니다."),
-    RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40402", "연관된 챌린지가 없습니다."),
+    // OAuth 관련 에러
+    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH40003", "요청한 이메일로 가입할 수 없습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH40402", "존재하지 않는 계정입니다."),
+    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH40901", "이미 가입한 소셜 계정입니다."),
 
-    //기타 에러
+    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH40005", "유효하지 않은 인가 코드입니다."),
+    INVALID_APPLE_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH40006", "유효하지 않은 Apple ID Token 입니다."),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH40007", "유효하지 않은 소셜 로그인 제공자입니다."),
+    INVALID_APPLE_CLIENT_SETTING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50003", "Apple Client 설정값이 유효하지 않습니다."),
+    APPLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50004", "ID Token 또는 JWKs 파싱에 실패했습니다."),
+
+    // 약관 관련 에러
+    MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40001", "필수 약관에 반드시 동의해야 합니다."),
+    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40002", "전체 약관 정보를 주세요."),
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM40401", "존재하지 않는 약관을 요청했습니다."),
+
+    // 비밀번호 에러
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD40001", "비밀번호 확인이 일치하지 않습니다."),
+
+    // 탈퇴 관련 에러
+    WITHDRAWAL_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "WITHDRAWAL40401", "존재하지 않는 탈퇴 사유입니다."),
+
+    // 그로 관련 에러
+    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "GRO40001", "닉네임은 2~8자 이내로 작성해야 합니다."),
+    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO40002", "그로의 닉네임에 수정사항이 없습니다."),
+    GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO40401", "그로에 대한 정보가 존재하지 않습니다."),
+    GRO_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40901", "사용자의 그로가 이미 존재합니다."),
+    GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40902", "다른 닉네임과 중복되는 닉네임입니다."),
+    GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO50001", "그로 레벨이 유효하지 않습니다."),
 
     // 아이템 관련 에러
     ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM40001", "아이템을 찾을 수 없습니다."),
@@ -76,7 +82,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 아이템 관련 에러
     EQUIPPED_USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI40401", "착용 중인 사용자 아이템이 존재하지 않습니다."),
 
-    //결제 관련 에러
+    // 결제 관련 에러
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT40001", "결제정보가 정확하지 않습니다."),
 
     // 크레딧 관련 에러
@@ -87,37 +93,12 @@ public enum ErrorStatus implements BaseErrorCode {
     DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE40001", "유효하지 않은 날짜입니다."),
     DATE_IS_AFTER(HttpStatus.BAD_REQUEST, "DATE40002", "날짜는 오늘 이후로 설정할 수 없습니다."),
 
-    //그로 관련
-    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "GRO40001", "닉네임은 2~8자 이내로 작성해야 합니다."),
-    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO40002", "그로의 닉네임에 수정사항이 없습니다."),
-    GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO40401", "그로에 대한 정보가 존재하지 않습니다."),
-    GRO_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40901", "사용자의 그로가 이미 존재합니다."),
-    GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40902", "다른 닉네임과 중복되는 닉네임입니다."),
-    GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO50001", "그로 레벨이 유효하지 않습니다."),
-
-    //일기 관련 에러
+    // 일기 관련 에러
     DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY40001", "존재하지 않는 일기입니다."),
     DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY40002", "100자 이내로 작성된 일기입니다."),
     DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY40003", "해당날짜에 이미 일기가 존재합니다."),
     DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY40004", "기존 일기와 동일한 내용입니다."),
     ANALYZED_DIARY(HttpStatus.BAD_REQUEST, "DIARY40005", "이미 분석된 일기입니다."),
-
-    // S3 관련 에러
-    S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S340001", "파일 확장자가 잘못되었습니다."),
-    S3_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340002", "파일 이름은 필수입니다."),
-    S3_FOLDER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340003", "폴더 이름은 필수입니다."),
-    S3_INVALID_FOLDER_NAME(HttpStatus.BAD_REQUEST, "S340004", "폴더명은 영어로 입력해야 합니다."),
-
-    // OAuth 관련 에러
-    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH40003", "요청한 이메일로 가입할 수 없습니다."),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH40402", "존재하지 않는 계정입니다."),
-    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH40901", "이미 가입한 소셜 계정입니다."),
-
-    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH40005", "유효하지 않은 인가 코드입니다."),
-    INVALID_APPLE_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH40006", "유효하지 않은 Apple ID Token 입니다."),
-    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH40007", "유효하지 않은 소셜 로그인 제공자입니다."),
-    INVALID_APPLE_CLIENT_SETTING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50003", "Apple Client 설정값이 유효하지 않습니다."),
-    APPLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50004", "ID Token 또는 JWKs 파싱에 실패했습니다."),
 
     // 감정 관련 에러
     KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD40401", "감정키워드가 존재하지 않습니다."),
@@ -130,8 +111,27 @@ public enum ErrorStatus implements BaseErrorCode {
     // 플라스크 관련 에러
     FLASK_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLASK50001", "Flask API 호출에 실패하였습니다."),
 
-    // 탈퇴 관련 에러
-    WITHDRAWAL_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "WITHDRAWAL40401", "존재하지 않는 탈퇴 사유입니다."),
+    // 챌린지 관련 에러
+    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE40001", "챌린지는 3개까지 저장 가능합니다."),
+    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE40002", "최소 하나의 챌린지를 선택해야 합니다."),
+    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40003", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),
+    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40004", "랜덤 챌린지는 최대 1개만 저장 가능합니다."),
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40401", "챌린지를 찾을 수 없습니다."),
+    RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40402", "연관된 챌린지가 없습니다."),
+
+    // 사용자 챌린지 관련 에러
+    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC40001", "완료된 챌린지는 삭제가 불가합니다"),
+    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC40002", "이미 완료된 챌린지입니다."),
+    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC40003", "챌린지 인증이 완료되지 않았습니다."),
+    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC40004", "챌린지 인증 내역에 수정사항이 없습니다."),
+    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC40005", "하루에 10번만 인증이 가능합니다."),
+    USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC40401", "사용자 챌린지가 존재하지 않습니다"),
+
+    // S3 관련 에러
+    S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S340001", "파일 확장자가 잘못되었습니다."),
+    S3_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340002", "파일 이름은 필수입니다."),
+    S3_FOLDER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340003", "폴더 이름은 필수입니다."),
+    S3_INVALID_FOLDER_NAME(HttpStatus.BAD_REQUEST, "S340004", "폴더명은 영어로 입력해야 합니다."),
 
     ;
 

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -18,125 +18,122 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     //멤버 관련 에러
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호 확인이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER4002", "이메일 또는 패스워드가 일치하지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003", "이미 존재하는 이메일입니다."),
-    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER4004", "탈퇴한 회원입니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER40001", "비밀번호 확인이 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER40102", "이메일 또는 패스워드가 일치하지 않습니다."),
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER40304", "탈퇴한 회원입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER40903", "이미 존재하는 이메일입니다."),
 
     //사용자 챌린지 관련 에러
-    USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC4001", "사용자 챌린지가 존재하지 않습니다"),
-    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC4002", "완료된 챌린지는 삭제가 불가합니다"),
-    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC4003", "이미 완료된 챌린지입니다."),
-    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC4004", "챌린지 인증이 완료되지 않았습니다."),
-    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC4005", "챌린지 인증 내역에 수정사항이 없습니다."),
-    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC4006", "하루에 10번만 인증이 가능합니다."),
+    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC40001", "완료된 챌린지는 삭제가 불가합니다"),
+    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC40002", "이미 완료된 챌린지입니다."),
+    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC40003", "챌린지 인증이 완료되지 않았습니다."),
+    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC40004", "챌린지 인증 내역에 수정사항이 없습니다."),
+    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC40005", "하루에 10번만 인증이 가능합니다."),
+    USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC40401", "사용자 챌린지가 존재하지 않습니다"),
 
     //약관 관련 에러
-    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "존재하지 않는 약관을 요청했습니다."),
-    MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4002", "필수 약관에 반드시 동의해야 합니다."),
-    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM4003", "전체 약관 정보를 주세요."),
+    MANDATORY_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40001", "필수 약관에 반드시 동의해야 합니다."),
+    ALL_TERMS_REQUIRED(HttpStatus.BAD_REQUEST, "TERM40002", "전체 약관 정보를 주세요."),
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM40401", "존재하지 않는 약관을 요청했습니다."),
 
     //인증 관련 에러
-    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH4001", "이메일 인증을 완료해주세요."),
-    INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "AUTH4002", "이메일 인증 타입이 잘못되었습니다."),
-    AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4003", "유효한 인증번호가 없습니다."),
-    AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH4004", "인증번호가 올바르지 않습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH40001", "이메일 인증을 완료해주세요."),
+    INVALID_AUTH_TYPE(HttpStatus.BAD_REQUEST, "AUTH40002", "이메일 인증 타입이 잘못되었습니다."),
+    AUTH_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH40003", "유효한 인증번호가 없습니다."),
+    AUTH_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH40004", "인증번호가 올바르지 않습니다."),
 
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4012", "만료된 토큰입니다. 토큰의 만료 시간이 지나 더 이상 유효하지 않습니다."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4013", "지원하지 않는 토큰입니다. 서버가 처리할 수 없는 형식의 토큰입니다."),
-    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4014", "손상된 토큰입니다. 토큰 구조가 올바르지 않거나, 일부 데이터가 손실되었습니다."),
-    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4015", "토큰이 제공되지 않았습니다."),
-    INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH4016", "잘못된 토큰 형식입니다. 토큰이 Base64 URL 인코딩 규칙을 따르지 않거나, 토큰 내부 JSON 구조가 잘못 되었습니다."),
-    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4017", "토큰의 서명이 올바르지 않습니다. 서명이 서버에서 사용하는 비밀키와 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40101", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40102", "만료된 토큰입니다. 토큰의 만료 시간이 지나 더 이상 유효하지 않습니다."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40103", "지원하지 않는 토큰입니다. 서버가 처리할 수 없는 형식의 토큰입니다."),
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40104", "손상된 토큰입니다. 토큰 구조가 올바르지 않거나, 일부 데이터가 손실되었습니다."),
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH40105", "토큰이 제공되지 않았습니다."),
+    INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH40106", "잘못된 토큰 형식입니다. 토큰이 Base64 URL 인코딩 규칙을 따르지 않거나, 토큰 내부 JSON 구조가 잘못 되었습니다."),
+    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH40107", "토큰의 서명이 올바르지 않습니다. 서명이 서버에서 사용하는 비밀키와 일치하지 않습니다."),
 
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4020", "데이터베이스에서 refreshToken을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH40401", "데이터베이스에서 refreshToken을 찾을 수 없습니다."),
 
-    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "이메일 전송에 실패했습니다."),
-    EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "이메일 내용 인코딩에 실패했습니다."),
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50001", "이메일 전송에 실패했습니다."),
+    EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50002", "이메일 내용 인코딩에 실패했습니다."),
 
     // 챌린지 관련 에러
-    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE4001", "챌린지를 찾을 수 없습니다."),
-    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "챌린지는 3개까지 저장 가능합니다."),
-    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "최소 하나의 챌린지를 선택해야 합니다."),
-    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),
-    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "랜덤 챌린지는 최대 1개만 저장 가능합니다."),
-    RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE5001", "연관된 챌린지가 없습니다."),
+    CHALLENGE_SAVE_LIMIT(HttpStatus.BAD_REQUEST, "CHALLENGE40001", "챌린지는 3개까지 저장 가능합니다."),
+    CHALLENGE_AT_LEAST(HttpStatus.BAD_REQUEST, "CHALLENGE40002", "최소 하나의 챌린지를 선택해야 합니다."),
+    CHALLENGE_DAILY_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40003", "데일리 챌린지는 최대 2개까지 저장 가능합니다."),
+    CHALLENGE_RANDOM_MAX(HttpStatus.BAD_REQUEST, "CHALLENGE40004", "랜덤 챌린지는 최대 1개만 저장 가능합니다."),
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40401", "챌린지를 찾을 수 없습니다."),
+    RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40402", "연관된 챌린지가 없습니다."),
 
     //기타 에러
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD4001", "비밀번호 확인이 일치하지 않습니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "PWD40001", "비밀번호 확인이 일치하지 않습니다."),
 
     // 아이템 관련 에러
-    ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM4001", "아이템을 찾을 수 없습니다."),
-    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM4002", "보유하지 않은 아이템입니다."),
-    ITEM_OWNED(HttpStatus.BAD_REQUEST, "ITEM4003", "이미 보유 중인 아이템입니다."),
-    ITEM_ALREADY_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM4004", "이미 착용중인 아이템입니다."),
-    ITEM_NOT_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM4005", "착용중인 아이템이 아닙니다."),
+    ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM40001", "아이템을 찾을 수 없습니다."),
+    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM40002", "보유하지 않은 아이템입니다."),
+    ITEM_OWNED(HttpStatus.BAD_REQUEST, "ITEM40003", "이미 보유 중인 아이템입니다."),
+    ITEM_ALREADY_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM40004", "이미 착용중인 아이템입니다."),
+    ITEM_NOT_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM40005", "착용중인 아이템이 아닙니다."),
 
     // 사용자 아이템 관련 에러
-    EQUIPPED_USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI4001", "착용 중인 사용자 아이템이 존재하지 않습니다."),
+    EQUIPPED_USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI40401", "착용 중인 사용자 아이템이 존재하지 않습니다."),
 
     //결제 관련 에러
-    PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT4001", "결제정보가 정확하지 않습니다."),
+    PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT40001", "결제정보가 정확하지 않습니다."),
 
     // 크레딧 관련 에러
-    CREDIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CREDIT4001", "크레딧 정보를 찾을 수 없습니다."),
-    INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "CREDIT4002", "보유 크레딧이 부족합니다."),
+    CREDIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CREDIT40001", "크레딧 정보를 찾을 수 없습니다."),
+    INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "CREDIT40002", "보유 크레딧이 부족합니다."),
 
     // 날짜 관련 에러
-    DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE4001", "유효하지 않은 날짜입니다."),
-    DATE_IS_AFTER(HttpStatus.BAD_REQUEST, "DATE4002", "날짜는 오늘 이후로 설정할 수 없습니다."),
+    DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE40001", "유효하지 않은 날짜입니다."),
+    DATE_IS_AFTER(HttpStatus.BAD_REQUEST, "DATE40002", "날짜는 오늘 이후로 설정할 수 없습니다."),
 
     //그로 관련
-    GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO4001", "다른 닉네임과 중복되는 닉네임입니다."),
-    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "GRO4002", "닉네임은 2~8자 이내로 작성해야 합니다."),
-    GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO4003", "그로에 대한 정보가 존재하지 않습니다."),
-    GRO_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO4001", "사용자의 그로가 이미 존재합니다."),
-    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO4004", "그로의 닉네임에 수정사항이 없습니다."),
-    GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO5001", "그로 레벨이 유효하지 않습니다."),
+    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "GRO40001", "닉네임은 2~8자 이내로 작성해야 합니다."),
+    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO40002", "그로의 닉네임에 수정사항이 없습니다."),
+    GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO40401", "그로에 대한 정보가 존재하지 않습니다."),
+    GRO_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40901", "사용자의 그로가 이미 존재합니다."),
+    GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40902", "다른 닉네임과 중복되는 닉네임입니다."),
+    GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO50001", "그로 레벨이 유효하지 않습니다."),
 
     //일기 관련 에러
-    DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "존재하지 않는 일기입니다."),
-    DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY4002", "100자 이내로 작성된 일기입니다."),
-    DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY4003", "해당날짜에 이미 일기가 존재합니다."),
-    DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY4004", "기존 일기와 동일한 내용입니다."),
-    ANALYZED_DIARY(HttpStatus.BAD_REQUEST, "DIARY4005", "이미 분석된 일기입니다."),
+    DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY40001", "존재하지 않는 일기입니다."),
+    DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY40002", "100자 이내로 작성된 일기입니다."),
+    DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY40003", "해당날짜에 이미 일기가 존재합니다."),
+    DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY40004", "기존 일기와 동일한 내용입니다."),
+    ANALYZED_DIARY(HttpStatus.BAD_REQUEST, "DIARY40005", "이미 분석된 일기입니다."),
 
     // S3 관련 에러
-    S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S34001", "파일 확장자가 잘못되었습니다."),
-    S3_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S34002", "파일 이름은 필수입니다."),
-    S3_FOLDER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S34003", "폴더 이름은 필수입니다."),
-    S3_INVALID_FOLDER_NAME(HttpStatus.BAD_REQUEST, "S34004", "폴더명은 영어로 입력해야 합니다."),
+    S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S340001", "파일 확장자가 잘못되었습니다."),
+    S3_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340002", "파일 이름은 필수입니다."),
+    S3_FOLDER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340003", "폴더 이름은 필수입니다."),
+    S3_INVALID_FOLDER_NAME(HttpStatus.BAD_REQUEST, "S340004", "폴더명은 영어로 입력해야 합니다."),
 
     // OAuth 관련 에러
-    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH4001", "이미 가입한 소셜 계정입니다."),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH4002", "존재하지 않는 계정입니다."),
-    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH4003", "요청한 이메일로 가입할 수 없습니다."),
-    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH4030", "유효하지 않은 인가 코드입니다."),
-    INVALID_APPLE_CLIENT_SETTING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "Apple Client 설정값이 유효하지 않습니다."),
-    INVALID_APPLE_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4032", "유효하지 않은 Apple ID Token 입니다."),
-    APPLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "ID Token 또는 JWKs 파싱에 실패했습니다."),
-    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH4033", "유효하지 않은 소셜 로그인 제공자입니다."),
+    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH40003", "요청한 이메일로 가입할 수 없습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH40402", "존재하지 않는 계정입니다."),
+    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH40901", "이미 가입한 소셜 계정입니다."),
+
+    INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH40005", "유효하지 않은 인가 코드입니다."),
+    INVALID_APPLE_ID_TOKEN(HttpStatus.BAD_REQUEST, "AUTH40006", "유효하지 않은 Apple ID Token 입니다."),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH40007", "유효하지 않은 소셜 로그인 제공자입니다."),
+    INVALID_APPLE_CLIENT_SETTING(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50003", "Apple Client 설정값이 유효하지 않습니다."),
+    APPLE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50004", "ID Token 또는 JWKs 파싱에 실패했습니다."),
 
     // 감정 관련 에러
-    KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD5001", "감정키워드가 존재하지 않습니다."),
+    KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD40401", "감정키워드가 존재하지 않습니다."),
 
     // GPT 관련 에러
-    GPT_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5001", "GPT 응답이 비어있습니다. 다시 시도해 주세요."),
-    EMOTIONS_COUNT_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5002", "GPT 응답에서 감정의 개수는 3개여야 합니다."),
-    EMOTIONS_DUPLICATE(HttpStatus.INTERNAL_SERVER_ERROR, "GPT5003", "GPT 응답에서 중복된 감정이 존재합니다."),
+    GPT_RESPONSE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "GPT50001", "GPT 응답이 비어있습니다. 다시 시도해 주세요."),
+    EMOTIONS_COUNT_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GPT50002", "GPT 응답에서 감정의 개수는 3개여야 합니다."),
+    EMOTIONS_DUPLICATE(HttpStatus.INTERNAL_SERVER_ERROR, "GPT50003", "GPT 응답에서 중복된 감정이 존재합니다."),
 
     // 플라스크 관련 에러
-    FLASK_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLASK5001", "Flask API 호출에 실패하였습니다."),
+    FLASK_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FLASK50001", "Flask API 호출에 실패하였습니다."),
 
     // 탈퇴 관련 에러
-    WITHDRAWAL_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "WITHDRAWAL4001", "존재하지 않는 탈퇴 사유입니다."),
-
-
-
+    WITHDRAWAL_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "WITHDRAWAL40401", "존재하지 않는 탈퇴 사유입니다."),
 
     ;
-
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -128,9 +128,6 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // S3 관련 에러
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S340001", "파일 확장자가 잘못되었습니다."),
-    S3_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340002", "파일 이름은 필수입니다."),
-    S3_FOLDER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "S340003", "폴더 이름은 필수입니다."),
-    S3_INVALID_FOLDER_NAME(HttpStatus.BAD_REQUEST, "S340004", "폴더명은 영어로 입력해야 합니다."),
 
     ;
 

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -19,9 +19,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 멤버 관련 에러
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER40001", "비밀번호 확인이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER40102", "이메일 또는 패스워드가 일치하지 않습니다."),
-    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER40304", "탈퇴한 회원입니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER40903", "이미 존재하는 이메일입니다."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER40101", "이메일 또는 패스워드가 일치하지 않습니다."),
+    USER_STATUS_INACTIVE(HttpStatus.FORBIDDEN, "USER40301", "탈퇴한 회원입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER40901", "이미 존재하는 이메일입니다."),
 
     // 인증 관련 에러
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH40001", "이메일 인증을 완료해주세요."),
@@ -43,8 +43,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_ENCODING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH50002", "이메일 내용 인코딩에 실패했습니다."),
 
     // OAuth 관련 에러
-    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH40003", "요청한 이메일로 가입할 수 없습니다."),
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH40402", "존재하지 않는 계정입니다."),
+    ACCOUNT_BAD_REQUEST(HttpStatus.BAD_REQUEST, "OAUTH40001", "요청한 이메일로 가입할 수 없습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "OAUTH40401", "존재하지 않는 계정입니다."),
     ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "OAUTH40901", "이미 가입한 소셜 계정입니다."),
 
     INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "AUTH40005", "유효하지 않은 인가 코드입니다."),

--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -65,19 +65,18 @@ public enum ErrorStatus implements BaseErrorCode {
     WITHDRAWAL_REASON_NOT_FOUND(HttpStatus.NOT_FOUND, "WITHDRAWAL40401", "존재하지 않는 탈퇴 사유입니다."),
 
     // 그로 관련 에러
-    GRO_NICKNAME_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "GRO40001", "닉네임은 2~8자 이내로 작성해야 합니다."),
-    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO40002", "그로의 닉네임에 수정사항이 없습니다."),
+    GRO_NICKNAME_UPDATE_NO_CHANGE(HttpStatus.BAD_REQUEST, "GRO40001", "그로의 닉네임에 수정사항이 없습니다."),
     GRO_NOT_FOUND(HttpStatus.NOT_FOUND, "GRO40401", "그로에 대한 정보가 존재하지 않습니다."),
     GRO_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40901", "사용자의 그로가 이미 존재합니다."),
     GRO_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "GRO40902", "다른 닉네임과 중복되는 닉네임입니다."),
     GRO_LEVEL_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "GRO50001", "그로 레벨이 유효하지 않습니다."),
 
     // 아이템 관련 에러
-    ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEM40001", "아이템을 찾을 수 없습니다."),
-    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM40002", "보유하지 않은 아이템입니다."),
-    ITEM_OWNED(HttpStatus.BAD_REQUEST, "ITEM40003", "이미 보유 중인 아이템입니다."),
-    ITEM_ALREADY_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM40004", "이미 착용중인 아이템입니다."),
-    ITEM_NOT_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM40005", "착용중인 아이템이 아닙니다."),
+    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "ITEM40001", "보유하지 않은 아이템입니다."),
+    ITEM_NOT_EQUIPPED(HttpStatus.BAD_REQUEST, "ITEM40002", "착용중인 아이템이 아닙니다."),
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM40401", "아이템을 찾을 수 없습니다."),
+    ITEM_ALREADY_EQUIPPED(HttpStatus.CONFLICT, "ITEM40901", "이미 착용중인 아이템입니다."),
+    ITEM_OWNED(HttpStatus.CONFLICT, "ITEM40902", "이미 보유중인 아이템입니다."),
 
     // 사용자 아이템 관련 에러
     EQUIPPED_USER_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "UI40401", "착용 중인 사용자 아이템이 존재하지 않습니다."),
@@ -86,19 +85,19 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "PAYMENT40001", "결제정보가 정확하지 않습니다."),
 
     // 크레딧 관련 에러
-    CREDIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CREDIT40001", "크레딧 정보를 찾을 수 없습니다."),
-    INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "CREDIT40002", "보유 크레딧이 부족합니다."),
+    INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "CREDIT40001", "보유 크레딧이 부족합니다."),
+    CREDIT_NOT_FOUND(HttpStatus.NOT_FOUND, "CREDIT40401", "크레딧 정보를 찾을 수 없습니다."),
 
     // 날짜 관련 에러
     DATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "DATE40001", "유효하지 않은 날짜입니다."),
     DATE_IS_AFTER(HttpStatus.BAD_REQUEST, "DATE40002", "날짜는 오늘 이후로 설정할 수 없습니다."),
 
     // 일기 관련 에러
-    DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY40001", "존재하지 않는 일기입니다."),
-    DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY40002", "100자 이내로 작성된 일기입니다."),
-    DIARY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "DIARY40003", "해당날짜에 이미 일기가 존재합니다."),
-    DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY40004", "기존 일기와 동일한 내용입니다."),
-    ANALYZED_DIARY(HttpStatus.BAD_REQUEST, "DIARY40005", "이미 분석된 일기입니다."),
+    DIARY_CHARACTER_LIMIT(HttpStatus.BAD_REQUEST, "DIARY40001", "100자 이내로 작성된 일기입니다."),
+    DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY40002", "기존 일기와 동일한 내용입니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY40401", "존재하지 않는 일기입니다."),
+    DIARY_ALREADY_EXISTS(HttpStatus.CONFLICT, "DIARY40901", "해당날짜에 이미 일기가 존재합니다."),
+    ANALYZED_DIARY(HttpStatus.CONFLICT, "DIARY40902", "이미 분석된 일기입니다."),
 
     // 감정 관련 에러
     KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD40401", "감정키워드가 존재하지 않습니다."),
@@ -120,12 +119,12 @@ public enum ErrorStatus implements BaseErrorCode {
     RELATED_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE40402", "연관된 챌린지가 없습니다."),
 
     // 사용자 챌린지 관련 에러
-    USER_CHALLENGE_COMPLETE(HttpStatus.BAD_REQUEST, "UC40001", "완료된 챌린지는 삭제가 불가합니다"),
-    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.BAD_REQUEST, "UC40002", "이미 완료된 챌린지입니다."),
-    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC40003", "챌린지 인증이 완료되지 않았습니다."),
-    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC40004", "챌린지 인증 내역에 수정사항이 없습니다."),
-    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC40005", "하루에 10번만 인증이 가능합니다."),
+    USER_CHALLENGE_NOT_PROVED(HttpStatus.BAD_REQUEST, "UC40001", "챌린지 인증이 완료되지 않았습니다."),
+    USER_CHALLENGE_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "UC40002", "챌린지 인증 내역에 수정사항이 없습니다."),
+    USER_CHALLENGE_PROVED_LIMIT(HttpStatus.BAD_REQUEST, "UC40003", "하루에 10번만 인증이 가능합니다."),
     USER_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "UC40401", "사용자 챌린지가 존재하지 않습니다"),
+    USER_CHALLENGE_COMPLETE(HttpStatus.CONFLICT, "UC40901", "완료된 챌린지는 삭제가 불가합니다"),
+    USER_CHALLENGE_ALREADY_PROVED(HttpStatus.CONFLICT, "UC40902", "이미 완료된 챌린지입니다."),
 
     // S3 관련 에러
     S3_BAD_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "S340001", "파일 확장자가 잘못되었습니다."),

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -14,7 +14,6 @@ import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.AuthType;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthRequestDTO;
 import umc.GrowIT.Server.web.dto.AuthDTO.AuthResponseDTO;
-import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthApiResponseDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthRequestDTO;
 import umc.GrowIT.Server.web.dto.OAuthDTO.OAuthResponseDTO;
 import umc.GrowIT.Server.web.dto.TokenDTO.TokenRequestDTO;
@@ -28,12 +27,12 @@ public interface AuthSpecification {
     @Operation(summary = "이메일 회원가입 API", description = "약관 목록 입력할 때 termId 1~6 입력해 주세요. (termId 1~4는 필수 동의 항목입니다.)", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4001", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM4001", description = "❌ 존재하지 않는 약관을 요청했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM4002", description = "❌ 필수 약관에 반드시 동의해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM4003", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 회원가입 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 회원가입 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40001", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40903", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40001", description = "❌ 필수 약관에 반드시 동의해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40002", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40401", description = "❌ 존재하지 않는 약관을 요청했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.LoginResponseDTO> signupEmail(@RequestBody @Valid UserRequestDTO.UserInfoDTO userInfoDTO);
 
@@ -41,9 +40,9 @@ public interface AuthSpecification {
     @Operation(summary = "이메일 로그인 API", description = "이메일 로그인 API 입니다. AccessToken, RefreshToken 이 모두 만료되어 토큰 재발급 API 에서 AccessToken 재발급이 불가능하면 로그인 화면으로 이동합니다.", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 로그인 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 로그인 입력 형식이 맞지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.LoginResponseDTO> loginEmail(@RequestBody @Valid UserRequestDTO.EmailLoginDTO emailLoginDTO);
 
@@ -51,9 +50,9 @@ public interface AuthSpecification {
     @Operation(summary = "토큰 재발급 API", description = "AccessToken 이 만료되었다는 401 에러 발생 시 토큰 재발급을 요청하는 API 입니다. 로그인 또는 회원가입 시 얻은 RefreshToken 을 Request Body 에 담아 요청해 주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4002", description = "❌ 만료된 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4007", description = "❌ 데이터베이스에서 refreshToken을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40102", description = "❌ 만료된 토큰입니다. 토큰의 만료 시간이 지나 더 이상 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40401", description = "❌ 데이터베이스에서 refreshToken을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<TokenResponseDTO.AccessTokenDTO> reissueToken(@RequestBody @Valid TokenRequestDTO.ReissueDTO reissueDTO);
 
@@ -61,12 +60,12 @@ public interface AuthSpecification {
     @Operation(summary = "인증 메일 전송 API", description = "사용자에게 인증 메일을 전송하는 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4003", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4006", description = "❌ 이메일 인증 타입이 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH5001", description = "❌ 이메일 전송에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH5002", description = "❌ 이메일 내용 인코딩에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40901", description = "❌ 이미 존재하는 이메일입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40002", description = "❌ 이메일 인증 타입이 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH50001", description = "❌ 이메일 전송에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH50002", description = "❌ 이메일 내용 인코딩에 실패했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.SendAuthEmailResponseDTO> sendAuthEmail(
             @RequestParam AuthType type,
@@ -77,9 +76,9 @@ public interface AuthSpecification {
     @Operation(summary = "인증 번호 확인 API", description = "사용자가 입력한 인증 번호를 확인하는 API 입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4007", description = "❌ 유효한 인증번호가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4008", description = "❌ 인증번호가 올바르지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40003", description = "❌ 유효한 인증번호가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40004", description = "❌ 인증번호가 올바르지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.VerifyAuthCodeResponseDTO> verifyAuthCode(@RequestBody @Valid AuthRequestDTO.VerifyAuthCodeRequestDTO request);
 
@@ -87,8 +86,8 @@ public interface AuthSpecification {
     @Operation(summary = "카카오 소셜 로그인", description = "카카오 소셜 로그인 API 입니다.", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4030", description = "❌ 인가 코드가 유효한지 확인하세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40005", description = "❌ 유효하지 않은 인가 코드입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<OAuthResponseDTO.OAuthLoginDTO> loginKakao(OAuthRequestDTO.SocialLoginDTO socialLoginDTO);
 
@@ -96,8 +95,8 @@ public interface AuthSpecification {
     @Operation(summary = "애플 소셜 로그인", description = "애플 소셜 로그인 API 입니다.", security = @SecurityRequirement(name = ""))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4031", description = "❌ 인가 코드가 유효한지 확인하세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40005", description = "❌ 유효하지 않은 인가 코드입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<OAuthResponseDTO.OAuthLoginDTO> loginApple(OAuthRequestDTO.SocialLoginDTO socialLoginDTO);
 
@@ -105,11 +104,11 @@ public interface AuthSpecification {
     @Operation(summary = "소셜 간편 가입", description = "소셜 로그인 시 계정이 존재하지 않을 때 약관 목록으로 간편 가입을 진행하는 API 입니다. (termId 1~4는 필수 동의 항목입니다.)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH_4001", description = "❌ 이미 가입한 소셜 계정입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH_4003", description = "❌ 요청한 이메일로 가입할 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM_4001", description = "❌ 존재하지 않는 약관을 요청했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM_4002", description = "❌ 필수 약관에 반드시 동의해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM4003", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH40001", description = "❌ 요청한 이메일로 가입할 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "OAUTH40901", description = "❌ 이미 가입한 소셜 계정입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40001", description = "❌ 필수 약관에 반드시 동의해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40002", description = "❌ 전체 약관 정보를 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TERM40401", description = "❌ 존재하지 않는 약관을 요청했습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.LoginResponseDTO> signupSocial(@RequestBody @Valid OAuthRequestDTO.OAuthUserInfoAndUserTermsDTO oAuthUserInfoAndUserTermsDTO);
 
@@ -117,11 +116,11 @@ public interface AuthSpecification {
     @Operation(summary = "로그아웃 API", description = "사용자 로그아웃을 처리하는 API입니다. AccessToken을 무효화하고 RefreshToken을 삭제합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4011", description = "❌ 유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4012", description = "❌ 만료된 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4015", description = "❌ 토큰이 제공되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40101", description = "❌ 유효하지 않은 토큰입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40102", description = "❌ 만료된 토큰입니다. 토큰의 만료 시간이 지나 더 이상 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40105", description = "❌ 토큰이 제공되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<AuthResponseDTO.LogoutResponseDTO> logout();
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -54,11 +54,12 @@ public interface ChallengeSpecification {
             "데일리챌린지는 최대 2개까지 저장할 수 있으며, 랜덤챌린지는 최대 1개까지 저장할 수 있습니다. <br> ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4001", description = "❌ 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4004", description = "❌ 최소 하나의 챌린지를 선택해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4005", description = "❌ 데일리 챌린지는 최대 2개까지 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE4006", description = "❌ 랜덤 챌린지는 최대 1개만 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40001", description = "❌ 챌린지는 3개까지 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40002", description = "❌ 최소 하나의 챌린지를 선택해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40003", description = "❌ 데일리 챌린지는 최대 2개까지 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40004", description = "❌ 랜덤 챌린지는 최대 1개만 저장 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40401", description = "❌ 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ChallengeResponseDTO.SelectChallengeResponseDTO> selectChallenges(@RequestBody List<ChallengeRequestDTO.SelectChallengeRequestDTO> selectRequestList);
 
@@ -66,7 +67,7 @@ public interface ChallengeSpecification {
     @Operation(summary = "사용자 챌린지 인증 이미지 업로드용 presigned url 생성 API", description = "사용자 챌린지 인증 이미지를 S3에 직접 업로드할 수 있는 presigned url을 생성합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "S34001", description = "❌ 파일 확장자가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "S340001", description = "❌ 파일 확장자가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ChallengeResponseDTO.ProofPresignedUrlResponseDTO> getProofPresignedUrl(@Valid @RequestBody ChallengeRequestDTO.ProofRequestPresignedUrlDTO request);
 
@@ -76,10 +77,10 @@ public interface ChallengeSpecification {
             "presigned url 생성 시 반환된 파일명을 certificationImageName으로 넘겨주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4003", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4006", description = "❌ 하루에 10번만 인증이 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40003", description = "❌ 하루에 10번만 인증이 가능합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40401", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40902", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 작성할 사용자 챌린지의 ID", example = "1")
     ApiResponse<Void> createChallengeProof(@PathVariable Long userChallengeId,
@@ -90,8 +91,9 @@ public interface ChallengeSpecification {
             "사용자 챌린지 ID를 path variable로 전달받아 해당 사용자 챌린지의 인증 내역을 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4004", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40001", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40401", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 내역을 조회할 사용자 챌린지의 ID", example = "1")
     ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long userChallengeId);
@@ -102,10 +104,10 @@ public interface ChallengeSpecification {
             "presigned url 생성 시 반환된 파일명을 certificationImage로 넘겨주세요. ")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4004", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4005", description = "❌ 챌린지 인증 내역에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40001", description = "❌ 챌린지 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40002", description = "❌ 챌린지 인증 내역에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40401", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 내역을 수정할 사용자 챌린지의 ID", example = "1")
     ApiResponse<Void> updateChallengeProof(@PathVariable Long userChallengeId,
@@ -120,11 +122,10 @@ public interface ChallengeSpecification {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4001", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC4002", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40401", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC40901", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", example = "1")
     ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -16,8 +16,8 @@ public interface DiarySpecification {
     @Operation(summary = "일기 작성 날짜 조회 API",description = "특정 사용자의 일기 메인 화면에서 사용할 월별 일기 기록한 날짜를 보여주기 위한 API입니다. Query String으로 year와 month를 주세요." +
             "ex)2025년 9월을 넘겨주면 해당 월에 기록한 일기들의 날짜 정보와 해당 일기의 id를 보내줍니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE40001", description = "❌ 유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(
             @Parameter(description = "일기 작성 연도",
@@ -28,8 +28,8 @@ public interface DiarySpecification {
     @GetMapping("/")
     @Operation(summary = "일기 모아보기 API",description = "특정 사용자가 작성한 일기를 모아보는 API입니다. query string으로 year와 month를 넘겨주면 해당 월에 작성한 일기들의 리스트, 작성한 일기 수를 보내줍니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4001", description = "유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE40001", description = "❌ 유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(
             @Parameter(description = "일기 작성 연도",
@@ -40,8 +40,8 @@ public interface DiarySpecification {
     @GetMapping("/{diaryId}")
     @Operation(summary = "특정 일기 조회 API",description = "특정 사용자가 작성한 특정 일기를 조회하는 API입니다. path variable로 일기의 id를 넘겨주면 해당 일기의 세부적인 내용을 보내줍니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40401", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "조회할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId);
@@ -49,10 +49,10 @@ public interface DiarySpecification {
     @PatchMapping("/{diaryId}")
     @Operation(summary = "일기 수정하기 API",description = "특정 사용자가 작성한 일기를 수정하는 API입니다. path variable로 일기의 id, RequestBody로 수정한 내용과 수정 시간을 보내주세요")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004",description = "기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40401", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40002",description = "❌ 기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "수정할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
@@ -60,8 +60,8 @@ public interface DiarySpecification {
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40401", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "삭제할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId);
@@ -69,23 +69,23 @@ public interface DiarySpecification {
     @PostMapping("/text")
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE4002",description = "날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE40002",description = "❌ 날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
     @PostMapping("/voice")
     @Operation(summary = "음성 대화하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용(STT)을 보내주세요")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
     })
     ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request);
 
     @PostMapping("/summary")
     @Operation(summary = "음성대화 종료 및 요약 후 일기 생성 API",description = "음성 대화를 종료하면서 음성 대화하기 API를 사용하여 대화한 내용을 바탕으로 그 날의 일기를 작성해주는 API입니다. 작성 날짜를 보내주세요.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
     })
     ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request);
 
@@ -98,15 +98,15 @@ public interface DiarySpecification {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "❌ 존재하지 않는 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4005", description = "❌ 이미 분석된 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT5003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FLASK5001", description = "❌ Flask API 호출에 실패하였습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD5001", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE5001", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40401", description = "❌ 존재하지 않는 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY40902", description = "❌ 이미 분석된 일기입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT50001", description = "❌ GPT 응답이 비어있습니다. 다시 시도해 주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT50002", description = "❌ GPT 응답에서 감정의 개수는 3개여야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GPT50003", description = "❌ GPT 응답에서 중복된 감정이 존재합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FLASK50001", description = "❌ Flask API 호출에 실패하였습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "KEYWORD40401", description = "❌ 감정키워드가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHALLENGE40402", description = "❌ 연관된 챌린지가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "분석할 일기의 ID", example = "1")
     ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary(@PathVariable("diaryId") Long diaryId);

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
@@ -18,20 +18,9 @@ public interface GroSpecification {
     @PostMapping("")
     @Operation(summary = "그로 캐릭터 생성", description = "사용자의 그로 캐릭터를 생성합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "COMMON200",
-                    description = "⭕ SUCCESS"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "GRO4001",
-                    description = "❌ 다른 닉네임과 중복되는 닉네임입니다.",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "COMMON400",
-                    description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.",
-                    content = @Content(schema = @Schema(implementation = ApiResponse.class))
-            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO40902", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@Valid @RequestBody GroRequestDTO.CreateRequestDTO request);
 
@@ -42,12 +31,11 @@ public interface GroSpecification {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4003", description = "❌ 그로에 대한 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UI4001", description = "❌ 착용 중인 사용자 아이템이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO5001", description = "❌ 그로 레벨이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO40401", description = "❌ 그로에 대한 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO50001", description = "❌ 그로 레벨이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UI40401", description = "❌ 착용 중인 사용자 아이템이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems();
 
@@ -55,9 +43,9 @@ public interface GroSpecification {
     @Operation(summary = "그로 닉네임 변경", description = "그로의 닉네임을 변경합니다. 닉네임을 2~8자 사이로 입력해주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4001", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO4004", description = "❌ 그로의 닉네임에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO40902", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO40001", description = "❌ 그로의 닉네임에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> updateNickname(@Valid @RequestBody GroRequestDTO.NicknameRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
@@ -33,8 +33,8 @@ public interface ItemSpecification {
             "착용하려면 EQUIPPED를, 해제하려면 UNEQUIPPED를 전달하세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4004", description = "❌ 이미 착용중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4005", description = "❌ 착용중인 아이템이 아닙니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM40002", description = "❌ 착용중인 아이템이 아닙니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM40901", description = "❌ 이미 착용중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ItemEquipResponseDTO> updateItemStatus(
             @Parameter(description = "아이템 ID", example = "1")
@@ -54,11 +54,11 @@ public interface ItemSpecification {
     @Operation(summary = "아이템 구매 API", description = "특정 아이템을 구매하는 API입니다. 아이템 ID를 path variable로 전달받아 해당 아이템을 주문합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4001", description = "❌ 아이템을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM4003", description = "❌ 이미 보유 중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT4002", description = "❌ 보유 크레딧이 부족합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM40401", description = "❌ 아이템을 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM40902", description = "❌ 이미 보유 중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT40001", description = "❌ 보유 크레딧이 부족합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "itemId", description = "주문할 아이템의 ID", required = true)
     ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(@PathVariable("itemId") Long itemId);

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -35,7 +35,7 @@ public interface UserSpecification {
     @Operation(summary = "현재 보유중인 크레딧 조회", description = "사용자가 현재 보유한 크레딧 조회")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "❌ 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit();
 
@@ -43,7 +43,7 @@ public interface UserSpecification {
     @Operation(summary = "누적 크레딧 조회", description = "사용자의 누적 크레딧을 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT4001", description = "❌ 크레딧 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT40401", description = "❌ 크레딧 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit();
 
@@ -52,7 +52,7 @@ public interface UserSpecification {
     @Operation(summary = "크레딧 구매", description = "결제를 통해 크레딧을 구매합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAYMENT4001", description = "❌ 결제정보가 정확하지않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAYMENT40001", description = "❌ 결제정보가 정확하지않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<PaymentResponseDTO> purchaseCredits(@RequestBody PaymentRequestDTO request);
 
@@ -60,10 +60,10 @@ public interface UserSpecification {
     @Operation(summary = "비밀번호 변경", description = "", security = @SecurityRequirement(name = "tempToken"))
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4002", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PWD4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH40001", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40301", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PWD40001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
 
@@ -74,9 +74,9 @@ public interface UserSpecification {
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "WITHDRAWAL4001", description = "❌ 존재하지 않는 탈퇴 사유입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "WITHDRAWAL40401", description = "❌ 존재하지 않는 탈퇴 사유입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<Void> withdrawUser(@Valid @RequestBody UserRequestDTO.DeleteUserRequestDTO deleteUserRequestDTO);
 
@@ -84,8 +84,8 @@ public interface UserSpecification {
     @Operation(summary = "마이페이지 조회 API", description = "마이페이지에서 사용자의 정보를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER40101", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<UserResponseDTO.MyPageDTO> getMyPage();
 }


### PR DESCRIPTION
## 📝 작업 내용
기존에는 **ErrorStatus**에서 대부분의 에러 코드가 `DIARY4001`, `DIARY4002`, `CHALLENGE4001`, `CHALLENGE4002 `이런식으로 순서대로 매겨지고 있었습니다.

NOT_FOUND인 경우, UNAUTHORIZED 등 4XX 에러인 경우에는 400X 또는 400XX 식으로 구분없이 처리되고 있었기 때문에
ErrorStatus 컨벤션 참고하여 통일하는 식으로 정리 작업하였습니다!

참고한 부분)
- `BAD_REQUEST`: 400XX
- `UNAUTHORIZED`: 401XX
- `FORBIDDEN`: 403XX
- `NOT_FOUND`: 404XX
- `CONFLICT`: 409XX
- `INTERNAL_SERVER_ERROR`: 500XX

## 👀 참고사항
1) 관련 있는 기능 순 + 그중에서도 에러코드 순으로 정렬하였습니다.
```
공통응답 - 멤버/인증/약관/비밀번호/탈퇴 등 계정 관련 에러 - 그로 - 아이템 - 사용자 아이템 - 결제 - 크레딧 - 날짜 - 일기 - 감정 - GPT - 플라스크 - 챌린지 - 사용자 챌린지 - S3
``` 

2) 500번대 에러는 `INTERNAL_SERVER_ERROR`만 사용되고 있는 것 같지만 400XX처럼 500XX 형식으로 통일하였습니다..ㅎㅎ

질문리스트 😿 
1. 이미 착용 or 보유중인 아이템이면 BAD_REQUEST -> CONFLICT로 수정하는게 맞을까요??
CONFLICT로 통일한 부분
- `USER40901`: "이미 존재하는 이메일입니다."
- `OAUTH40901`: "이미 가입한 소셜 계정입니다."
- `GRO40901`: "사용자의 그로가 이미 존재합니다."
- `ITEM40901`: "이미 착용중인 아이템입니다."
- `DIARY40901`: "해당날짜에 이미 일기가 존재합니다."
- `UC40901`: "완료된 챌린지는 삭제가 불가합니다"
- `UC40902`: "이미 완료된 챌린지입니다."

2. 감정키워드 `KEYWORD_NOT_FOUND`에서 NOT_FOUND에 에러 코드는 500번대가 사용되고 있는데, gpt 분석 관련이니까 500번대로 처리하는게 맞을까여? +연관된 챌린지도 마찬가지
-> 기존 코드에는 NOT_FOUND로 처리되고 있어서 일단은 `KEYWORD5001` -> `KEYWORD40401` 로 수정하였습니다.

3. 수정사항이 없는 경우 422 Unprocessable Entity 상태 코드로 처리가 가능한데, 
요청 자체는 문법적으로 올바르지만 의미적으로 처리 불가능할 때 사용된다고 합니다.
일단은 수정사항이 없는 경우 BAD_REQUEST, 400XX 이런식으로 처리하고 있는데 어떻게 처리하는게 나을까요 ?-?

## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
1. 