### PR TITLE
[#313] Fix: 일기 작성 시  크레딧 미적립 문제 해결

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -86,6 +86,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     }
 
     @Override
+    @Transactional
     public DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId) {
 
         //유저 조회
@@ -191,6 +192,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     }
 
     @Override
+    @Transactional
     public DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId) {
 
         // 유저 조회


### PR DESCRIPTION
## 📝 작업 내용
일기 도메인에서는 트랜잭션 어노테이션도 사용하지 않고 기존에 존재하던 `userRepository.save(user)` 코드가 사라져서 (나 아님..)
일기 작성 시에도 사용자의 크레딧이 올라가지 않는 문제가 있었습니다.
(이전 PR에서 작업량이 많다보니 사용자 크레딧이 증가되는거까지는 확인하지 않았었던... 🥲)

## 👀 참고사항
X


## 🔍 테스트 방법
1. 처음 사용자 크레딧
<img width="1010" height="386" alt="image" src="https://github.com/user-attachments/assets/f81faec6-5621-4374-83d7-86e3fe67ad2f" />

2. 일기 작성
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/1c4d576b-06cd-4731-a8ff-060bb552f555" />

3. 증가된 사용자 크레딧
<img width="842" height="336" alt="image" src="https://github.com/user-attachments/assets/42bddaab-f507-4ba8-b762-5ef4485f1c9d" />

4. 아이템 구매
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/27df1a0c-0887-4b1f-9e2a-1dca03331976" />

5. 감소된 사용자 크레딧
<img width="828" height="332" alt="image" src="https://github.com/user-attachments/assets/484f9eaf-6d48-491b-ab3d-26cdf3d8685b" />