### PR TITLE
[#374] Refactor: CreditHistory 테이블 enum 구조 개선

### DIFF
--- a/src/main/java/umc/GrowIT/Server/domain/CreditHistory.java
+++ b/src/main/java/umc/GrowIT/Server/domain/CreditHistory.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.GrowIT.Server.domain.common.BaseEntity;
 import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 
 import java.time.LocalDate;
 
@@ -39,11 +38,6 @@ public class CreditHistory extends BaseEntity {
     // 과거의 DIARY, CHALLENGE를 관리하기 위한 날짜
     @Column(nullable = true)
     private LocalDate date;
-
-    // CreditSource가 Diary일 경우만 사용되는 일기 타입 (음성 or 텍스트)
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = true)
-    private DiaryType diaryType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/umc/GrowIT/Server/domain/Diary.java
+++ b/src/main/java/umc/GrowIT/Server/domain/Diary.java
@@ -3,8 +3,6 @@ package umc.GrowIT.Server.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.GrowIT.Server.domain.common.BaseEntity;
-import umc.GrowIT.Server.domain.enums.DiaryType;
-import umc.GrowIT.Server.domain.enums.TermType;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -30,10 +28,11 @@ public class Diary extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    // 일기 타입 (음성 or 텍스트)
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private DiaryType type;
+//    // 일기 타입 (음성 or 텍스트)
+//    @Enumerated(EnumType.STRING)
+//    @Column(nullable = false)
+//    private DiaryType type;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/umc/GrowIT/Server/domain/enums/CreditSource.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/CreditSource.java
@@ -1,7 +1,8 @@
 package umc.GrowIT.Server.domain.enums;
 
 public enum CreditSource {
-    DIARY,
+    VOICE_DIARY,
+    TEXT_DIARY,
     CHALLENGE,
     ITEM,
 }

--- a/src/main/java/umc/GrowIT/Server/domain/enums/DiaryType.java
+++ b/src/main/java/umc/GrowIT/Server/domain/enums/DiaryType.java
@@ -1,6 +1,0 @@
-package umc.GrowIT.Server.domain.enums;
-
-public enum DiaryType {
-    VOICE,
-    TEXT
-}

--- a/src/main/java/umc/GrowIT/Server/repository/CreditHistoryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/CreditHistoryRepository.java
@@ -9,14 +9,12 @@ import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.CreditHistory;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Long> {
-    boolean existsByUserAndDateAndSource(User user, LocalDate date, CreditSource creditSource);
-
     Slice<CreditHistory> findByUserAndCreatedAtBetweenOrderByCreatedAtDesc(
             User user, LocalDateTime start, LocalDateTime end, Pageable pageable);
 
@@ -30,5 +28,7 @@ public interface CreditHistoryRepository extends JpaRepository<CreditHistory, Lo
     @Query("DELETE FROM CreditHistory ch WHERE ch.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 
-    boolean existsByUserAndSourceAndDiaryType(User user, CreditSource creditSource, DiaryType diaryType);
+    boolean existsByUserAndSource(User user, CreditSource creditSource);
+
+    boolean existsByUserAndDateAndSourceIn(User user, LocalDate date, List<CreditSource> sources);
 }

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -5,18 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;
 import umc.GrowIT.Server.apiPayload.exception.*;
 import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.converter.FlaskConverter;
 import umc.GrowIT.Server.domain.*;
-import umc.GrowIT.Server.domain.enums.DiaryType;
+import umc.GrowIT.Server.domain.enums.CreditSource;
 import umc.GrowIT.Server.repository.*;
 import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.util.CreditUtil;
@@ -106,14 +104,13 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
                 .content(request.getContent())
                 .user(user)
                 .date(request.getDate())
-                .type(DiaryType.TEXT)
                 .build();
 
         //일기 저장
         diary = diaryRepository.save(diary);
 
         // 사용자의 크레딧 수 증가
-        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary, DiaryType.TEXT);
+        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary, CreditSource.TEXT_DIARY);
 
         return DiaryConverter.toCreateResultDTO(diary, result);
     }
@@ -251,14 +248,13 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
                 .content(aiChat)
                 .user(user)
                 .date(request.getDate())
-                .type(DiaryType.VOICE)
                 .build();
 
         //일기 저장
         diary = diaryRepository.save(diary);
 
         // 사용자의 크레딧 수 증가
-        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary, DiaryType.VOICE);
+        CreditGrantResult result = creditUtil.grantDiaryCredit(user, diary, CreditSource.VOICE_DIARY);
 
         // 대화 기록 삭제
         conversationHistory.remove(userId);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryService.java
@@ -1,7 +1,5 @@
 package umc.GrowIT.Server.service.diaryService;
 
-import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 
 public interface DiaryQueryService {

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryQueryServiceImpl.java
@@ -10,7 +10,6 @@ import umc.GrowIT.Server.converter.DiaryConverter;
 import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 import umc.GrowIT.Server.repository.CreditHistoryRepository;
 import umc.GrowIT.Server.repository.DiaryRepository;
 import umc.GrowIT.Server.repository.UserRepository;
@@ -32,7 +31,7 @@ public class DiaryQueryServiceImpl implements DiaryQueryService{
     public boolean hasVoiceDiaries(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        return creditHistoryRepository.existsByUserAndSourceAndDiaryType(user, CreditSource.DIARY, DiaryType.VOICE);
+        return creditHistoryRepository.existsByUserAndSource(user, CreditSource.VOICE_DIARY);
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -7,12 +7,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
-import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 import umc.GrowIT.Server.service.diaryService.DiaryCommandService;
 import umc.GrowIT.Server.service.diaryService.DiaryQueryService;
 import umc.GrowIT.Server.web.controller.specification.DiarySpecification;
-import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -15,8 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
-import umc.GrowIT.Server.domain.enums.CreditSource;
-import umc.GrowIT.Server.domain.enums.DiaryType;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 


### PR DESCRIPTION
## 📝 작업 내용
#374 이슈에 자세하게 작성해서 간단하게만 작성하겠습니다.
기존에는 `CreditHistory`안에 `CreditSource`와 `diaryType`을 별도로 구분하여 관리하고 있었는데, `CreditHistory`의 스키마 구조가 너무 지저분해진다는 느낌을 받았습니다. `CreditSource`가 diary일때에만 `diaryType`이 활용되기 때문에 컬럼 간의 관계가 너무 특정 경우에만 사용되는 느낌.

다른 컬럼은 정리가 어렵지만, `CreditSource`와 `diaryType`은 1개로 정리가 가능할 거 같아서 정리하였습니다.


## 👀 참고사항
`CreditHistory`를 정리하며, 현재 기준으로는 Diary 테이블에서는 음성이냐? 텍스트냐?를 구분할 필요가 없고
CreditSrorcue- VOICE_DIARY or TEXT_DIARY / diaryType - VOICE or TEXT 다소 중복되는 내용이라고 생각되어서
주석 처리하였습니다.

-> 일기 목록 조회에서, 음성이냐 텍스트를 구분하는 UI가 생긴다면 그때가서 재추가해도 괜찮을 거 같습니다.

## 🔍 테스트 방법
X