### PR TITLE
[#425] Bug : 날짜사용 로직 타임존설정

### DIFF
--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -22,6 +22,7 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.*;
 
 @Service
@@ -133,7 +134,7 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     @Override
     @Transactional
     public ChallengeResponseDTO.CreateProofDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeCommandServiceImpl.java
@@ -134,7 +134,9 @@ public class ChallengeCommandServiceImpl implements ChallengeCommandService {
     @Override
     @Transactional
     public ChallengeResponseDTO.CreateProofDTO createChallengeProof(Long userId, Long userChallengeId, ChallengeRequestDTO.ProofRequestDTO proofRequest) {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        // 타임존 설정 (클라이언트에서 전달되지 않으면 Asia/Seoul로 기본 설정)
+        String timeZone = proofRequest.getTimeZone() != null ? proofRequest.getTimeZone() : "Asia/Seoul";
+        LocalDate today = LocalDate.now(ZoneId.of(timeZone));
 
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryService.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryService.java
@@ -6,8 +6,8 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 public interface ChallengeQueryService {
     int getTotalCredits(Long userId);
     int getTotalDiaries(Long userId);
-    String getDiaryDate(Long userId);
-    ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId);
+    String getDiaryDate(Long userId, String timeZone);
+    ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId, String timeZone);
     ChallengeResponseDTO.ChallengeStatusPagedResponseDTO getChallengeStatus(Long userId, UserChallengeType challengeType, Boolean completed, Integer page);
     ChallengeResponseDTO.ProofDetailsDTO getChallengeProofDetails(Long userId, Long userChallengeId);
 }

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
@@ -48,13 +48,13 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     }
 
     @Override
-    public String getDiaryDate(Long userId) {
+    public String getDiaryDate(Long userId, String timeZone) {
         // 사용자가 마지막으로 일기를 작성한 날짜 조회
         LocalDate lastDiaryDate = diaryRepository.findLastDiaryDateByUserId(userId)
-                .orElse(LocalDate.now(ZoneId.of("Asia/Seoul"))); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용 (한국 시간)
+                .orElse(LocalDate.now(ZoneId.of(timeZone))); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
 
         // 오늘 날짜와의 차이를 계산
-        long days = ChronoUnit.DAYS.between(lastDiaryDate, LocalDate.now(ZoneId.of("Asia/Seoul")));
+        long days = ChronoUnit.DAYS.between(lastDiaryDate, LocalDate.now(ZoneId.of(timeZone)));
 
         return "D+" + days;
     }
@@ -62,15 +62,15 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     // 챌린지 홈 조회
     @Override
     @Transactional
-    public ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId) {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    public ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId, String timeZone) {
+        LocalDate today = LocalDate.now(ZoneId.of(timeZone));
 
         // 오늘 날짜의 일기 존재 여부 확인
         Optional<Diary> todayDiary = diaryRepository.findTodayDiaryByUserId(userId, today);
 
         // 감정 키워드 조회
         List<String> keywordNames = todayDiary.isPresent()
-                ? keywordService.getTodayDiaryKeywords(userId)
+                ? keywordService.getTodayDiaryKeywords(userId, timeZone)
                 : Collections.emptyList();
 
         // 오늘 날짜의 일기에서 저장한 챌린지 목록 조회 (최신순, 최대 3개)
@@ -80,7 +80,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
                 savedChallenges,
                 getTotalCredits(userId),
                 getTotalDiaries(userId),
-                getDiaryDate(userId),
+                getDiaryDate(userId, timeZone),
                 keywordNames
         );
     }

--- a/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/challengeService/ChallengeQueryServiceImpl.java
@@ -20,6 +20,7 @@ import umc.GrowIT.Server.web.dto.ChallengeDTO.ChallengeResponseDTO;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
@@ -50,10 +51,10 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     public String getDiaryDate(Long userId) {
         // 사용자가 마지막으로 일기를 작성한 날짜 조회
         LocalDate lastDiaryDate = diaryRepository.findLastDiaryDateByUserId(userId)
-                .orElse(LocalDate.now()); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용
+                .orElse(LocalDate.now(ZoneId.of("Asia/Seoul"))); // 작성 기록이 없으면 오늘 날짜를 기본값으로 사용 (한국 시간)
 
         // 오늘 날짜와의 차이를 계산
-        long days = ChronoUnit.DAYS.between(lastDiaryDate, LocalDate.now());
+        long days = ChronoUnit.DAYS.between(lastDiaryDate, LocalDate.now(ZoneId.of("Asia/Seoul")));
 
         return "D+" + days;
     }
