### PR TITLE
[#391] refactor : @AuthenticationPrincipal를 사용한 userId 조회 적용

### DIFF
--- a/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/AuthController.java
@@ -3,8 +3,7 @@ package umc.GrowIT.Server.web.controller;
 import static umc.GrowIT.Server.apiPayload.code.status.SuccessStatus.NEED_TO_ACCEPT_TERMS;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -110,11 +109,7 @@ public class AuthController implements AuthSpecification {
 
     @Override
     @PostMapping("/logout")
-    public ApiResponse<AuthResponseDTO.LogoutResponseDTO> logout() {
-        // AccessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<AuthResponseDTO.LogoutResponseDTO> logout(@AuthenticationPrincipal Long userId) {
         // 로그아웃 처리
         AuthResponseDTO.LogoutResponseDTO result = authService.logout(userId);
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -3,8 +3,7 @@ package umc.GrowIT.Server.web.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.UserChallengeType;
@@ -28,19 +27,16 @@ public class ChallengeController implements ChallengeSpecification {
     private final ChallengeCommandService challengeCommandService;
 
     @GetMapping("")
-    public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
+    public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(challengeQueryService.getChallengeHome(userId));
     }
 
     @GetMapping("status")
     public ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
+            @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) UserChallengeType challengeType,
             @RequestParam Boolean completed,
             @RequestParam Integer page) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
         // 서비스 호출
         ChallengeResponseDTO.ChallengeStatusPagedResponseDTO challengeStatusList = challengeQueryService.getChallengeStatus(userId, challengeType, completed, page);
 
@@ -49,56 +45,38 @@ public class ChallengeController implements ChallengeSpecification {
     }
 
     @PostMapping("select")
-    public ApiResponse<Void> selectChallenges(@RequestBody ChallengeRequestDTO.SelectChallengesRequestDTO selectRequestList) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<Void> selectChallenges(@AuthenticationPrincipal Long userId, @RequestBody ChallengeRequestDTO.SelectChallengesRequestDTO selectRequestList) {
         challengeCommandService.selectChallenges(userId, selectRequestList);
         return ApiResponse.onSuccess();
     }
 
     @PostMapping("presigned-url")
-    public ApiResponse<ChallengeResponseDTO.ProofPresignedUrlResponseDTO> getProofPresignedUrl(@Valid @RequestBody ChallengeRequestDTO.ProofRequestPresignedUrlDTO request) {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<ChallengeResponseDTO.ProofPresignedUrlResponseDTO> getProofPresignedUrl(@AuthenticationPrincipal Long userId, @Valid @RequestBody ChallengeRequestDTO.ProofRequestPresignedUrlDTO request) {
         ChallengeResponseDTO.ProofPresignedUrlResponseDTO result = challengeCommandService.createChallengePresignedUrl(userId, request);
 
         return ApiResponse.onSuccess(result);
     }
 
     @PostMapping("{userChallengeId}")
-    public ApiResponse<ChallengeResponseDTO.CreateProofDTO> createChallengeProof(@PathVariable Long userChallengeId, @Valid @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest) {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
+    public ApiResponse<ChallengeResponseDTO.CreateProofDTO> createChallengeProof(@AuthenticationPrincipal Long userId, @PathVariable Long userChallengeId, @Valid @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest) {
         ChallengeResponseDTO.CreateProofDTO response = challengeCommandService.createChallengeProof(userId, userChallengeId, proofRequest);
         return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("{userChallengeId}")
-    public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long userChallengeId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
+    public ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@AuthenticationPrincipal Long userId, @PathVariable Long userChallengeId) {
         ChallengeResponseDTO.ProofDetailsDTO response = challengeQueryService.getChallengeProofDetails(userId, userChallengeId);
         return ApiResponse.onSuccess(response);
     }
 
     @PatchMapping("{userChallengeId}")
-    public ApiResponse<Void> updateChallengeProof(@PathVariable("userChallengeId") Long userChallengeId, @Valid @RequestBody(required = false) ChallengeRequestDTO.ProofRequestDTO updateRequest) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
+    public ApiResponse<Void> updateChallengeProof(@AuthenticationPrincipal Long userId, @PathVariable("userChallengeId") Long userChallengeId, @Valid @RequestBody(required = false) ChallengeRequestDTO.ProofRequestDTO updateRequest) {
         challengeCommandService.updateChallengeProof(userId, userChallengeId, updateRequest);
         return ApiResponse.onSuccess();
     }
 
     @DeleteMapping("{userChallengeId}")
-    public ApiResponse<Void> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId) {
-        //AccessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<Void> deleteChallenge(@AuthenticationPrincipal Long userId, @PathVariable("userChallengeId") Long userChallengeId) {
         challengeCommandService.delete(userChallengeId, userId);
         return ApiResponse.onSuccess();
     }

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -3,8 +3,7 @@ package umc.GrowIT.Server.web.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.service.diaryService.DiaryCommandService;
@@ -23,83 +22,48 @@ public class DiaryController implements DiarySpecification {
     private final DiaryCommandService diaryCommandService;
 
     @GetMapping("/voice/exists")
-    public ApiResponse<Boolean> hasVoiceDiary(){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<Boolean> hasVoiceDiary(@AuthenticationPrincipal Long userId){
         return ApiResponse.onSuccess(diaryQueryService.hasVoiceDiaries(userId));
     }
 
     @GetMapping("/dates")
-    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@RequestParam Integer year,
+    public ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(@AuthenticationPrincipal Long userId,
+                                                                       @RequestParam Integer year,
                                                                        @RequestParam Integer month){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
         return ApiResponse.onSuccess(diaryQueryService.getDiaryDate(year,month,userId));
     }
     @GetMapping("")
-    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@RequestParam Integer year,
+    public ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(@AuthenticationPrincipal Long userId,
+                                                                   @RequestParam Integer year,
                                                                    @RequestParam Integer month){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
         return ApiResponse.onSuccess(diaryQueryService.getDiaryList(year,month,userId));
     }
     @GetMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId){
         return ApiResponse.onSuccess(diaryQueryService.getDiary(diaryId, userId));
     }
 
     @PatchMapping("/{diaryId}")
-    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request){
         return ApiResponse.onSuccess(diaryCommandService.modifyDiary(request, diaryId, userId));
     }
 
     @DeleteMapping("/{diaryId}")
-    public ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
+    public ApiResponse<Void> deleteDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId){
         diaryCommandService.deleteDiary(diaryId, userId);
         return ApiResponse.onSuccess();
     }
     @PostMapping("/text")
-    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request){
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@AuthenticationPrincipal Long userId, @Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request){
         return ApiResponse.onSuccess(diaryCommandService.saveDiaryByText(request, userId));
     }
     @PostMapping("/voice/chat")
