### PR TITLE
[#330] Feat: 앱 자체 일기 첫작성 시 제공되는 크레딧 구분

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -3,6 +3,7 @@ package umc.GrowIT.Server.converter;
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.domain.Keyword;
+import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
@@ -57,15 +58,15 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.CreateDiaryResultDTO toCreateResultDTO(Diary diary, boolean creditGranted, int creditAmount){
+    public static DiaryResponseDTO.CreateDiaryResultDTO toCreateResultDTO(Diary diary, CreditGrantResult result){
 
         return DiaryResponseDTO.CreateDiaryResultDTO.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
                 .date(diary.getDate())
                 .creditInfo(DiaryResponseDTO.CreditInfo.builder()
-                        .granted(creditGranted)
-                        .amount(creditGranted ? creditAmount : 0)
+                        .granted(result.isGranted())
+                        .amount(result.isGranted() ? result.getAmount() : 0)
                         .build())
                 .build()
                 ;
@@ -78,15 +79,15 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.SummaryResultDTO toSummaryResultDTO(Diary diary, boolean creditGranted, int creditAmount){
+    public static DiaryResponseDTO.SummaryResultDTO toSummaryResultDTO(Diary diary, CreditGrantResult result){
 
         return DiaryResponseDTO.SummaryResultDTO.builder()
                 .diaryId(diary.getId())
                 .content(diary.getContent())
                 .date(diary.getDate())
                 .creditInfo(DiaryResponseDTO.CreditInfo.builder()
-                        .granted(creditGranted)
-                        .amount(creditGranted ? creditAmount : 0)
+                        .granted(result.isGranted())
+                        .amount(result.isGranted() ? result.getAmount() : 0)
                         .build())
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/repository/CreditHistoryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/CreditHistoryRepository.java
@@ -28,4 +28,6 @@ public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Lo
     @Modifying
     @Query("DELETE FROM CreditHistory ch WHERE ch.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
+
+    boolean existsByUserAndSource(User user, CreditSource creditSource);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -14,6 +14,7 @@ import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.converter.FlaskConverter;
 import umc.GrowIT.Server.domain.*;
 import umc.GrowIT.Server.repository.*;
+import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.util.CreditUtil;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -36,12 +37,8 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     private final ChallengeKeywordRepository challengeKeywordRepository;
     private final KeywordRepository keywordRepository;
     private final ChallengeRepository challengeRepository;
-    private final UserChallengeRepository userChallengeRepository;
 
     private final CreditUtil creditUtil;
-
-    //일기 작성 시 추가되는 크레딧 개수
-    private static final int DIARY_CREDIT = 2;
 
     @Value("${openai.model1}")
     private String chatModel;
@@ -105,9 +102,9 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         diary = diaryRepository.save(diary);
 
         // 사용자의 크레딧 수 증가
-        boolean isGranted = creditUtil.grantDiaryCredit(user, diary, DIARY_CREDIT);
+        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary);
 
-        return DiaryConverter.toCreateResultDTO(diary, isGranted, DIARY_CREDIT);
+        return DiaryConverter.toCreateResultDTO(diary, result);
     }
 
     @Override
@@ -249,12 +246,12 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         diary = diaryRepository.save(diary);
 
         // 사용자의 크레딧 수 증가
-        boolean isGranted = creditUtil.grantDiaryCredit(user, diary, DIARY_CREDIT);
+        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary);
 
         // 대화 기록 삭제
         conversationHistory.remove(userId);
 
-        return DiaryConverter.toSummaryResultDTO(diary, isGranted, DIARY_CREDIT);
+        return DiaryConverter.toSummaryResultDTO(diary, result);
     }
 
     private void checkDiaryDate(Long userId, LocalDate date) {

--- a/src/main/java/umc/GrowIT/Server/util/CreditUtil.java
+++ b/src/main/java/umc/GrowIT/Server/util/CreditUtil.java
@@ -1,111 +1,129 @@
-package umc.GrowIT.Server.util;
+    package umc.GrowIT.Server.util;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import umc.GrowIT.Server.domain.*;
-import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.repository.CreditHistoryRepository;
-import umc.GrowIT.Server.repository.CreditRepository;
-import umc.GrowIT.Server.repository.UserChallengeRepository;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.stereotype.Service;
+    import umc.GrowIT.Server.domain.*;
+    import umc.GrowIT.Server.domain.enums.CreditSource;
+    import umc.GrowIT.Server.repository.CreditHistoryRepository;
+    import umc.GrowIT.Server.repository.UserChallengeRepository;
+    import umc.GrowIT.Server.util.dto.CreditGrantResult;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+    import java.time.LocalDate;
+    import java.time.format.DateTimeFormatter;
 
-@Service
-@RequiredArgsConstructor
-public class CreditUtil {
+    @Service
+    @RequiredArgsConstructor
+    public class CreditUtil {
 
-    private final CreditHistoryRepository creditHistoryRepository;
-    private final UserChallengeRepository userChallengeRepository;
+        private final CreditHistoryRepository creditHistoryRepository;
+        private final UserChallengeRepository userChallengeRepository;
 
-    // 일기 첫작성으로 인한 크레딧 제공 기록 및 사용자 크레딧 최신화
-    public boolean grantDiaryCredit(User user, Diary diary, Integer amount) {
-        // 1. 해당 날짜에 크레딧 받았는지 확인
-        if (hasDiaryCreditForDate(user, diary.getDate())) {
-            return false; // 이미 지급되었으므로 크레딧 제공 X
+        // 앱 자체에서 처음 일기 작성 시 적립되는 크레딧
+        private static final int FIRST_DIARY_CREDIT = 5;
+
+        // 날짜별로 처음 일기 작성 시 적립되는 크레딧
+        private static final int DAILY_FIRST_DIARY_CREDIT = 2;
+
+        // 일기 첫작성으로 인한 크레딧 제공 기록 및 사용자 크레딧 최신화
+        public CreditGrantResult grantDiaryCredit(User user, Diary diary) {
+            int amount = 0;
+
+            // 1. 사용자의 상황 판단 통해 크레딧 결정
+            // 앱 자체 일기 첫작성 시
+            if (isFirstDiaryEver(user)) {
+                amount = FIRST_DIARY_CREDIT;
+            }
+            // 날짜별 일기 첫작성 시
+            else if (!hasDiaryCreditForDate(user, diary.getDate())) {
+                amount = DAILY_FIRST_DIARY_CREDIT;
+            }
+            // 날짜별 일기 재작성 시
+            else {
+                return new CreditGrantResult(false, 0);
+            }
+
+            // 2. 크레딧 기록
+            CreditHistory credit = CreditHistory.builder()
+                    .user(user)
+                    .source(CreditSource.DIARY)
+                    .referenceId(diary.getId())
+                    .date(diary.getDate())
+                    .amount(amount)
+                    .description(String.format("[%s] 일기 작성", diary.getDate().format(DateTimeFormatter.ofPattern("MM-dd"))))
+                    .build()
+                    ;
+
+            creditHistoryRepository.save(credit);
+
+            // 3. 사용자 크레딧 최신화
+            user.updateCurrentCredit(user.getCurrentCredit() + amount);
+            user.updateTotalCredit(user.getTotalCredit() + amount);
+
+            // 4. 크레딧 제공 O
+            return new CreditGrantResult(true, amount);
         }
 
-        // 2. 크레딧 기록
-        CreditHistory credit = CreditHistory.builder()
-                .user(user)
-                .source(CreditSource.DIARY)
-                .referenceId(diary.getId())
-                .date(diary.getDate())
-                .amount(amount)
-                .description(String.format("[%s] 일기 작성", diary.getDate().format(DateTimeFormatter.ofPattern("MM-dd"))))
-                .build()
-                ;
+        // 아이템 구매로 인한 사용자 크레딧 최신화
+        public void deductItemCredit(User user, UserItem userItem, Item item) {
+            // 1. 크레딧 사용 기록 (음수로 저장)
+            CreditHistory credit = CreditHistory.builder()
+                    .user(user)
+                    .source(CreditSource.ITEM)
+                    .referenceId(userItem.getId())
+                    .amount(-item.getPrice())
+                    .description(String.format("[%s] 아이템 구매", item.getName()))
+                    .build()
+                    ;
 
-        creditHistoryRepository.save(credit);
+            creditHistoryRepository.save(credit);
 
-
-        // 3. 사용자 크레딧 최신화
-        user.updateCurrentCredit(user.getCurrentCredit() + amount);
-        user.updateTotalCredit(user.getTotalCredit() + amount);
-
-
-        // 4. 크레딧 제공 O
-        return true;
-    }
-
-    // 아이템 구매로 인한 사용자 크레딧 최신화
-    public void deductItemCredit(User user, UserItem userItem, Item item) {
-        // 1. 크레딧 사용 기록 (음수로 저장)
-        CreditHistory credit = CreditHistory.builder()
-                .user(user)
-                .source(CreditSource.ITEM)
-                .referenceId(userItem.getId())
-                .amount(-item.getPrice())
-                .description(String.format("[%s] 아이템 구매", item.getName()))
-                .build()
-                ;
-
-        creditHistoryRepository.save(credit);
-
-        // 2. 사용자 크레딧 최신화
-        user.updateCurrentCredit(user.getCurrentCredit() - item.getPrice());
-    }
-
-    // 챌린지 인증으로 인한 크레딧 제공 기록 및 사용자 크레딧 최신화
-    public boolean grantUserChallengeCredit(User user, UserChallenge userChallenge, Integer amount) {
-        // 1. 동일한 날짜의 일기에 대해 인증 완료한 챌린지 개수 가져오기
-        long completedCountOnDate = userChallengeRepository.countCompletedOnDateByUserId(user.getId(), userChallenge.getDate());
-
-        if (completedCountOnDate >= 4) {
-            return false; // 챌린지 인증 4번째부터는 크레딧 제공 x
+            // 2. 사용자 크레딧 최신화
+            user.updateCurrentCredit(user.getCurrentCredit() - item.getPrice());
         }
 
-        // 2. 크레딧 기록
-        CreditHistory credit = CreditHistory.builder()
-                .user(user)
-                .source(CreditSource.CHALLENGE)
-                .referenceId(userChallenge.getId())
-                .date(userChallenge.getDate())
-                .amount(amount)
-                .description(String.format("[%s] 챌린지 완료",
-                        userChallenge.getDate().format(DateTimeFormatter.ofPattern("MM-dd"))))
-                .build()
-                ;
+        // 챌린지 인증으로 인한 크레딧 제공 기록 및 사용자 크레딧 최신화
+        public boolean grantUserChallengeCredit(User user, UserChallenge userChallenge, Integer amount) {
+            // 1. 동일한 날짜의 일기에 대해 인증 완료한 챌린지 개수 가져오기
+            long completedCountOnDate = userChallengeRepository.countCompletedOnDateByUserId(user.getId(), userChallenge.getDate());
 
-        creditHistoryRepository.save(credit);
+            if (completedCountOnDate >= 4) {
+                return false; // 챌린지 인증 4번째부터는 크레딧 제공 x
+            }
 
-        // 3. 사용자 크레딧 최신화
-        user.updateCurrentCredit(user.getCurrentCredit() + amount);
-        user.updateTotalCredit(user.getTotalCredit() + amount);
+            // 2. 크레딧 기록
+            CreditHistory credit = CreditHistory.builder()
+                    .user(user)
+                    .source(CreditSource.CHALLENGE)
+                    .referenceId(userChallenge.getId())
+                    .date(userChallenge.getDate())
+                    .amount(amount)
+                    .description(String.format("[%s] 챌린지 완료",
+                            userChallenge.getDate().format(DateTimeFormatter.ofPattern("MM-dd"))))
+                    .build()
+                    ;
 
-        // 4. 크레딧 제공 O
-        return true;
+            creditHistoryRepository.save(credit);
+
+            // 3. 사용자 크레딧 최신화
+            user.updateCurrentCredit(user.getCurrentCredit() + amount);
+            user.updateTotalCredit(user.getTotalCredit() + amount);
+
+            // 4. 크레딧 제공 O
+            return true;
+        }
+
+
+        /*
+            이 아래부터 헬퍼메소드
+        */
+        // 앱 최초 일기 작성 여부 확인 (가입 후 최초 1회)
+        private boolean isFirstDiaryEver(User user) {
+            return !creditHistoryRepository.existsByUserAndSource(user, CreditSource.DIARY);
+        }
+        // 해당 날짜에 일기 첫작성으로 인해서 크레딧을 이미 받았는지 확인
+        public boolean hasDiaryCreditForDate(User user, LocalDate date) {
+            return creditHistoryRepository.existsByUserAndDateAndSource(user, date, CreditSource.DIARY);
+        }
     }
-
-
-    /*
-        이 아래부터 헬퍼메소드
-    */
-    // 해당 날짜에 일기 첫작성으로 인해서 크레딧을 이미 받았는지 확인
-    public boolean hasDiaryCreditForDate(User user, LocalDate date) {
-        return creditHistoryRepository.existsByUserAndDateAndSource(user, date, CreditSource.DIARY);
-    }
-}
 
 

--- a/src/main/java/umc/GrowIT/Server/util/dto/CreditGrantResult.java
+++ b/src/main/java/umc/GrowIT/Server/util/dto/CreditGrantResult.java
@@ -1,0 +1,11 @@
+package umc.GrowIT.Server.util.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreditGrantResult {
+    private final boolean granted;   // 크레딧 지급 여부
+    private final int amount;        // 실제 지급된 크레딧 수
+}


### PR DESCRIPTION
## 📝 작업 내용
User에 첫일기 작성여부 필드 추가 등 다른 방법도 존재하겠지만
당장에는 `CreditHistory` 테이블 조회가 가장 빠른 구현이 가능하여 이렇게 구현하였습니다.
(하지만, 5크레딧 제공하는 경우는 각 사용자별로 앱에서 단 1번만 발생함에도 불구하고 일기 작성시마다 회원가입 후 첫일기 작성인가?를 판단하는 쿼리가 발생하는 문제가 존재합니다)

## 👀 참고사항
보니까 약관쪽에 변경사항이 있고, 기존 DB를 날리지 않고 반영하기 위해서 table.sql이 config에 추가된 거 같습니다.
그런데 data.sql에는 제대로 최신화가 되지 않고 누락된 내용이 있어서 수정하였습니다.

※ 서므모듈 설정 관련
서브모듈 설정한 이유는 내부적으로는 공유되어야 하지만, 외부적으로는 드러나면 안되는 파일들 관리/공유를 원활하게 하기 위해 설정하였습니다.
그런데 `data.sql` & `table.sql` 이렇게 별도로 관리되다보니 위의 상황이 발생한거 같습니다.
DB를 결국에 초기화 or 새롭게 생성 후에 기본 데이터 세팅이 필요하다보니까 `data.sql` 관리가 중요합니다. 신경써주시면 감사하겠습니다!!

## 🔍 테스트 방법
1. 앱 자체 첫일기 작성
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/bca24f2c-aeac-485c-9be9-c0bcb7ee780b" />
2. 일기 삭제 후 재작성
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/2742b923-6639-477d-90cf-4535c5455b4a" />
3. 그 후, 다른 날짜 일기 첫작성
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/fabf8666-146e-4b9a-ad38-a6b3f4906e22" />
4. 일기 삭제 후 재작성
    <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/807b1383-4562-4234-ae26-4a46d13816e5" />