@@ -62,7 +63,7 @@ public class ChallengeQueryServiceImpl implements ChallengeQueryService {
     @Override
     @Transactional
     public ChallengeResponseDTO.ChallengeHomeDTO getChallengeHome(Long userId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         // 오늘 날짜의 일기 존재 여부 확인
         Optional<Diary> todayDiary = diaryRepository.findTodayDiaryByUserId(userId, today);

--- a/src/main/java/umc/GrowIT/Server/service/keywordService/KeywordService.java
+++ b/src/main/java/umc/GrowIT/Server/service/keywordService/KeywordService.java
@@ -6,6 +6,7 @@ import umc.GrowIT.Server.repository.KeywordRepository;
 import umc.GrowIT.Server.repository.DiaryRepository;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class KeywordService {
     private final KeywordRepository keywordRepository;
 
     public List<String> getTodayDiaryKeywords(Long userId) {
-        LocalDate date = LocalDate.now();
+        LocalDate date = LocalDate.now(ZoneId.of("Asia/Seoul"));
         return diaryRepository.findTodayDiaryByUserId(userId, date)
                 .map(diary -> diary.getDiaryKeywords().stream()
                         .map(diaryKeyword -> diaryKeyword.getKeyword().getName())

--- a/src/main/java/umc/GrowIT/Server/service/keywordService/KeywordService.java
+++ b/src/main/java/umc/GrowIT/Server/service/keywordService/KeywordService.java
@@ -17,8 +17,8 @@ public class KeywordService {
     private final DiaryRepository diaryRepository;
     private final KeywordRepository keywordRepository;
 
-    public List<String> getTodayDiaryKeywords(Long userId) {
-        LocalDate date = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    public List<String> getTodayDiaryKeywords(Long userId, String timeZone) {
+        LocalDate date = LocalDate.now(ZoneId.of(timeZone));
         return diaryRepository.findTodayDiaryByUserId(userId, date)
                 .map(diary -> diary.getDiaryKeywords().stream()
                         .map(diaryKeyword -> diaryKeyword.getKeyword().getName())

--- a/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/ChallengeController.java
@@ -27,8 +27,9 @@ public class ChallengeController implements ChallengeSpecification {
     private final ChallengeCommandService challengeCommandService;
 
     @GetMapping("")
-    public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId) {
-        return ApiResponse.onSuccess(challengeQueryService.getChallengeHome(userId));
+    public ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId,
+                                                                               @RequestParam(defaultValue = "Asia/Seoul") String timeZone) {
+        return ApiResponse.onSuccess(challengeQueryService.getChallengeHome(userId, timeZone));
     }
 
     @GetMapping("status")

--- a/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
+++ b/src/main/java/umc/GrowIT/Server/web/controller/specification/ChallengeSpecification.java
@@ -29,7 +29,8 @@ public interface ChallengeSpecification {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_200", description = "⭕ SUCCESS"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON_400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId);
+    ApiResponse<ChallengeResponseDTO.ChallengeHomeDTO> getChallengeHome(@AuthenticationPrincipal Long userId,
+                                                                       @Parameter(description = "클라이언트 타임존", example = "Asia/Seoul") @RequestParam(defaultValue = "Asia/Seoul") String timeZone);
 
     @GetMapping("status")
     @Operation(summary = "챌린지 현황 조회 API", description = "챌린지의 진행 상태(미완료/완료 등)를 조회하는 API입니다. <br> " +

--- a/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/ChallengeDTO/ChallengeRequestDTO.java
@@ -27,13 +27,20 @@ public class ChallengeRequestDTO {
     @AllArgsConstructor
     @Schema(title = "챌린지 인증 작성/수정 request")
     public static class ProofRequestDTO {
+
         @Schema(description = "업로드할 파일의 이름", example = "3c99605a8e01.png")
         @NotBlank(message = "이미지는 필수 입력입니다.")
         private String certificationImageName;
+
         @Schema(description = "소감(텍스트)", example = "오늘은 ~")
         @NotBlank(message = "챌린지 한줄소감은 필수로 입력해야 합니다.")
         @Size(min = 50, max = 100, message = "챌린지 한줄소감은 50자~100자 이내로 입력해야 합니다.")
         private String thoughts;
+
+        @Builder.Default
+        @Schema(description = "클라이언트 타임존", example = "Asia/Seoul")
+        private String timeZone = "Asia/Seoul";
+
     }
 
     @Getter

--- a/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
+++ b/src/main/java/umc/GrowIT/Server/web/dto/DiaryDTO/DiaryRequestDTO.java
@@ -26,6 +26,10 @@ public class DiaryRequestDTO {
         @NotNull
         @Schema(description = "일기 작성 날짜")
         private LocalDate date;
+
+        @Builder.Default //기본값 설정
+        @Schema(description = "클라이언트 타임존", example = "Asia/Seoul")
+        private String timeZone = "Asia/Seoul";
     }
 
     @Getter
@@ -68,5 +72,9 @@ public class DiaryRequestDTO {
         @NotNull
         @Schema(description = "일기 작성 날짜")
         private LocalDate date;
+
+        @Builder.Default
+        @Schema(description = "클라이언트 타임존", example = "Asia/Seoul")
+        private String timeZone = "Asia/Seoul";
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 간략히 설명해주세요 -->
 - SaveTextDiaryDTO, SaveVoiceDiaryDTO에 timeZone 필드 추가 클라이언트 업데이트가 어떻게 될지몰라 일단 기본값을 `Asia/Seoul`로 적용해서 timeZone 필드가 아예 없이 요청이 오더라도 한국시간으로 처리하였습니다.

이외에 기존에 LocalDate.now()이 사용되는 모든곳에 timeZone 필드를 사용해서 조회하도록 변경했습니다.

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
1. 텍스트/음성 일기 저장 api 호출