### PR TITLE
[#334] Refactor: CreditGrantResult 생성에 따른 챌린지 응답 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -5,6 +5,7 @@ import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.UserChallenge;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
+import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.time.LocalDate;
@@ -89,7 +90,7 @@ public class ChallengeConverter {
     }
 
     // 챌린지 인증 작성 결과
-    public static ChallengeResponseDTO.CreateProofDTO toCreateProofDTO(UserChallenge userChallenge, boolean creditGranted, int creditAmount) {
+    public static ChallengeResponseDTO.CreateProofDTO toCreateProofDTO(UserChallenge userChallenge, CreditGrantResult result) {
         return ChallengeResponseDTO.CreateProofDTO.builder()
                 .id(userChallenge.getId())
                 .title(userChallenge.getChallenge().getTitle())
@@ -97,8 +98,8 @@ public class ChallengeConverter {
                 .thoughts(userChallenge.getThoughts())
                 .certificationDate(userChallenge.getCertificationDate())
                 .creditInfo(ChallengeResponseDTO.CreditInfo.builder()
-                        .granted(creditGranted)
-                        .amount(creditGranted ? creditAmount : 0)
+                        .granted(result.isGranted())
+                        .amount(result.isGranted() ? result.getAmount() : 0)
                         .build())
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -12,6 +12,7 @@ import umc.GrowIT.Server.domain.enums.UserChallengeType;
 import umc.GrowIT.Server.repository.*;
 import umc.GrowIT.Server.util.CreditUtil;
 import umc.GrowIT.Server.util.S3Util;
+import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeRequestDTO;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
@@ -29,9 +30,6 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     private final ChallengeRepository challengeRepository;
     private final S3Util s3Util;
     private final CreditUtil creditUtil;
-
-    //챌린지 인증 작성 시 추가되는 크레딧 개수
-    private static final int CHALLENGE_CREDIT = 1;
 
     @Override
     @Transactional
@@ -136,9 +134,9 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
         userChallenge.verifyUserChallenge(proofRequest);
 
         // 사용자의 크레딧 수 증가
-        boolean isGranted = creditUtil.grantUserChallengeCredit(user, userChallenge, CHALLENGE_CREDIT);
+        CreditGrantResult isGranted = creditUtil.grantUserChallengeCredit(user, userChallenge);
 
-        return ChallengeConverter.toCreateProofDTO(userChallenge, isGranted, CHALLENGE_CREDIT);
+        return ChallengeConverter.toCreateProofDTO(userChallenge, isGranted);
     }
 
     @Override


### PR DESCRIPTION
## 📝 작업 내용
CreditGrantResult 생성에 따른 챌린지 응답 수정

```java
@Getter
@AllArgsConstructor
public class CreditGrantResult {
    private final boolean granted;   // 크레딧 지급 여부
    private final int amount;        // 실제 지급된 크레딧 수
}
``` 

1. ChallengeConverter에서 `boolean creditGranted, int creditAmount` 으로 선언하던 부분을 `CreditGrantResult result` 으로 변경함에 따라 크레딧 응답 부분도 일기와 동일하게 `result.isGranted()`, `result.getAmount()` 식으로 수정
2. `CHALLENGE_CREDIT` 상수는 `CreditUtil`에서 관리, 따라서
- 챌린지 인증 3개까지는 `CreditGrantResult(true, CHALLENGE_CREDIT)` 반환
- 챌린지 인증 4번째부터는 `CreditGrantResult(false, 0)` 반환

## 👀 참고사항
놉


## 🔍 테스트 방법
1. 챌린지 인증 3개까지 크레딧 지급
<img width="873" height="490" alt="image" src="https://github.com/user-attachments/assets/2ac6e70e-d8df-40af-82cf-ae4af4705cec" />


2. 챌린지 인증 4번째부터 크레딧 지급 x
<img width="887" height="487" alt="image" src="https://github.com/user-attachments/assets/245acede-2d56-4067-ac30-bebad71452e8" />