### PR TITLE
[#440] Feat : s3 이미지 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,11 @@ dependencies {
 	// Prometheus
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'io.prometheus:prometheus-metrics-core:1.2.1'
+
+	// Spring Boot Caching
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	// Caffeine (고성능 로컬 캐시 구현체)
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 task copyPrivateYml(type: Copy) {

--- a/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
+++ b/src/main/java/umc/GrowIT/Server/GrowItServerApplication.java
@@ -3,6 +3,7 @@ package umc.GrowIT.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @ConfigurationPropertiesScan
+@EnableCaching
 public class GrowItServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
+++ b/src/main/java/umc/GrowIT/Server/converter/ItemConverter.java
@@ -40,8 +40,8 @@ public class ItemConverter {
             Long userId,
             Map<Long, ItemStatus> itemStatuses,
             Map<Long, Boolean> purchaseStatuses,
-            Map<Item, String> itemUrls,
-            Map<Item, String> groItemUrls) {
+            Map<Long, String> itemUrls,
+            Map<Long, String> groItemUrls) {
 
         return ItemResponseDTO.ItemListDTO.builder()
                 .itemList(itemList.stream()
@@ -50,8 +50,8 @@ public class ItemConverter {
                                 userId,
                                 itemStatuses.get(item.getId()),
                                 purchaseStatuses.get(item.getId()),
-                                itemUrls.get(item),
-                                groItemUrls.get(item)))
+                                itemUrls.get(item.getId()),
+                                groItemUrls.get(item.getId())))
                         .collect(Collectors.toList()))
                 .build();
     }

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository.java
@@ -11,8 +11,8 @@ import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     // 카테고리별 아이템 조회
-    @Query("SELECT i FROM Item i WHERE i.category = :category ORDER BY i.price ASC")
-    List<Item> findAllByCategoryOrderByPriceAtAsc(ItemCategory category);
+    @Query("SELECT i FROM Item i WHERE i.category = :category ORDER BY i.id ASC")
+    List<Item> findAllByCategoryOrderByIdAsc(ItemCategory category);
 
     // UserItem을 통해 현재 사용자의 특정 아이템 구매여부 판별
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);

--- a/src/main/java/umc/GrowIT/Server/repository/ItemRepository.java
+++ b/src/main/java/umc/GrowIT/Server/repository/ItemRepository.java
@@ -11,8 +11,8 @@ import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     // 카테고리별 아이템 조회
-    @Query("SELECT i FROM Item i WHERE i.category = :category ORDER BY i.id ASC")
-    List<Item> findAllByCategoryOrderByIdAsc(ItemCategory category);
+    @Query("SELECT i FROM Item i WHERE i.category = :category ORDER BY i.price ASC")
+    List<Item> findAllByCategoryOrderByPriceAsc(ItemCategory category);
 
     // UserItem을 통해 현재 사용자의 특정 아이템 구매여부 판별
     boolean existsByUserItemsUserIdAndId(Long userId, Long itemId);

--- a/src/main/java/umc/GrowIT/Server/service/groService/GroQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/groService/GroQueryServiceImpl.java
@@ -2,6 +2,7 @@ package umc.GrowIT.Server.service.groService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.apiPayload.code.status.ErrorStatus;