-    public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request){
-
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@AuthenticationPrincipal Long userId, @RequestBody DiaryRequestDTO.VoiceChatDTO request){
         return ApiResponse.onSuccess(diaryCommandService.chatByVoice(request, userId));
     }
 
     @PostMapping("/voice")
-    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request) {
-
-        //accessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@AuthenticationPrincipal Long userId, @RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request) {
         return ApiResponse.onSuccess(diaryCommandService.saveDiaryByVoice(request, userId));
     }
 

--- a/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/GroController.java
@@ -5,8 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.service.groService.GroCommandService;
 import umc.GrowIT.Server.service.groService.GroQueryService;
@@ -23,10 +22,8 @@ public class GroController implements GroSpecification {
     private final GroCommandService groCommandService;
     private final GroQueryService groQueryService;
 
-    public ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@Valid @RequestBody GroRequestDTO.CreateRequestDTO request) {
-
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+    @Override
+    public ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@AuthenticationPrincipal Long userId, @Valid @RequestBody GroRequestDTO.CreateRequestDTO request) {
         System.out.println(userId);
         String name = request.getName();
         String backgroundItem = request.getBackgroundItem();
@@ -38,11 +35,7 @@ public class GroController implements GroSpecification {
 
     @Override
     @GetMapping("")
-    public ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems() {
-        //AccessToken에서 userId 추출
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems(@AuthenticationPrincipal Long userId) {
         GroResponseDTO.GroAndEquippedItemsDTO result = groQueryService.getGroAndEquippedItems(userId);
 
         return ApiResponse.onSuccess(result);
@@ -50,10 +43,7 @@ public class GroController implements GroSpecification {
 
     @Override
     @PatchMapping("/nickname")
-    public ApiResponse<Void> updateNickname(@Valid @RequestBody GroRequestDTO.NicknameRequestDTO nicknameDTO) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<Void> updateNickname(@AuthenticationPrincipal Long userId, @Valid @RequestBody GroRequestDTO.NicknameRequestDTO nicknameDTO) {
         groCommandService.updateNickname(userId, nicknameDTO.getName());
         return ApiResponse.onSuccess();
     }

--- a/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ItemController.java
@@ -3,8 +3,7 @@ package umc.GrowIT.Server.web.controller;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
@@ -26,21 +25,14 @@ public class ItemController implements ItemSpecification {
 
     @Override
     @GetMapping("")
-    public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(ItemCategory category) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
-
+    public ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(@AuthenticationPrincipal Long userId, ItemCategory category) {
         return ApiResponse.onSuccess(itemQueryServiceImpl.getItemList(category, userId));
-
     }
 
     //그로 아이템 착용/해제
     @Override
     @PatchMapping("/{itemId}")
-    public ApiResponse<ItemEquipResponseDTO> updateItemStatus(Long itemId, ItemEquipRequestDTO request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<ItemEquipResponseDTO> updateItemStatus(@AuthenticationPrincipal Long userId, @PathVariable Long itemId, @RequestBody ItemEquipRequestDTO request) {
         String status = request.getStatus();
 
         return ApiResponse.onSuccess(itemCommandService.updateItemStatus(userId, itemId, status));
@@ -48,10 +40,7 @@ public class ItemController implements ItemSpecification {
 
     @Override
     @PostMapping("/{itemId}/purchase")
-    public ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(Long itemId) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
-
+    public ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(@AuthenticationPrincipal Long userId, @PathVariable Long itemId) {
         ItemResponseDTO.PurchaseItemResponseDTO purchasedItem = itemCommandService.purchase(itemId, userId);
 
         return ApiResponse.onSuccess(purchasedItem);

--- a/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/UserController.java
@@ -3,8 +3,7 @@ package umc.GrowIT.Server.web.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.domain.enums.ItemCategory;
@@ -34,26 +33,19 @@ public class UserController implements UserSpecification {
 
     @Override
     @GetMapping("/items")
-    public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(ItemCategory category) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
-
+    public ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(@AuthenticationPrincipal Long userId, ItemCategory category) {
         return ApiResponse.onSuccess(itemQueryServiceImpl.getUserOwnedItemList(category, userId));
     }
 
     @Override
     @GetMapping("/credits")
-    public ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+    public ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(creditQueryService.getCurrentCredit(userId));
     }
 
     @Override
     @GetMapping("/credits/total")
-    public ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal(); //사용자 식별 id
+    public ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(creditQueryService.getTotalCredit(userId));
     }
 
@@ -67,14 +59,12 @@ public class UserController implements UserSpecification {
     @Override
     @GetMapping("/credits/history")
     public ApiResponse<UserResponseDTO.CreditHistoryResponseDTO> getCreditHistory(
+            @AuthenticationPrincipal Long userId,
             @RequestParam Integer year,
             @RequestParam Integer month,
             @RequestParam CreditTransactionType type,
             @RequestParam int page
     ) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
         return ApiResponse.onSuccess(userQueryService.getCreditHistory(userId, year, month, type, page));
     }
 
@@ -82,11 +72,9 @@ public class UserController implements UserSpecification {
     @Override
     @DeleteMapping("")
     public ApiResponse<Void> withdrawUser(
+            @AuthenticationPrincipal Long userId,
             @Valid @RequestBody UserRequestDTO.DeleteUserRequestDTO deleteUserRequestDTO
     ) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
         userCommandService.withdraw(userId, deleteUserRequestDTO);
         return ApiResponse.onSuccess();
     }
@@ -102,20 +90,14 @@ public class UserController implements UserSpecification {
 
     @Override
     @GetMapping("/mypage")
-    public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<UserResponseDTO.MyPageDTO> getMyPage(@AuthenticationPrincipal Long userId) {
         UserResponseDTO.MyPageDTO result = userQueryService.getMyPage(userId);
         return ApiResponse.onSuccess(result);
     }
 
     @Override
     @GetMapping("/me/email")
-    public ApiResponse<UserResponseDTO.EmailResponseDTO> getMyEmail() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Long userId = (Long) authentication.getPrincipal();
-
+    public ApiResponse<UserResponseDTO.EmailResponseDTO> getMyEmail(@AuthenticationPrincipal Long userId) {
         UserResponseDTO.EmailResponseDTO result = userQueryService.getMyEmail(userId);
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/AuthSpecification.java
@@ -1,6 +1,7 @@
 package umc.GrowIT.Server.web.controller.specification;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -124,5 +125,5 @@ public interface AuthSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH_401_02", description = "❌ 만료된 토큰입니다. 토큰의 만료 시간이 지나 더 이상 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH_401_05", description = "❌ 토큰이 제공되지 않았습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<AuthResponseDTO.LogoutResponseDTO> logout();
+    ApiResponse<AuthResponseDTO.LogoutResponseDTO> logout(@AuthenticationPrincipal Long userId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.controller.specification;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,7 +29,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome();
+    ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId);
 
     @GetMapping("status")
     @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다. <br> " +
@@ -38,6 +39,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ChallengeResponseDTO.ChallengeStatusPagedResponseDTO> getChallengeStatus(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "챌린지 유형",
                     example = "DAILY")
             @RequestParam(required = false) UserChallengeType challengeType,
@@ -64,7 +66,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY_400_03", description = "❌ 임시저장된 일기가 아닙니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY_404_01", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Void> selectChallenges(@RequestBody ChallengeRequestDTO.SelectChallengesRequestDTO selectRequestList);
+    ApiResponse<Void> selectChallenges(@AuthenticationPrincipal Long userId, @RequestBody ChallengeRequestDTO.SelectChallengesRequestDTO selectRequestList);
 
     @PostMapping("presigned-url")
     @Operation(summary = "사용자 챌린지 인증 이미지 업로드용 presigned url 생성 API", description = "사용자 챌린지 인증 이미지를 S3에 직접 업로드할 수 있는 presigned url을 생성합니다.")
@@ -72,7 +74,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "S3_400_01", description = "❌ 파일 확장자가 잘못되었습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ProofPresignedUrlResponseDTO> getProofPresignedUrl(@Valid @RequestBody ChallengeRequestDTO.ProofRequestPresignedUrlDTO request);
+    ApiResponse<ChallengeResponseDTO.ProofPresignedUrlResponseDTO> getProofPresignedUrl(@AuthenticationPrincipal Long userId, @Valid @RequestBody ChallengeRequestDTO.ProofRequestPresignedUrlDTO request);
 
     @PostMapping("{userChallengeId}")
     @Operation(summary = "사용자 챌린지 인증 작성 API", description = "사용자의 특정 챌린지 인증내역을 작성하는 API입니다. <br>" +
@@ -86,7 +88,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC_409_02", description = "❌ 이미 완료된 챌린지입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 작성할 사용자 챌린지의 ID", example = "1")
-    ApiResponse<ChallengeResponseDTO.CreateProofDTO> createChallengeProof(@PathVariable Long userChallengeId,
+    ApiResponse<ChallengeResponseDTO.CreateProofDTO> createChallengeProof(@AuthenticationPrincipal Long userId, @PathVariable Long userChallengeId,
             @Valid @RequestBody ChallengeRequestDTO.ProofRequestDTO proofRequest);
 
     @GetMapping("{userChallengeId}")
@@ -99,7 +101,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC_404_01", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 내역을 조회할 사용자 챌린지의 ID", example = "1")
-    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@PathVariable Long userChallengeId);
+    ApiResponse<ChallengeResponseDTO.ProofDetailsDTO> getChallengeProofDetails(@AuthenticationPrincipal Long userId, @PathVariable Long userChallengeId);
 
 
     @PatchMapping("{userChallengeId}")
@@ -113,7 +115,7 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC_404_01", description = "❌ 사용자 챌린지가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "인증 내역을 수정할 사용자 챌린지의 ID", example = "1")
-    ApiResponse<Void> updateChallengeProof(@PathVariable Long userChallengeId,
+    ApiResponse<Void> updateChallengeProof(@AuthenticationPrincipal Long userId, @PathVariable Long userChallengeId,
             @Valid @RequestBody(required = false) ChallengeRequestDTO.ProofRequestDTO updateRequest);
 
     @DeleteMapping("{userChallengeId}")
@@ -131,5 +133,5 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UC_409_01", description = "❌ 완료된 챌린지는 삭제가 불가합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "userChallengeId", description = "삭제할 사용자 챌린지의 ID", example = "1")
-    ApiResponse<Void> deleteChallenge(@PathVariable("userChallengeId") Long userChallengeId);
+    ApiResponse<Void> deleteChallenge(@AuthenticationPrincipal Long userId, @PathVariable("userChallengeId") Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/DiarySpecification.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.GrowIT.Server.apiPayload.ApiResponse;
 import umc.GrowIT.Server.web.dto.DiaryDTO.DiaryRequestDTO;
@@ -17,7 +18,7 @@ public interface DiarySpecification {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })
-    ApiResponse<Boolean> hasVoiceDiary();
+    ApiResponse<Boolean> hasVoiceDiary(@AuthenticationPrincipal Long userId);
 
     @GetMapping("/dates")
     @Operation(summary = "일기 작성 날짜 조회 API",description = "특정 사용자의 일기 메인 화면에서 사용할 월별 일기 기록한 날짜를 보여주기 위한 API입니다. Query String으로 year와 month를 주세요." +
@@ -27,6 +28,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE_400_01", description = "❌ 유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.DiaryDateListDTO> getDiaryDate(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "일기 작성 연도",
                     example = "2025")@RequestParam Integer year,
             @Parameter(description = "일기 작성 월",
@@ -39,6 +41,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE_400_01", description = "❌ 유효하지 않은 날짜입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<DiaryResponseDTO.DiaryListDTO> getDiaryList(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "일기 작성 연도",
                     example = "2025")@RequestParam Integer year,
             @Parameter(description = "일기 작성 월",
@@ -51,7 +54,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY_404_01", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "조회할 일기의 ID", example = "1")
-    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@PathVariable("diaryId") Long diaryId);
+    ApiResponse<DiaryResponseDTO.DiaryDTO> getDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId);
 
     @PatchMapping("/{diaryId}")
     @Operation(summary = "일기 수정하기 API",description = "특정 사용자가 작성한 일기를 수정하는 API입니다. path variable로 일기의 id, RequestBody로 수정한 내용과 수정 시간을 보내주세요")
@@ -62,7 +65,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY_400_02",description = "❌ 기존 일기와 동일한 내용입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "수정할 일기의 ID", example = "1")
-    ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.ModifyDiaryResultDTO> modifyDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId, @Valid @RequestBody DiaryRequestDTO.ModifyDiaryDTO request);
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "일기 삭제하기 API",description = "특정 사용자가 작성한 일기를 삭제하는 API입니다. path variable로 일기의 id를 보내주세요")
@@ -71,7 +74,7 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY_404_01", description = "❌ 존재하지 않는 일기입니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "diaryId", description = "삭제할 일기의 ID", example = "1")
-    ApiResponse<Void> deleteDiary(@PathVariable("diaryId") Long diaryId);
+    ApiResponse<Void> deleteDiary(@AuthenticationPrincipal Long userId, @PathVariable("diaryId") Long diaryId);
 
     @PostMapping("/text")
     @Operation(summary = "직접 작성한 일기 임시저장 API",description = "직접 작성한 일기를 임시저장하는 API입니다.")
@@ -80,21 +83,21 @@ public interface DiarySpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400",description = "❌ 일기는 100자 이상으로 작성해야 합니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DATE_400_02",description = "❌ 날짜는 오늘 이후로 설정할 수 없습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByText(@AuthenticationPrincipal Long userId, @Valid @RequestBody DiaryRequestDTO.SaveTextDiaryDTO request);
 
     @PostMapping("/voice/chat")
     @Operation(summary = "AI와 음성 대화 API",description = "AI와 자신의 하루를 음성으로 대화 나누는 API입니다. 음성내용(STT)을 보내주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })
-    ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@RequestBody DiaryRequestDTO.VoiceChatDTO request);
+    ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@AuthenticationPrincipal Long userId, @RequestBody DiaryRequestDTO.VoiceChatDTO request);
 
     @PostMapping("/voice")
     @Operation(summary = "음성으로 작성한 일기 임시저장 API",description = "AI와 대화한 내용을 바탕으로 생성한 일기를 임시저장하는 API입니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
     })
-    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request);
+    ApiResponse<DiaryResponseDTO.SaveDiaryResultDTO> saveDiaryByVoice(@AuthenticationPrincipal Long userId, @RequestBody DiaryRequestDTO.SaveVoiceDiaryDTO request);
 
     @PostMapping("/{diaryId}/analyze")
     @Operation(

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/GroSpecification.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.controller.specification;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,7 +24,7 @@ public interface GroSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO_409_02", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ 닉네임은 2~8자 이내로 작성해야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@Valid @RequestBody GroRequestDTO.CreateRequestDTO request);
+    ApiResponse<GroResponseDTO.CreateResponseDTO> createGro(@AuthenticationPrincipal Long userId, @Valid @RequestBody GroRequestDTO.CreateRequestDTO request);
 
     @GetMapping("")
     @Operation(
@@ -38,7 +39,7 @@ public interface GroSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO_500_01", description = "❌ 그로 레벨이 유효하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "UI_404_01", description = "❌ 착용 중인 사용자 아이템이 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems();
+    ApiResponse<GroResponseDTO.GroAndEquippedItemsDTO> getGroAndEquippedItems(@AuthenticationPrincipal Long userId);
 
     @PatchMapping("/nickname")
     @Operation(summary = "그로 닉네임 변경", description = "그로의 닉네임을 변경합니다. 닉네임을 2~8자 사이로 입력해주세요.")
@@ -48,5 +49,5 @@ public interface GroSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO_409_02", description = "❌ 다른 닉네임과 중복되는 닉네임입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "GRO_400_01", description = "❌ 그로의 닉네임에 수정사항이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Void> updateNickname(@Valid @RequestBody GroRequestDTO.NicknameRequestDTO request);
+    ApiResponse<Void> updateNickname(@AuthenticationPrincipal Long userId, @Valid @RequestBody GroRequestDTO.NicknameRequestDTO request);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ItemSpecification.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.controller.specification;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,12 +22,13 @@ import umc.GrowIT.Server.web.dto.ItemEquipDTO.ItemEquipResponseDTO;
 
 public interface ItemSpecification {
 
-    @GetMapping("/items")
+    @GetMapping("")
     @Operation(summary = "카테고리별 아이템 조회", description = "상점이나 보유아이템 조회에서 카테고리를 선택했을 때 실행.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS")
     })
     ApiResponse<ItemResponseDTO.ItemListDTO> getItemList(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
                     schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
                     example = "BACKGROUND")
@@ -34,7 +36,7 @@ public interface ItemSpecification {
 
 
 
-    @PatchMapping("/items/{itemId}")
+    @PatchMapping("/{itemId}")
     @Operation(summary = "아이템 착용/해제", description = "아이템의 착용 상태를 변경합니다. " +
             "착용하려면 EQUIPPED를, 해제하려면 UNEQUIPPED를 전달하세요.")
     @ApiResponses({
@@ -43,6 +45,7 @@ public interface ItemSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ITEM_409_01", description = "❌ 이미 착용중인 아이템입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<ItemEquipResponseDTO> updateItemStatus(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "아이템 ID", example = "1")
             @PathVariable(name = "itemId") Long itemId,
             @Valid @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -56,7 +59,7 @@ public interface ItemSpecification {
 
 
 
-    @PostMapping("/items/{itemId}/purchase")
+    @PostMapping("/{itemId}/purchase")
     @Operation(summary = "아이템 구매 API", description = "특정 아이템을 구매하는 API입니다. 아이템 ID를 path variable로 전달받아 해당 아이템을 주문합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
@@ -67,5 +70,5 @@ public interface ItemSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT_400_01", description = "❌ 보유 크레딧이 부족합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     @Parameter(name = "itemId", description = "주문할 아이템의 ID", required = true)
-    ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(@PathVariable("itemId") Long itemId);
+    ApiResponse<ItemResponseDTO.PurchaseItemResponseDTO> purchaseItem(@AuthenticationPrincipal Long userId, @PathVariable("itemId") Long itemId);
 }

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/UserSpecification.java
@@ -1,5 +1,6 @@
 package umc.GrowIT.Server.web.controller.specification;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,6 +33,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS")
     })
     ApiResponse<ItemResponseDTO.ItemListDTO> getUserItemList(
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "아이템 카테고리 (카테고리 명으로 전달)",
                     schema = @Schema(allowableValues = {"BACKGROUND", "OBJECT", "PLANT", "HEAD_ACCESSORY"}),
                     example = "BACKGROUND")
@@ -44,7 +46,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER_401_01", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit();
+    ApiResponse<CreditResponseDTO.CurrentCreditDTO> getUserCredit(@AuthenticationPrincipal Long userId);
 
 
     @GetMapping("/credits/total")
@@ -53,7 +55,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CREDIT_404_01", description = "❌ 크레딧 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit();
+    ApiResponse<CreditResponseDTO.TotalCreditDTO> getUserTotalCredit(@AuthenticationPrincipal Long userId);
 
 
     @PostMapping("/credits/payment")
@@ -72,6 +74,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<UserResponseDTO.CreditHistoryResponseDTO> getCreditHistory (
+            @AuthenticationPrincipal Long userId,
             @Parameter(description = "조회 연도", example = "2025") @RequestParam Integer year,
             @Parameter(description = "조회 월", example = "9") @RequestParam Integer month,
             @Parameter(description = "조회 타입 (ALL, EARN, SPEND)", example = "ALL")
@@ -91,7 +94,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER_401_01", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "WITHDRAWAL_404_01", description = "❌ 존재하지 않는 탈퇴 사유입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<Void> withdrawUser(@Valid @RequestBody UserRequestDTO.DeleteUserRequestDTO deleteUserRequestDTO);
+    ApiResponse<Void> withdrawUser(@AuthenticationPrincipal Long userId, @Valid @RequestBody UserRequestDTO.DeleteUserRequestDTO deleteUserRequestDTO);
 
 
     @PatchMapping("/password")
@@ -114,7 +117,7 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER_401_01", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<UserResponseDTO.MyPageDTO> getMyPage();
+    ApiResponse<UserResponseDTO.MyPageDTO> getMyPage(@AuthenticationPrincipal Long userId);
 
 
     @GetMapping("/me/email")
@@ -124,5 +127,5 @@ public interface UserSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER_401_01", description = "❌ 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<UserResponseDTO.EmailResponseDTO> getMyEmail ();
+    ApiResponse<UserResponseDTO.EmailResponseDTO> getMyEmail(@AuthenticationPrincipal Long userId);
 }


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 간략히 설명해주세요 -->
```java
public ApiResponse<ItemEquipResponseDTO> updateItemStatus(Long itemId, ItemEquipRequestDTO request) {
          Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
          Long userId = (Long) authentication.getPrincipal();

```

기존에 위와 같은 방법으로 userId를 조회하고있기 때문에 똑같은 코드가 반복되고 있어 이를  `@AuthenticationPrincipal` 어노테이션을 사용해 주입받도록 리팩토링하였습니다.


## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
userId 를 사용하는  컨트롤러 메서드를 실행하면됩니다.
리팩토링한 메서드 모두 테스트 성공했습니다.