### PR TITLE
[#369] Refactor: 챌린지 현황 조회 시 챌린지 내용 반환

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ChallengeConverter.java
@@ -62,6 +62,7 @@ public class ChallengeConverter {
         return ChallengeResponseDTO.ChallengeStatusDTO.builder()
                 .id(userChallenge.getId())
                 .title(userChallenge.getChallenge().getTitle())
+                .content(userChallenge.getChallenge().getContent())
                 .challengeType(userChallenge.getChallengeType())
                 .time(userChallenge.getChallenge().getTime())
                 .completed(userChallenge.isCompleted())

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeResponseDTO.java
@@ -46,9 +46,9 @@ public class ChallengeResponseDTO {
         private Long id;
         @Schema(description = "저장한 챌린지 타입", example = "DAILY")
         private UserChallengeType challengeType;
-        @Schema(description = "저장한 챌린지 제목", example = "좋아하는 책 독서하기")
+        @Schema(description = "저장한 챌린지 제목", example = "독서하기")
         private String title;
-        @Schema(description = "저장한 챌린지 내용", example = "좋아하는 책을 골라서 한 번 읽어 보세요!")
+        @Schema(description = "저장한 챌린지 내용", example = "좋아하는 책 한 페이지 읽기.")
         private String content;
         @Schema(description = "챌린지 소요 시간", example = "1")
         private Integer time;
@@ -62,9 +62,9 @@ public class ChallengeResponseDTO {
     public static class RecommendedChallengeDTO {
         @Schema(description = "추천 챌린지 id", example = "1")
         private Long id;
-        @Schema(description = "추천 챌린지 제목", example = "좋아하는 책 독서하기")
+        @Schema(description = "추천 챌린지 제목", example = "독서하기")
         private String title;
-        @Schema(description = "추천 챌린지 내용", example = "좋아하는 책을 골라서 한 번 읽어 보세요!")
+        @Schema(description = "추천 챌린지 내용", example = "좋아하는 책 한 페이지 읽기.")
         private String content;
         @Schema(description = "챌린지 타입(DAILY or RANDOM)", example = "DAILY")
         private UserChallengeType challengeType;
@@ -96,8 +96,10 @@ public class ChallengeResponseDTO {
     public static class ChallengeStatusDTO {
         @Schema(description = "챌린지 id", example = "1")
         private Long id;
-        @Schema(description = "챌린지 제목", example = "좋아하는 책 독서하기")
+        @Schema(description = "챌린지 제목", example = "독서하기")
         private String title;
+        @Schema(description = "챌린지 내용", example = "좋아하는 책 한 페이지 읽기.")
+        private String content;
         @Schema(description = "챌린지 타입(DAILY or RANDOM)", example = "DAILY")
         private UserChallengeType challengeType;
         @Schema(description = "챌린지 소요 시간", example = "1")
@@ -213,9 +215,9 @@ public class ChallengeResponseDTO {
     public static class ChallengeDTO {
         @Schema(description = "추천 챌린지 id", example = "1")
         private Long id;
-        @Schema(description = "추천 챌린지 제목", example = "좋아하는 책 독서하기")
+        @Schema(description = "추천 챌린지 제목", example = "독서하기")
         private String title;
-        @Schema(description = "추천 챌린지 내용", example = "좋아하는 책을 골라서 한 번 읽어 보세요!")
+        @Schema(description = "추천 챌린지 내용", example = "좋아하는 책 한 페이지 읽기.")
         private String content;
         @Schema(description = "챌린지 소요 시간", example = "1")
         private Integer time;


### PR DESCRIPTION
## 📝 작업 내용
챌린지 현황 조회 시 챌린지 내용(content)을 반환하여,
챌린지 인증 작성 시 프론트측에서 챌린지의 내용까지 조회할 수 있도록 작업하였습니다.

## 👀 참고사항
그 외.. db값에 맞게 example 수정.. 그리고 n+1 문제 발생에 대한 고민...


## 🔍 테스트 방법
<img width="517" height="415" alt="image" src="https://github.com/user-attachments/assets/471f4a2e-d8b7-40dc-a3ee-fc32e26f38b5" />