--- a/src/main/java/umc/GrowIT/Server/service/itemService/ItemQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/itemService/ItemQueryServiceImpl.java
@@ -35,7 +35,7 @@ public class ItemQueryServiceImpl implements ItemQueryService {
     @Override
     @Transactional(readOnly = true)
     public ItemResponseDTO.ItemListDTO getItemList(ItemCategory category, Long userId) {
-        List<Item> itemList = itemRepository.findAllByCategoryOrderByIdAsc(category);
+        List<Item> itemList = itemRepository.findAllByCategoryOrderByPriceAsc(category);
 
         // status 조회 - null 처리 추가
         Map<Long, ItemStatus> itemStatuses = new HashMap<>();

--- a/src/main/java/umc/GrowIT/Server/service/itemService/ItemQueryServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/itemService/ItemQueryServiceImpl.java
@@ -2,6 +2,9 @@ package umc.GrowIT.Server.service.itemService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.GrowIT.Server.converter.ItemConverter;
@@ -26,11 +29,13 @@ public class ItemQueryServiceImpl implements ItemQueryService {
 
     private final ItemRepository itemRepository;
     private final S3Util s3Util;
+    private final PreSignedUrlCacheService preSignedUrlCacheService;
+    private final CacheManager cacheManager;
 
     @Override
     @Transactional(readOnly = true)
     public ItemResponseDTO.ItemListDTO getItemList(ItemCategory category, Long userId) {
-        List<Item> itemList = itemRepository.findAllByCategoryOrderByPriceAtAsc(category);
+        List<Item> itemList = itemRepository.findAllByCategoryOrderByIdAsc(category);
 
         // status 조회 - null 처리 추가
         Map<Long, ItemStatus> itemStatuses = new HashMap<>();
@@ -47,8 +52,8 @@ public class ItemQueryServiceImpl implements ItemQueryService {
                 ));
 
         // Pre-signed URL 생성
-        Map<Item, String> itemUrls = createItemPreSignedUrl(itemList);
-        Map<Item, String> groItemUrls = createGroItemPreSignedUrl(itemList);
+        Map<Long, String> itemUrls = preSignedUrlCacheService.createItemPreSignedUrl(itemList);
+        Map<Long, String> groItemUrls = preSignedUrlCacheService.createGroItemPreSignedUrl(itemList);
 
         return ItemConverter.toItemListDTO(itemList, userId, itemStatuses, purchaseStatuses, itemUrls, groItemUrls);
     }
@@ -74,29 +79,11 @@ public class ItemQueryServiceImpl implements ItemQueryService {
                 ));
 
         // Pre-signed URL 생성 로직만 추가
-        Map<Item, String> itemUrls = createItemPreSignedUrl(userItems);
-        Map<Item, String> groItemUrls = createGroItemPreSignedUrl(userItems);
+        Map<Long, String> itemUrls = preSignedUrlCacheService.createItemPreSignedUrl(userItems);
+        Map<Long, String> groItemUrls = preSignedUrlCacheService.createGroItemPreSignedUrl(userItems);
 
         // converter에 URL 맵 전달
         return ItemConverter.toItemListDTO(userItems, userId, itemStatuses, purchaseStatuses, itemUrls, groItemUrls);
-    }
-
-    // 상점 리스트용 이미지의 Pre-signed URL 생성
-    private Map<Item, String> createItemPreSignedUrl(List<Item> items) {
-        return items.stream()
-                .collect(Collectors.toMap(
-                        item -> item,
-                        item -> s3Util.toGetPresignedUrl(item.getImageKey(), Duration.ofMinutes(15))
-                ));
-    }
-
-    // 그로 착용용 이미지의 Pre-signed URL 생성
-    private Map<Item, String> createGroItemPreSignedUrl(List<Item> items) {
-        return items.stream()
-                .collect(Collectors.toMap(
-                        item -> item,
-                        item -> s3Util.toGetPresignedUrl(item.getGroImageKey(), Duration.ofMinutes(15))
-                ));
     }
 }
 

--- a/src/main/java/umc/GrowIT/Server/service/itemService/PreSignedUrlCacheService.java
+++ b/src/main/java/umc/GrowIT/Server/service/itemService/PreSignedUrlCacheService.java
@@ -1,0 +1,12 @@
+package umc.GrowIT.Server.service.itemService;
+
+import umc.GrowIT.Server.domain.Item;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PreSignedUrlCacheService {
+    Map<Long, String> createItemPreSignedUrl(List<Item> items);
+
+    Map<Long, String> createGroItemPreSignedUrl(List<Item> items);
+}

--- a/src/main/java/umc/GrowIT/Server/service/itemService/PreSignedUrlCacheServiceImpl.java
+++ b/src/main/java/umc/GrowIT/Server/service/itemService/PreSignedUrlCacheServiceImpl.java
@@ -1,0 +1,41 @@
+package umc.GrowIT.Server.service.itemService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import umc.GrowIT.Server.domain.Item;
+import umc.GrowIT.Server.util.S3Util;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PreSignedUrlCacheServiceImpl implements PreSignedUrlCacheService {
+    private final S3Util s3Util;
+
+    // 상점 리스트용 이미지의 Pre-signed URL 생성
+    @Cacheable(value = "imageUrls", key = "#items.!['image_' + id]")
+    public Map<Long, String> createItemPreSignedUrl(List<Item> items) {
+        return items.stream()
+                .collect(Collectors.toMap(
+                        Item::getId,
+                        item -> s3Util.toGetPresignedUrl(item.getImageKey(), Duration.ofHours(24))
+                ));
+    }
+
+    // 그로 착용용 이미지의 Pre-signed URL 생성
+    @Cacheable(value = "groImageUrls", key = "#items.!['groImage_' + id]")
+    public Map<Long, String> createGroItemPreSignedUrl(List<Item> items) {
+        return items.stream()
+                .collect(Collectors.toMap(
+                        Item::getId,
+                        item -> s3Util.toGetPresignedUrl(item.getGroImageKey(), Duration.ofHours(24))
+                ));
+    }
+
+}


### PR DESCRIPTION
## 📝 작업 내용
GET /items API에서  presigned url 이 요청할 때마다 재생성되어서
/items?category=BACKGROUND, /items?category=BACKGROUND
2번 요청 시 클라이언트에서 캐시가 풀리는 문제가 있어서
일정 시간(24시간)동안 로컬 캐시에 presigned url 저장하고 presigned url 접근 시간도 24시간으로 늘렸습니다.
이때 캐시를 사용하기 위해서 같은 클래스 내에서 presigned url 생성 메소드를 호출할 수 없기 때문에 다른 클래스로 분리했습니다.

## 👀 참고사항
<!-- 참고할 사항을 간략히 설명해주세요 -->


## 🔍 테스트 방법
<!-- 테스트 방법을 상세히 적어주세요 -->
1. 