### PR TITLE
[#410] Feat: 음성 대화 일기 작성 시 로직 수정/추가

### DIFF
--- a/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/GrowIT/Server/apiPayload/code/status/ErrorStatus.java
@@ -106,6 +106,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_SAME_CONTENT(HttpStatus.BAD_REQUEST, "DIARY_400_02", "기존 일기와 동일한 내용입니다."),
     DIARY_NOT_PENDING(HttpStatus.NOT_FOUND, "DIARY_400_03", "임시저장된 일기가 아닙니다."),
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_404_01", "존재하지 않는 일기입니다."),
+    CHAT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY_404_02", "대화 기록이 존재하지 않습니다."),
     DIARY_ALREADY_EXISTS(HttpStatus.CONFLICT, "DIARY_409_01", "해당날짜에 이미 일기가 존재합니다."),
     ANALYZED_DIARY(HttpStatus.CONFLICT, "DIARY_409_02", "이미 분석된 일기입니다."),
 

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandService.java
@@ -13,6 +13,8 @@ public interface DiaryCommandService {
 
     DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
 
+    DiaryResponseDTO.VoiceChatResultDTO additionalChatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId);
+
     DiaryResponseDTO.SaveDiaryResultDTO saveDiaryByVoice(DiaryRequestDTO.SaveVoiceDiaryDTO request, Long userId);
 
     DiaryResponseDTO.AnalyzedDiaryResponseDTO analyze(Long diaryId);

--- a/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/diaryService/DiaryCommandServiceImpl.java
@@ -123,15 +123,18 @@ public class DiaryCommandServiceImpl implements DiaryCommandService{
     @Override
     @Transactional
     public DiaryResponseDTO.VoiceChatResultDTO chatByVoice(DiaryRequestDTO.VoiceChatDTO request, Long userId) {
-
-        //유저 조회
+        // 유저 조회
         userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-
         String userChat = request.getChat();
 
-        conversationHistory.putIfAbsent(userId, new ArrayList<>());
+        // 최초 대화 흐름인 경우, 기존 대화 목록 삭제
+        if (request.getIsNewConversation()) {
+            log.debug("기존 대화 목록 삭제 : {}", conversationHistory);
+            conversationHistory.remove(userId);
+        }
 
         // 기존 대화 목록 가져오기
+        conversationHistory.putIfAbsent(userId, new ArrayList<>());
         List<Message> messages = conversationHistory.get(userId);
 
         // 처음 대화라면 시스템 프롬프트 추가

--- a/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/DiaryController.java
@@ -59,7 +59,11 @@ public class DiaryController implements DiarySpecification {
     }
     @PostMapping("/voice/chat")
     public ApiResponse<DiaryResponseDTO.VoiceChatResultDTO> chatByVoice(@AuthenticationPrincipal Long userId, @RequestBody DiaryRequestDTO.VoiceChatDTO request){
-        return ApiResponse.onSuccess(diaryCommandService.chatByVoice(request, userId));
+        if (!request.getHasAdditionalChat()) {
+            return ApiResponse.onSuccess(diaryCommandService.chatByVoice(request, userId));
+        } else {
+            return ApiResponse.onSuccess(diaryCommandService.additionalChatByVoice(request, userId));
+        }
     }
 
     @PostMapping("/voice")

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -47,6 +47,10 @@ public class DiaryRequestDTO {
     @Schema(title = "AI 음성 대화 request")
     public static class VoiceChatDTO {
         @NotNull
+        @Schema(description = "최초 대화 흐름 여부", example = "false")
+        private Boolean isNewConversation;
+
+        @NotNull
         @Schema(description = "사용자의 음성내용", example = "오늘 정말 힘든 하루였어.")
         private String chat;
 

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -21,11 +21,11 @@ public class DiaryRequestDTO {
         @NotNull
         @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
         @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+        private String content;
 
         @NotNull
         @Schema(description = "일기 작성 날짜")
-        LocalDate date;
+        private LocalDate date;
     }
 
     @Getter
@@ -37,7 +37,7 @@ public class DiaryRequestDTO {
         @NotNull
         @Size(min = 100, message = "일기는 100자 이상으로 작성해야 합니다.")
         @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+        private String content;
     }
 
     @Getter
@@ -48,7 +48,11 @@ public class DiaryRequestDTO {
     public static class VoiceChatDTO {
         @NotNull
         @Schema(description = "사용자의 음성내용", example = "오늘 정말 힘든 하루였어.")
-        String chat;
+        private String chat;
+
+        @NotNull
+        @Schema(description = "할 말 추가 여부", example = "false")
+        private Boolean hasAdditionalChat;
     }
 
     @Getter
@@ -59,6 +63,6 @@ public class DiaryRequestDTO {
     public static class SaveVoiceDiaryDTO {
         @NotNull
         @Schema(description = "일기 작성 날짜")
-        LocalDate date;
+        private LocalDate date;
     }
 }

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryResponseDTO.java
@@ -19,9 +19,9 @@ public class DiaryResponseDTO {
     @Schema(title = "작성된 일기 조회 response")
     public static class DiaryDateDTO{
         @Schema(description = "일기 id", example = "1")
-        Long diaryId;
+        private Long diaryId;
         @Schema(description = "일기 최종 수정 날짜")
-        LocalDate date;
+        private LocalDate date;
     }
     @Builder
     @Getter
@@ -30,9 +30,9 @@ public class DiaryResponseDTO {
     @Schema(title = "일기 작성 날짜 조회 response")
     public static class DiaryDateListDTO{
         @Schema(description = "일기 작성 날짜들의 리스트")
-        List<DiaryDateDTO> diaryDateList;
+        private List<DiaryDateDTO> diaryDateList;
         @Schema(description = "리스트 사이즈", example = "1")
-        Integer listSize;
+        private Integer listSize;
     }
     @Builder
     @Getter
@@ -41,11 +41,11 @@ public class DiaryResponseDTO {
     @Schema(title = "작성된 일기 내용 조회 response")
     public static class DiaryDTO{
         @Schema(description = "일기 id", example = "1")
-        Long diaryId;
+        private Long diaryId;
         @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+        private String content;
         @Schema(description = "일기 최종 수정 날짜")
-        LocalDate date;
+        private LocalDate date;
     }
     @Builder
     @Getter
@@ -54,9 +54,9 @@ public class DiaryResponseDTO {
     @Schema(title = "일기 모아보기 response")
     public static class DiaryListDTO {
         @Schema(description = "일기 리스트")
-        List<DiaryDTO> diaryList;
+        private List<DiaryDTO> diaryList;
         @Schema(description = "리스트 사이즈", example = "1")
-        Integer listSize;
+        private Integer listSize;
     }
     @Builder
     @Getter
@@ -65,11 +65,11 @@ public class DiaryResponseDTO {
     @Schema(title = "일기 임시 저장 response")
     public static class SaveDiaryResultDTO {
         @Schema(description = "일기 id", example = "1")
-        Long diaryId;
+        private Long diaryId;
         @Schema(description = "일기 작성 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+        private String content;
         @Schema(description = "일기 작성 날짜")
-        LocalDate date;
+        private LocalDate date;
     }
 
     @Builder
@@ -79,9 +79,9 @@ public class DiaryResponseDTO {
     @Schema(title = "일기 수정 response")
     public static class ModifyDiaryResultDTO {
         @Schema(description = "일기 id", example = "1")
-        Long diaryId;
+        private Long diaryId;
         @Schema(description = "일기 수정 내용", example = "오늘은 미라클 모닝을 해서 아침 8시에 학교에 도착했다. 그런데 강사님께서 ~")
-        String content;
+        private String content;
     }
 
     @Builder
@@ -91,7 +91,7 @@ public class DiaryResponseDTO {
     @Schema(title = "음성 대화 response")
     public static class VoiceChatResultDTO {
         @Schema(description = "AI의 답변 내용", example = "힘든 하루셨군요. 어떤 일이 있으셨나요?")
-        String chat;
+        private String chat;
     }
 
     @Getter

--- a/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/Message.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/OpenAIDTO/Message.java
@@ -10,4 +10,8 @@ import lombok.NoArgsConstructor;
 public class Message {
     private String role;
     private String content;
+
+    public void addContent (String additionalContent) {
+        this.content = this.content + " " + additionalContent;
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
1. 할 말 추가 버튼이 생김에 따라, 할 말 추가 시 직전에 생성된 AI 답변이 문맥에 영향을 끼치기 때문에, AI 답변을 제거하고 직전에 생성한 사용자 말에 요청된 할 말을 추가했습니다.
예시) 
- 사용자 : 오늘 영화봤어. 
- AI : 무슨 영화를 보셨나요?
(이때 사용자가 더 길게 말하려는 의도였던 경우)
- 사용자 : 거기 핫도그는 항상 맛있어 -> 오늘 영화봤어 거기 핫도그는 항상 맛있어
- AI : 영화보면서 핫도그라니 더욱 즐거웠겠어요

2. 음성 대화로 일기 작성 중 나가고 다시 음성 대화를 처음부터 시작하면, 일기가 작성될 때 이전 음성 대화 내용 기록이 삭제되지 않아서 일기가 제대로 작성되지 않습니다. 따라서 대화 시 최초 대화 흐름인지 여부를 체크하는 필드를 추가했습니다.

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
1. 