### PR TITLE
[#398] Fix: 챌린지 홈에서 일기 데이터 조회 시 COMPLETED 조건 추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
@@ -27,11 +27,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Diary> findCompletedByUserIdAndId(@Param("userId") Long userId,
                                                @Param("diaryId") Long diaryId);
 
-    @Query("SELECT MAX(d.date) FROM Diary d WHERE d.user.id = :userId") // 마지막 일기 작성 날짜 조회
+    // 마지막 일기 작성 날짜 조회
+    @Query("SELECT MAX(d.date) FROM Diary d WHERE d.user.id = :userId " +
+            "AND d.status = umc.GrowIT.Server.domain.enums.DiaryStatus.COMPLETED")
     Optional<LocalDate> findLastDiaryDateByUserId(@Param("userId") Long userId);
 
     // 오늘 작성한 일기 조회
-    @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND d.date = :date")
+    @Query("SELECT d FROM Diary d WHERE d.user.id = :userId AND d.date = :date " +
+            "AND d.status = umc.GrowIT.Server.domain.enums.DiaryStatus.COMPLETED")
     Optional<Diary> findTodayDiaryByUserId(@Param("userId") Long userId, @Param("date") LocalDate date);
 
     @Modifying


### PR DESCRIPTION
## 📝 작업 내용
일기 상태 PENDING, COMPLETED 추가 이후
일기가 PENDING 상태임에도 챌린지 홈에서 일기의 감정키워드가 조회되는 문제가 발생
-> 쿼리문에 COMPLETED 조건 추가하였습니다.

챌린지 리포트의 "마지막 일기 작성 날짜 조회" 쿼리문에도 COMPLETED 조건 추가하였습니다.

## 👀 참고사항
x


## 🔍 테스트 방법
x