### PR TITLE
[#388] Refactor: 기존 일기 저장 API 임시저장으로 변경

### DIFF
--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -3,8 +3,12 @@ package umc.GrowIT.Server.converter;
 import umc.GrowIT.Server.domain.Challenge;
 import umc.GrowIT.Server.domain.Diary;
 import umc.GrowIT.Server.domain.Keyword;
+import umc.GrowIT.Server.domain.User;
+import umc.GrowIT.Server.domain.enums.DiaryStatus;
+import umc.GrowIT.Server.domain.enums.DiaryType;
 import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
+import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
@@ -58,16 +62,10 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.CreateDiaryResultDTO toCreateResultDTO(Diary diary, CreditGrantResult result){
-
-        return DiaryResponseDTO.CreateDiaryResultDTO.builder()
+    public static DiaryResponseDTO.SaveDiaryResultDTO toSaveResultDTO(Diary diary){
+        return DiaryResponseDTO.SaveDiaryResultDTO.builder()
                 .diaryId(diary.getId())
-                .content(diary.getContent())
                 .date(diary.getDate())
-                .creditInfo(DiaryResponseDTO.CreditInfo.builder()
-                        .granted(result.isGranted())
-                        .amount(result.isGranted() ? result.getAmount() : 0)
-                        .build())
                 .build()
                 ;
     }
@@ -105,5 +103,16 @@ public class DiaryConverter {
                 .emotionKeywords(emotionKeywordsDTOs)
                 .recommendedChallenges(recommendedChallenges)
                 .build();
+    }
+
+    public static Diary toDiary (DiaryRequestDTO.SaveTextDiaryDTO request, User user, DiaryType type) {
+        return Diary.builder()
+                .content(request.getContent())
+                .user(user)
+                .date(request.getDate())
+                .status(DiaryStatus.PENDING)
+                .type(type)
+                .build()
+                ;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/DiaryConverter.java
@@ -6,12 +6,11 @@ import umc.GrowIT.Server.domain.Keyword;
 import umc.GrowIT.Server.domain.User;
 import umc.GrowIT.Server.domain.enums.DiaryStatus;
 import umc.GrowIT.Server.domain.enums.DiaryType;
-import umc.GrowIT.Server.util.dto.CreditGrantResult;
 import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
-import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
 import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -77,18 +76,6 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryResponseDTO.SummaryResultDTO toSummaryResultDTO(Diary diary, CreditGrantResult result){
-
-        return DiaryResponseDTO.SummaryResultDTO.builder()
-                .diaryId(diary.getId())
-                .content(diary.getContent())
-                .date(diary.getDate())
-                .creditInfo(DiaryResponseDTO.CreditInfo.builder()
-                        .granted(result.isGranted())
-                        .amount(result.isGranted() ? result.getAmount() : 0)
-                        .build())
-                .build();
-    }
 
     // 챌린지 추천
     public static DiaryResponseDTO.AnalyzedDiaryResponseDTO toAnalyzedDiaryDTO(List<Keyword> analyzedEmotions, List<Challenge> dailyChallenges, Challenge randomChallenge) {
@@ -105,11 +92,11 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static Diary toDiary (DiaryRequestDTO.SaveTextDiaryDTO request, User user, DiaryType type) {
+    public static Diary toDiary(String content, LocalDate date, User user, DiaryType type) {
         return Diary.builder()
-                .content(request.getContent())
+                .content(content)
                 .user(user)
-                .date(request.getDate())
+                .date(date)
                 .status(DiaryStatus.PENDING)
                 .type(type)
                 .build()

--- a/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.GrowIT.Server.domain.Diary;
+import umc.GrowIT.Server.domain.enums.DiaryStatus;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,8 +20,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<Diary> findByUserIdAndId(Long userId, Long diaryId);
 
-    boolean existsByUserIdAndDate(Long userId, LocalDate date);
-
     @Query("SELECT MAX(d.date) FROM Diary d WHERE d.user.id = :userId") // 마지막 일기 작성 날짜 조회
     Optional<LocalDate> findLastDiaryDateByUserId(@Param("userId") Long userId);
 
@@ -32,6 +31,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Modifying
     @Query("DELETE FROM Diary d WHERE d.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
+
+    boolean existsByUserIdAndDateAndStatus(Long userId, LocalDate date, DiaryStatus diaryStatus);
 
     // TODO 회원탈퇴 API 네이티브 삭제 메소드 - 추후 확인 필요
 //    @Modifying

--- a/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
@@ -34,6 +34,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     boolean existsByUserIdAndDateAndStatus(Long userId, LocalDate date, DiaryStatus diaryStatus);
 
+    @Modifying
+    @Query("DELETE FROM Diary d WHERE d.status = :status")
+    int deleteByStatus(@Param("status") DiaryStatus status);
+
     // TODO 회원탈퇴 API 네이티브 삭제 메소드 - 추후 확인 필요
 //    @Modifying
 //    @Query(value = "DELETE FROM diary WHERE user_id = :userId", nativeQuery = true)

--- a/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
+++ b/src/main/java/umc/GrowIT/Server/scheduler/Scheduler.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import umc.GrowIT.Server.domain.enums.DiaryStatus;
 import umc.GrowIT.Server.repository.AuthenticationCodeRepository;
+import umc.GrowIT.Server.repository.DiaryRepository;
 
 import java.time.LocalDateTime;
 
@@ -15,19 +17,33 @@ import java.time.LocalDateTime;
 public class Scheduler {
 
     private final AuthenticationCodeRepository authenticationCodeRepository;
+    private final DiaryRepository diaryRepository;
 
     // 인증번호 삭제 스케줄러
     @Transactional
-    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정 실행
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정
     public void deleteExpiredAuthenticationCodes() {
         try {
             LocalDateTime now = LocalDateTime.now();
 
-            int count = authenticationCodeRepository.deleteExpiredUnverifiedCodes(now);
+            int deletedCount = authenticationCodeRepository.deleteExpiredUnverifiedCodes(now);
 
-            log.info("[스케줄러] : 인증번호 삭제 진행 (삭제된 데이터 개수 : " + count + "개)");
+            log.info("[스케줄러] : 인증번호 삭제 진행 (삭제된 데이터 개수 : {}개)", deletedCount);
         } catch (Exception e) {
             log.error("[스케줄러] : 인증번호 삭제 실패", e);
+        }
+    }
+
+    // 일기 삭제 스케줄러
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정
+    public void deletePendingDiaries() {
+        try {
+            int deletedCount = diaryRepository.deleteByStatus(DiaryStatus.PENDING);
+
+            log.info("[스케줄러] : PENDING 상태 일기 삭제 진행 (삭제된 데이터 개수 : {}개)", deletedCount);
+        } catch (Exception e) {
+            log.error("[스케줄러] : PENDING 상태 일기 삭제 실패", e);
         }
     }
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -7,7 +7,7 @@ public interface DiaryCommandService {
 
     DiaryResponseDTO.ModifyDiaryResultDTO modifyDiary(DiaryRequestDTO.ModifyDiaryDTO request, Long diaryId, Long userId);
 
-    DiaryResponseDTO.CreateDiaryResultDTO createDiary(DiaryRequestDTO.CreateDiaryDTO request, Long userId);
+    DiaryResponseDTO.SaveDiaryResultDTO saveDiaryByText(DiaryRequestDTO.SaveTextDiaryDTO request, Long userId);
 
     void deleteDiary(Long diaryId, Long userId);
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -13,7 +13,7 @@ public interface DiaryCommandService {
 
     DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 
-    DiaryResponseDTO.SummaryResultDTO createDiaryByVoice(DiaryRequestDTO.SummaryDTO request, Long userId);
+    DiaryResponseDTO.SaveDiaryResultDTO saveDiaryByVoice(DiaryRequestDTO.SaveVoiceDiaryDTO request, Long userId);
 
     DiaryResponseDTO.AnalyzedDiaryResponseDTO analyze(Long diaryId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -76,12 +76,12 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess();
     }
     @PostMapping("/text")
-    public ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request){
+    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request){
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        return ApiResponse.onSuccess(diaryCommandService.createDiary(request, userId));
+        return ApiResponse.onSuccess(diaryCommandService.saveDiaryByText(request, userId));
     }
     @PostMapping("/voice/chat")
     public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request){

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -83,7 +83,7 @@ public class DiaryController implements DiarySpecification {
 
         return ApiResponse.onSuccess(diaryCommandService.createDiary(request, userId));
     }
-    @PostMapping("/voice")
+    @PostMapping("/voice/chat")
     public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request){
 
         //accessToken에서 userId 추출
@@ -93,7 +93,7 @@ public class DiaryController implements DiarySpecification {
         return ApiResponse.onSuccess(diaryCommandService.chatByVoice(request, userId));
     }
 
-    @PostMapping("/summary")
+    @PostMapping("/voice")
     public ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request) {
 
         //accessToken에서 userId 추출

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -104,7 +104,7 @@ public class DiaryController implements DiarySpecification {
     }
 
     @Override
-    @PostMapping("/analyze/{diaryId}")
+    @PostMapping("/{diaryId}/analyze")
     public ApiResponse<DiaryResponseDTO.AnalyzedDiaryResponseDTO> analyzeDiary (@PathVariable("diaryId") Long diaryId) {
         DiaryResponseDTO.AnalyzedDiaryResponseDTO result = diaryCommandService.analyze(diaryId);
         return ApiResponse.onSuccess(result);

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -94,13 +94,13 @@ public class DiaryController implements DiarySpecification {
     }
 
     @PostMapping("/voice")
-    public ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request) {
+    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request) {
 
         //accessToken에서 userId 추출
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Long userId = (Long) authentication.getPrincipal();
 
-        return ApiResponse.onSuccess(diaryCommandService.createDiaryByVoice(request, userId));
+        return ApiResponse.onSuccess(diaryCommandService.saveDiaryByVoice(request, userId));
     }
 
     @Override

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -81,7 +81,7 @@ public interface DiarySpecification {
     ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
-    @Operation(summary = "직접 일기 작성하기 API",description = "특정 사용자가 일기를 텍스트로 직접 작성하는 API입니다. 작성내용과 작성일자를 보내주세요")
+    @Operation(summary = "직접 작성한 일기 임시저장하기 API",description = "직접 작성한 일기를 임시저장하는 API입니다. 작성내용과 작성일자를 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -81,7 +81,7 @@ public interface DiarySpecification {
     ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
-    @Operation(summary = "직접 작성한 일기 임시저장하기 API",description = "직접 작성한 일기를 임시저장하는 API입니다. 작성내용과 작성일자를 보내주세요")
+    @Operation(summary = "직접 작성한 일기 임시저장 API",description = "직접 작성한 일기를 임시저장하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
@@ -90,14 +90,14 @@ public interface DiarySpecification {
     ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
     @PostMapping("/voice/chat")
-    @Operation(summary = "AI와 음성 대화하기 API",description = "AI와 자신의 하루를 음성으로 대화 나누는 API입니다. 음성내용(STT)을 보내주세요")
+    @Operation(summary = "AI와 음성 대화 API",description = "AI와 자신의 하루를 음성으로 대화 나누는 API입니다. 음성내용(STT)을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })
     ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request);
 
-    @PostMapping("/summary")
-    @Operation(summary = "음성대화 종료 및 요약 후 일기 생성 API",description = "음성 대화를 종료하면서 음성 대화하기 API를 사용하여 대화한 내용을 바탕으로 그 날의 일기를 작성해주는 API입니다. 작성 날짜를 보내주세요.")
+    @PostMapping("/voice")
+    @Operation(summary = "음성으로 작성한 일기 임시저장 API",description = "AI와 대화한 내용을 바탕으로 생성한 일기를 임시저장하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -1,19 +1,12 @@
 package umc.GrowIT.Server.web.controller.specification;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryResponseDTO;
@@ -101,7 +94,7 @@ public interface DiarySpecification {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })
-    ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request);
+    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request);
 
     @PostMapping("/{diaryId}/analyze")
     @Operation(

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -87,7 +87,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE_400_02",description = "❌ 날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request);
 
     @PostMapping("/voice/chat")
     @Operation(summary = "AI와 음성 대화 API",description = "AI와 자신의 하루를 음성으로 대화 나누는 API입니다. 음성내용(STT)을 보내주세요")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -103,12 +103,11 @@ public interface DiarySpecification {
     })
     ApiResponse<DiaryResponseDTO.SummaryResultDTO> createDiaryByVoice(@RequestBody DiaryRequestDTO.SummaryDTO request);
 
-    @PostMapping("/analyze/{diaryId}")
+    @PostMapping("/{diaryId}/analyze")
     @Operation(
             summary = "일기 분석 API",
             description = "일기 내용을 분석하여, 적절한 감정과 데일리/랜덤 챌린지를 반환하는 API입니다.<br>" +
-                    "일기 ID를 path variable로 전달받아 해당 일기를 분석합니다.<br>" +
-                    "❗Request Header에 JWT Access Token 값을 넣어야 합니다.❗"
+                    "일기 ID를 path variable로 전달받아 해당 일기를 분석합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -89,8 +89,8 @@ public interface DiarySpecification {
     })
     ApiResponse<DiaryResponseDTO.CreateDiaryResultDTO> createDiaryByText(@Valid @RequestBody DiaryRequestDTO.CreateDiaryDTO request);
 
-    @PostMapping("/voice")
-    @Operation(summary = "음성 대화하기 API",description = "특정 사용자가 일기를 음성으로 말하며 작성하는 API입니다. 음성내용(STT)을 보내주세요")
+    @PostMapping("/voice/chat")
+    @Operation(summary = "AI와 음성 대화하기 API",description = "AI와 자신의 하루를 음성으로 대화 나누는 API입니다. 음성내용(STT)을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -12,14 +12,16 @@ public class DiaryRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "일기 작성 request")
+    @Schema(title = "직접 일기 임시저장 request")
     public static class CreateDiaryDTO {
-        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
+
         @NotNull
         @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
+        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         String content;
-        @Schema(description = "일기 작성 날짜")
+
         @NotNull
+        @Schema(description = "일기 작성 날짜")
         LocalDate date;
     }
 
@@ -29,9 +31,9 @@ public class DiaryRequestDTO {
     @AllArgsConstructor
     @Schema(title = "일기 수정 request")
     public static class ModifyDiaryDTO {
-        @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         @NotNull
         @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
+        @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
         String content;
     }
 
@@ -39,10 +41,10 @@ public class DiaryRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "음성 대화 request")
+    @Schema(title = "AI 음성 대화 request")
     public static class VoiceChatDTO {
-        @Schema(description = "사용자의 음성내용", example = "오늘 정말 힘든 하루였어.")
         @NotNull
+        @Schema(description = "사용자의 음성내용", example = "오늘 정말 힘든 하루였어.")
         String chat;
     }
 
@@ -50,10 +52,10 @@ public class DiaryRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "일기 요약 request")
+    @Schema(title = "음성 일기 임시저장 request")
     public static class SummaryDTO {
-        @Schema(description = "일기 작성 날짜")
         @NotNull
+        @Schema(description = "일기 작성 날짜")
         LocalDate date;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -13,7 +13,7 @@ public class DiaryRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(title = "직접 일기 임시저장 request")
-    public static class CreateDiaryDTO {
+    public static class SaveTextDiaryDTO {
 
         @NotNull
         @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -3,7 +3,10 @@ package umc.GrowIT.Server.web.dto.DiaryDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
@@ -53,7 +56,7 @@ public class DiaryRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(title = "음성 일기 임시저장 request")
-    public static class SummaryDTO {
+    public static class SaveVoiceDiaryDTO {
         @NotNull
         @Schema(description = "일기 작성 날짜")
         LocalDate date;

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -64,16 +64,13 @@ public class DiaryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(title = "일기 작성 response")
-    public static class CreateDiaryResultDTO {
+    @Schema(title = "일기 저장 response")
+    public static class SaveDiaryResultDTO {
         @Schema(description = "일기 id", example = "1")
         Long diaryId;
-        @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+
         @Schema(description = "일기 작성 날짜")
         LocalDate date;
-        @Schema(description = "크레딧 정보")
-        CreditInfo creditInfo;
     }
 
     @Builder

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -11,8 +11,6 @@ import umc.GrowIT.Server.web.dto.KeywordDTO.KeywordResponseDTO;
 import java.time.LocalDate;
 import java.util.List;
 
-;
-
 public class DiaryResponseDTO {
     @Builder
     @Getter
@@ -93,33 +91,6 @@ public class DiaryResponseDTO {
     public static class VoiceChatResultDTO {
         @Schema(description = "AI의 답변 내용", example = "힘든 하루셨군요. 어떤 일이 있으셨나요?")
         String chat;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Schema(title = "일기 요약 response")
-    public static class SummaryResultDTO {
-        @Schema(description = "일기 id", example = "1")
-        Long diaryId;
-        @Schema(description = "일기 요약 내용", example = "오늘은 평소보다 더 차분한 하루를 보냈다. 아침에 일어나 창밖을 보니..")
-        String content;
-        @Schema(description = "일기 작성 날짜")
-        LocalDate date;
-        @Schema(description = "크레딧 정보")
-        CreditInfo creditInfo;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class CreditInfo {
-        @Schema(description = "크레딧 지급 여부", example = "true")
-        Boolean granted;
-        @Schema(description = "지급된 크레딧 양 (지급되지 않은 경우 0)", example = "2")
-        Integer amount;
     }
 
     @Getter


### PR DESCRIPTION
## 📝 작업 내용
승현님과 파트를 나누어서 작업 진행하였습니다. #381 

### API 엔드포인트 변경
<img width="300" height="200" alt="스크린샷 2025-09-15 오후 4 16 32" src="https://github.com/user-attachments/assets/284a9500-7c6c-484d-9939-e31b2e11feb3" />

### 로직 수정
- 동일 날짜에 작성한 일기 존재하는지 체크할 때에 `COMPLETED` 조건 추가
- 일기 저장 시, `PENDING` + `TEXT` or `VOICE` 추가 저장
- 크레딧 제공 & 기록 코드 삭제

(그 외, 메소드, dto 등 자잘한 것들 수정하였습니다)

### 스케줄러 구현
스케줄러를 통해 `PENDING`일기 삭제 진행

## 👀 참고사항
X

## 🔍 테스트 방법
X