### PR TITLE
[#299] Refactor: 일기 삭제 시, 사용자 챌린지는 삭제되지 않도록 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -71,13 +71,6 @@ public class DiaryConverter {
                 ;
     }
 
-    public static DiaryResponseDTO.DeleteDiaryResultDTO toDeleteResultDTO(Diary diary){
-
-        return DiaryResponseDTO.DeleteDiaryResultDTO.builder()
-                .message("일기를 삭제했어요.")
-                .build();
-    }
-
     public static DiaryResponseDTO.VoiceChatResultDTO toVoiceChatResultDTO(String aiChat){
 
         return DiaryResponseDTO.VoiceChatResultDTO.builder()

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
@@ -73,9 +73,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
                 : Collections.emptyList();
 
         // 사용자가 직접 저장한 챌린지만 가져옴
-        List<UserChallenge> savedChallenges = todayDiary.isPresent()
-                ? userChallengeRepository.findTodayUserChallengesByUserId(userId, today)
-                : Collections.emptyList();
+        List<UserChallenge> savedChallenges = userChallengeRepository.findTodayUserChallengesByUserId(userId, today);
 
         return ChallengeConverter.toChallengeHomeDTO(
                 savedChallenges,

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -9,7 +9,7 @@ public interface DiaryCommandService {
 
     DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId);
 
-    DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId);
+    void deleteDiary(Long diaryId, Long userId);
 
     DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -14,7 +14,6 @@ import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.converter.FlaskConverter;
 import umc.GrowIT.Server.domain.*;
 import umc.GrowIT.Server.repository.*;
-import umc.GrowIT.Server.repository.DiaryRepository;
 import umc.GrowIT.Server.util.CreditUtil;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -112,24 +111,15 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     }
 
     @Override
-    public DiaryResponseDTO.DeleteDiaryResultDTO deleteDiary(Long diaryId, Long userId) {
+    public void deleteDiary(Long diaryId, Long userId) {
         //유저 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         Optional<Diary> optionalDiary = diaryRepository.findByUserIdAndId(userId, diaryId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
-        LocalDate targetDate = diary.getDate();
 
         //일기 삭제
         diaryRepository.delete(diary);
-
-        //UserChallenge 조회
-        List<UserChallenge> targetUserChallenge = userChallengeRepository.findUserChallengesByDateAndUserId(user.getId(), targetDate);
-
-        //UserChallenge 삭제
-        userChallengeRepository.deleteAll(targetUserChallenge);
-
-        return DiaryConverter.toDeleteResultDTO(diary);
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -60,12 +60,12 @@ public class DiaryController implements DiarySpecification {
     }
 
     @DeleteMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId){
+    public ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
-
-        return ApiResponse.onSuccess(diaryCommandService.deleteDiary(diaryId, userId));
+        diaryCommandService.deleteDiary(diaryId, userId);
+        return ApiResponse.onSuccess();
     }
     @PostMapping("/text")
     public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request){

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -64,7 +64,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "삭제할 일기의 ID", example = "1")
-    ApiResponse<DiaryResponseDTO.DeleteDiaryResultDTO> deleteDiary(@PathVariable("diaryId") Long diaryId);
+    ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
     @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -92,16 +92,6 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "일기 삭제 response")
-    public static class DeleteDiaryResultDTO {
-        @Schema(description = "일기 삭제 성공 메시지", example = "일기를 삭제했어요.")
-        String message;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     @Schema(title = "음성 대화 response")
     public static class VoiceChatResultDTO {
         @Schema(description = "AI의 답변 내용", example = "힘든 하루셨군요. 어떤 일이 있으셨나요?")


### PR DESCRIPTION
## 📝 작업 내용
원래는 일기 삭제 시, 분석된 감정키워드 + 선택했던 챌린지까지 다 삭제하는 로직이였지만 (원랜 인증한 챌린지도 삭제했었음..)
-> 변경사항으로 감정키워드까지만 삭제되도록 수정하였습니다.

추가로, 챌린지 홈 조회 API에서 일기 존재 여부를 통해서 챌린지를 조회하도록 하고 있어서 무관하게 조회하도록 수정까지 하였습니다.

## 👀 참고사항
- 간단한 작업인데 로컬에서 Flask 띄워서 직접 분석도 실행해보다가 오래 걸렸습니다.. (MySQL 포트 3307로 바뀐거 등등 때문에..) 🥲

- 챌린지 홈 조회 API
    <img width="3172" height="1154" alt="image" src="https://github.com/user-attachments/assets/b2e94ee5-491e-4191-9fea-a316b573b7d1" />
로그를 봐버렸어..

## 🔍 테스트 방법
1. 세팅 결과
  일기
    <img width="2074" height="616" alt="image" src="https://github.com/user-attachments/assets/46c90c99-20ce-4e56-89f8-910b585af3c8" />
  감정키워드
    <img width="2004" height="462" alt="image" src="https://github.com/user-attachments/assets/1c9bf022-3b80-42fa-8bcb-4a138eff164d" />
  챌린지
    <img width="2018" height="532" alt="image" src="https://github.com/user-attachments/assets/4a3ba548-3fd4-4599-8273-2713606776d7" />

2. 일기 삭제 API 실행
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/128d1ecd-2114-4222-9dcd-e92b6afaf737" />

3. 삭제 결과
    <img width="1944" height="572" alt="image" src="https://github.com/user-attachments/assets/1484d0fb-4a67-478c-94c8-d540794ca4a7" />
    <img width="1776" height="490" alt="image" src="https://github.com/user-attachments/assets/fdcedf40-13c5-4105-8e93-f86ef3c4fecf" />
    <img width="1736" height="574" alt="image" src="https://github.com/user-attachments/assets/2e1fe060-5a39-411c-9f60-67140909bf5a" />

4. (1~3의 상태에서 진행) 기존 챌린지 홈 조회 API (감정 X / 챌린지 X)
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/f709fb1d-bf6b-41a8-8115-d9d29383c29a" />

5. (1~3의 상태에서 진행) 변경된 챌린지 홈 조회 API (감정 X / 챌린지 O)
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/1ae2064d-2480-4490-92ac-dfde0806bffb" />