### PR TITLE
[#405] Fix: 일기 수정&삭제 API 조회 조건 수정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/DiaryRepository.java
@@ -47,6 +47,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("DELETE FROM Diary d WHERE d.status = :status")
     int deleteByStatus(@Param("status") DiaryStatus status);
 
+    Optional<Diary> findByIdAndUserId(Long diaryId, Long userId);
+
     // TODO 회원탈퇴 API 네이티브 삭제 메소드 - 추후 확인 필요
 //    @Modifying
 //    @Query(value = "DELETE FROM diary WHERE user_id = :userId", nativeQuery = true)

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -75,7 +75,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         //유저 조회
         userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Optional<Diary> optionalDiary = diaryRepository.findCompletedByUserIdAndId(userId, diaryId);
+        Optional<Diary> optionalDiary = diaryRepository.findByIdAndUserId(diaryId, userId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
         //기존의 내용과 변경되지 않았을 경우
@@ -113,7 +113,7 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
         //유저 조회
         userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Optional<Diary> optionalDiary = diaryRepository.findCompletedByUserIdAndId(userId, diaryId);
+        Optional<Diary> optionalDiary = diaryRepository.findByIdAndUserId(diaryId, userId);
         Diary diary = optionalDiary.orElseThrow(()->new DiaryHandler(ErrorStatus.DIARY_NOT_FOUND));
 
         //일기 삭제


### PR DESCRIPTION
## 📝 작업 내용
#381
지난번에 위의 이슈와 같이 흐름을 정리하였으나, 아래와 같은 문제를 발견하였습니다.
(추가로 삭제 API에도 잘못 작업돼있는 것을 발견하였습니다.)

- 음성 일기 작성 중 중간 과정(`PENDING` 상태)에서도 일기 수정 API의 호출이 필요한 시나리오 존재
- 특정 일기 삭제 API에는 조건 추가(`COMPLETED`)하지 않았어야 하는데, 추가돼 있는 문제

## 👀 참고사항
X


## 🔍 테스트 방법
X