### PR TITLE
[#318] Refactor: 챌린지 삭제 api 응답 반환 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -152,14 +152,6 @@ public class ChallengeConverter {
                 .build();
     }
 
-    // 챌린지 삭제
-    public static ChallengeResponseDTO.DeleteChallengeResponseDTO toDeletedUserChallenge(UserChallenge userChallenge) {
-        return ChallengeResponseDTO.DeleteChallengeResponseDTO.builder()
-                .id(userChallenge.getId())
-                .message("챌린지를 삭제했어요")
-                .build();
-    }
-
     public static List<ChallengeResponseDTO.ChallengeDTO> toRecommendedChallenges(List<Challenge> dailyChallenges, Challenge randomChallenge) {
         // daily 챌린지 변환
         List<ChallengeResponseDTO.ChallengeDTO> recommendedChallenges = dailyChallenges.stream()

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandService.java
@@ -4,7 +4,6 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.util.List;
-import java.util.Map;
 
 public interface ChallengeCommandService {
 
@@ -12,5 +11,5 @@ public interface ChallengeCommandService {
     ChallengeResponseDTO.ProofPresignedUrlResponseDTO createChallengePresignedUrl(Long userId, ChallengeRequestDTO.ProofRequestPresignedUrlDTO request);
     ChallengeResponseDTO.CreateProofDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest);
     ChallengeResponseDTO.ModifyProofDTO updateChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO updateRequest);
-    ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId);
+    void delete(Long userChallengeId, Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -170,7 +170,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
     // 삭제
     @Override
-    public ChallengeResponseDTO.DeleteChallengeResponseDTO delete(Long userChallengeId, Long userId) {
+    public void delete(Long userChallengeId, Long userId) {
         // 1. userId를 조회하고 없으면 오류
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
@@ -186,8 +186,5 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
 
         // 4. 삭제
         userChallengeRepository.deleteById(userChallengeId);
-
-        // 5. converter 작업
-        return ChallengeConverter.toDeletedUserChallenge(userChallenge);
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -98,12 +98,12 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @DeleteMapping("{userChallengeId}")
-    public ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId) {
+    public ApiResponse<Void> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId) {
         //AccessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        ChallengeResponseDTO.DeleteChallengeResponseDTO deleteChallenge = challengeCommandService.delete(userChallengeId, userId);
-        return ApiResponse.onSuccess(deleteChallenge);
+        challengeCommandService.delete(userChallengeId, userId);
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -124,5 +124,5 @@ public interface ChallengeSpecification {
 
     })
     @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", example = "1")
-    ApiResponse<ChallengeResponseDTO.DeleteChallengeResponseDTO> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
+    ApiResponse<Void> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -209,18 +209,6 @@ public class ChallengeResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "챌린지 삭제 response")
-    public static class DeleteChallengeResponseDTO {
-        @Schema(description = "사용자 챌린지 id", example = "1")
-        private Long id;
-        @Schema(description = "챌린지 삭제 성공 메시지", example = "챌린지를 삭제했어요.")
-        private String message;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     @Schema(title = "챌린지 추천 response")
     public static class ChallengeDTO {
         @Schema(description = "추천 챌린지 id", example = "1")


### PR DESCRIPTION
## 📝 작업 내용
챌린지 삭제 api 응답이 null로 반환되도록 수정하였습니다!

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
미완료한 유저챌린지 삭제
<img width="383" height="306" alt="image" src="https://github.com/user-attachments/assets/ac965f36-6d10-459b-b5f8-937b887edf6e" />
