### PR TITLE
[#357] Fix: Flask 호출 Http Client 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/OpenAiConfig.java
@@ -7,9 +7,11 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class OpenAiConfig {
+    // 대화&요약용
     @Value("${openai.api.key}")
     private String openAiKey;
 
+    // 감정 분석용
     @Value("${openai.api.key-sub}")
     private String subOpenAiKey;
 

--- a/src/main/java/umc/GrowIT/Server/config/RestClientConfig.java
+++ b/src/main/java/umc/GrowIT/Server/config/RestClientConfig.java
@@ -1,0 +1,15 @@
+package umc.GrowIT.Server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    public RestClient flaskRestClient() {
+        return RestClient.builder()
+                .baseUrl("http://localhost:5000")
+                .build();
+    }
+}

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.*;
 import umc.GrowIT.Server.converter.DiaryConverter;
@@ -52,11 +55,17 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     @Value("${openai.api.url}")
     private String apiURL;
 
+    // 대화&요약용
     @Autowired
     private RestTemplate template;
 
+    // 감정 분석용
     @Autowired
     private RestTemplate subTemplate;
+
+    // Flask 호출용
+    private final RestClient flaskRestClient;
+
 
     //userId-대화내용 저장용 HashMap
     private final Map<Long, List<Message>> conversationHistory = new HashMap<>();
@@ -387,19 +396,21 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         // Flask에 모든 감정을 전달하여 유사도 분석 요청
         log.info("[입력된 감정을 Flask로 전달하여 분석]");
 
-        ResponseEntity<FlaskResponseDTO.EmotionAnalysisResponseDTO> response = template.postForEntity(
-                "http://localhost:5000/analyze_emotions",
-                request,
-                FlaskResponseDTO.EmotionAnalysisResponseDTO.class);
+        FlaskResponseDTO.EmotionAnalysisResponseDTO response = flaskRestClient
+                .post()
+                .uri("/analyze_emotions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(FlaskResponseDTO.EmotionAnalysisResponseDTO.class);
 
-        FlaskResponseDTO.EmotionAnalysisResponseDTO body = response.getBody();
 
         // 응답 오류체크
-        if (body.getAnalyzedEmotions() == null || body.getAnalyzedEmotions().isEmpty()) {
+        if (response == null || response.getAnalyzedEmotions() == null || response.getAnalyzedEmotions().isEmpty()) {
             throw new FlaskHandler(ErrorStatus.FLASK_API_CALL_FAILED);
         }
 
-        List<FlaskResponseDTO.SimilarityResultDTO> analyzedEmotions = body.getAnalyzedEmotions();
+        List<FlaskResponseDTO.SimilarityResultDTO> analyzedEmotions = response.getAnalyzedEmotions();
 
         for (FlaskResponseDTO.SimilarityResultDTO analysisResult : analyzedEmotions) {
 


### PR DESCRIPTION
## 📝 작업 내용
이슈에 작성한대로 Flask를 호출하는 Http Client를 변경하였습니다.
`RestTemplate`-> `WebClient` -> `RestClient`순으로 제공된거 같아 최근 흐름에 가장 적절하다고 생각하였고
동기/비동기 모두 가능하며 `WebClient`와 달리 별도의 의존성(`webflux`)이 필요하지 않다고 합니다.

위의 이유로 인해서, 다른 `Http Client`를 사용하는 로직에서도 `RestClient`로 통일하는 것은 어떨지 여쭈어 보고 싶습니다!
기존 로직에 아마 비동기 호출이 없을...거라 `RestTemplate`과 `WebClient` 혼용되는 부분은 애초에 통일 필요할 거 같습니다.
통일하는 작업은 별도의 이슈생성해서 진행하도록 하겠습니다.


## 👀 참고사항
X


## 🔍 테스트 방법
X